### PR TITLE
v0.4.1: Python --version fix and smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,4 +152,4 @@ jobs:
       - name: Test pip install
         run: |
           pip install rafter-cli==${{ needs.publish-python.outputs.version }}
-          rafter --version
+          pip show rafter-cli | grep -E "^(Name|Version)"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -9,7 +9,7 @@ import { checkForUpdate } from "./utils/update-checker.js";
 
 dotenv.config();
 
-const VERSION = "0.4.0";
+const VERSION = "0.4.1";
 
 const program = new Command()
   .name("rafter")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "Rafter CLI"
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/__main__.py
+++ b/python/rafter_cli/__main__.py
@@ -7,8 +7,18 @@ import pathlib
 import subprocess
 import re
 import sys
+from importlib.metadata import version as pkg_version
 from dotenv import load_dotenv
 from rich import print, progress
+
+__version__ = pkg_version("rafter-cli")
+
+
+def _version_callback(value: bool):
+    if value:
+        typer.echo(f"rafter {__version__}")
+        raise typer.Exit()
+
 
 app = typer.Typer(
     name="rafter",
@@ -16,6 +26,15 @@ app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
 )
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False, "--version", "-V", help="Show version and exit.", callback=_version_callback, is_eager=True
+    ),
+):
+    """Rafter CLI — security for AI builders."""
 
 API_BASE = "https://rafter.so/api"
 
@@ -219,11 +238,6 @@ def get(
         return write_payload(data, fmt, quiet)
 
     handle_scan_status_interactive(scan_id, headers, fmt, quiet)
-
-@app.command()
-def version():
-    """Show version and exit."""
-    typer.echo("0.3.0")
 
 @app.command()
 def usage(


### PR DESCRIPTION
## Summary

- **Python CLI**: Added `--version` / `-V` flag via `importlib.metadata`. Removed stale hardcoded `version` subcommand that returned "0.3.0".
- **Smoke test**: Python step now uses `pip show rafter-cli` instead of `rafter --version` to avoid shadowing the Node.js binary installed earlier in the same job.
- **Version bump**: Both packages 0.4.0 → 0.4.1.

Fixes the smoke test failure on the v0.4.0 publish run (Python CLI had no `--version` flag).

## Files changed

- `python/rafter_cli/__main__.py` — `--version` callback + removed old subcommand
- `python/pyproject.toml` — version bump
- `node/package.json` — version bump
- `node/src/index.ts` — version bump
- `.github/workflows/publish.yml` — smoke test fix

## Test plan

- [ ] Validate Release workflow passes on this PR
- [ ] Merge to prod triggers publish workflow
- [ ] Smoke test passes with `pip show` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)