### PR TITLE
v0.4.2: fix Python importlib crash

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -9,7 +9,7 @@ import { checkForUpdate } from "./utils/update-checker.js";
 
 dotenv.config();
 
-const VERSION = "0.4.1";
+const VERSION = "0.4.2";
 
 const program = new Command()
   .name("rafter")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.4.1"
+version = "0.4.2"
 description = "Rafter CLI"
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/__main__.py
+++ b/python/rafter_cli/__main__.py
@@ -7,11 +7,14 @@ import pathlib
 import subprocess
 import re
 import sys
-from importlib.metadata import version as pkg_version
 from dotenv import load_dotenv
 from rich import print, progress
 
-__version__ = pkg_version("rafter-cli")
+try:
+    from importlib.metadata import version as _pkg_version
+    __version__ = _pkg_version("rafter-cli")
+except Exception:
+    __version__ = "0.4.2"
 
 
 def _version_callback(value: bool):


### PR DESCRIPTION
## Summary

- Guard `importlib.metadata.version()` call with try/except—crashes if package isn't installed in the build environment
- Bump both packages to 0.4.2 (0.4.1 artifacts already on registries)

Root cause of v0.4.1 smoke test failure: `rafter-cli==0.4.1` never published to PyPI, likely because the module-level `pkg_version("rafter-cli")` raised `PackageNotFoundError` during the build/test environment.

## Test plan

- [ ] publish-python job succeeds
- [ ] Smoke test installs `rafter-cli==0.4.2` from PyPI
- [ ] `rafter --version` returns `rafter 0.4.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)