### PR TITLE
fix: resolve hardcoded versions and last pnpm@9 reference

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -98,7 +98,7 @@ jobs:
           node-version: "20"
 
       - name: Enable pnpm
-        run: corepack enable && corepack prepare pnpm@9 --activate
+        run: corepack enable && corepack prepare pnpm@10 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/node/src/commands/agent/scan.ts
+++ b/node/src/commands/agent/scan.ts
@@ -8,6 +8,10 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { fmt } from "../../utils/formatter.js";
+import { createRequire } from "module";
+
+const _require = createRequire(import.meta.url);
+const { version: CLI_VERSION } = _require("../../../package.json");
 
 interface ScanOpts {
   quiet?: boolean;
@@ -189,7 +193,7 @@ function outputSarif(results: ScanResult[]): void {
         tool: {
           driver: {
             name: "rafter",
-            version: "0.5.7",
+            version: CLI_VERSION,
             informationUri: "https://rafter.so",
             rules: Array.from(rules.values()),
           },

--- a/node/src/commands/mcp/server.ts
+++ b/node/src/commands/mcp/server.ts
@@ -12,6 +12,10 @@ import { GitleaksScanner } from "../../scanners/gitleaks.js";
 import { CommandInterceptor } from "../../core/command-interceptor.js";
 import { AuditLogger } from "../../core/audit-logger.js";
 import { ConfigManager } from "../../core/config-manager.js";
+import { createRequire } from "module";
+
+const _require = createRequire(import.meta.url);
+const { version: CLI_VERSION } = _require("../../../package.json");
 
 interface ScanResultOutput {
   file: string;
@@ -45,7 +49,7 @@ function errorResult(message: string) {
 
 function createServer(): Server {
   const server = new Server(
-    { name: "rafter", version: "0.6.1" },
+    { name: "rafter", version: CLI_VERSION },
     { capabilities: { tools: {}, resources: {} } },
   );
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -19,7 +19,7 @@ import { createRequire } from "module";
 dotenv.config();
 
 const require = createRequire(import.meta.url);
-const { version: VERSION } = require("../../package.json");
+const { version: VERSION } = require("../package.json");
 
 const program = new Command()
   .name("rafter")


### PR DESCRIPTION
## Summary
Follow-up to v0.6.1 — fixes that were missed:

- **package.json import path** in `index.ts`: `../../package.json` couldn't resolve when running via tsx (tests), changed to `../package.json` which works in both source and compiled contexts
- **SARIF version hardcoded to 0.5.7** in `scan.ts`: now reads from package.json dynamically
- **MCP server version**: made dynamic instead of hardcoded (future-proofed)
- **Last pnpm@9 in validate-release.yml**: the `test-package` job's `Enable pnpm` step was missed in the original fix

All 279 Node tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)