### PR TITLE
test: expand adapter coverage across all 8 platforms

### DIFF
--- a/node/tests/codex-integration.test.ts
+++ b/node/tests/codex-integration.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { randomBytes } from "crypto";
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+
+// CLI integration tests spawn subprocesses — allow generous timeouts
+vi.setConfig({ testTimeout: 30_000 });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const CLI_ENTRY = path.join(PROJECT_ROOT, "src", "index.ts");
+
+function createTempDir(prefix: string): string {
+  const tmpDir = path.join(
+    os.tmpdir(),
+    `${prefix}-${Date.now()}-${randomBytes(6).toString("hex")}`
+  );
+  fs.mkdirSync(tmpDir, { recursive: true });
+  return tmpDir;
+}
+
+function cleanupDir(dir: string) {
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function runCli(
+  args: string,
+  homeDir: string,
+  timeout = 30_000
+): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execSync(`npx tsx ${CLI_ENTRY} ${args}`, {
+      cwd: PROJECT_ROOT,
+      encoding: "utf-8",
+      timeout,
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        XDG_CONFIG_HOME: path.join(homeDir, ".config"),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (e: any) {
+    return {
+      stdout: e.stdout || "",
+      stderr: e.stderr || "",
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+describe("Codex CLI Integration", () => {
+  let testHomeDir: string;
+
+  beforeEach(() => {
+    testHomeDir = createTempDir("rafter-codex-test");
+  });
+
+  afterEach(() => {
+    cleanupDir(testHomeDir);
+  });
+
+  // ── 1. Skill installation ─────────────────────────────────────────
+
+  describe("Skill installation (--with-codex)", () => {
+    it("should create both skill files in ~/.agents/skills/", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+
+      const result = runCli("agent init --with-codex", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      const backendSkill = path.join(
+        testHomeDir,
+        ".agents",
+        "skills",
+        "rafter",
+        "SKILL.md"
+      );
+      const securitySkill = path.join(
+        testHomeDir,
+        ".agents",
+        "skills",
+        "rafter-agent-security",
+        "SKILL.md"
+      );
+
+      expect(fs.existsSync(backendSkill)).toBe(true);
+      expect(fs.existsSync(securitySkill)).toBe(true);
+    });
+
+    it("backend skill should contain valid frontmatter", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+      runCli("agent init --with-codex", testHomeDir);
+
+      const skillContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".agents",
+          "skills",
+          "rafter",
+          "SKILL.md"
+        ),
+        "utf-8"
+      );
+      // Check frontmatter markers
+      expect(skillContent).toMatch(/^---\n/);
+      expect(skillContent).toContain("name: rafter");
+      expect(skillContent).toContain("version:");
+      expect(skillContent).toContain("allowed-tools:");
+    });
+
+    it("agent security skill should contain valid frontmatter", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+      runCli("agent init --with-codex", testHomeDir);
+
+      const skillContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".agents",
+          "skills",
+          "rafter-agent-security",
+          "SKILL.md"
+        ),
+        "utf-8"
+      );
+      expect(skillContent).toMatch(/^---\n/);
+      expect(skillContent).toContain("name:");
+      expect(skillContent).toContain("version:");
+    });
+
+    it("skill files should contain rafter CLI commands", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+      runCli("agent init --with-codex", testHomeDir);
+
+      const backendContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".agents",
+          "skills",
+          "rafter",
+          "SKILL.md"
+        ),
+        "utf-8"
+      );
+      // Should reference rafter CLI usage
+      expect(backendContent).toContain("rafter");
+    });
+  });
+
+  // ── 2. Idempotency ────────────────────────────────────────────────
+
+  describe("Codex idempotency", () => {
+    it("should not corrupt skills on repeated installs", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+
+      runCli("agent init --with-codex", testHomeDir);
+      const firstContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".agents",
+          "skills",
+          "rafter",
+          "SKILL.md"
+        ),
+        "utf-8"
+      );
+
+      runCli("agent init --with-codex", testHomeDir);
+      const secondContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".agents",
+          "skills",
+          "rafter",
+          "SKILL.md"
+        ),
+        "utf-8"
+      );
+
+      expect(secondContent).toBe(firstContent);
+    });
+
+    it("should overwrite stale skill content on re-install", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+      const skillDir = path.join(
+        testHomeDir,
+        ".agents",
+        "skills",
+        "rafter"
+      );
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, "SKILL.md"),
+        "---\nname: rafter\nversion: 0.0.1\n---\nOld content\n"
+      );
+
+      runCli("agent init --with-codex", testHomeDir);
+
+      const content = fs.readFileSync(
+        path.join(skillDir, "SKILL.md"),
+        "utf-8"
+      );
+      // Should be overwritten with the current template, not the old content
+      expect(content).not.toContain("Old content");
+      expect(content).not.toContain("version: 0.0.1");
+    });
+  });
+
+  // ── 3. Environment detection ──────────────────────────────────────
+
+  describe("Codex environment detection", () => {
+    it("should warn when --with-codex used without ~/.codex", () => {
+      // Do NOT create .codex dir
+      const result = runCli("agent init --with-codex", testHomeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Codex CLI requested but not detected");
+
+      // Skills should NOT be installed
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".agents",
+            "skills",
+            "rafter",
+            "SKILL.md"
+          )
+        )
+      ).toBe(false);
+    });
+
+    it("should detect .codex and install when requested", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+
+      const result = runCli("agent init --with-codex", testHomeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Codex CLI");
+      // Should not contain the "not detected" warning
+      expect(result.stdout).not.toContain(
+        "Codex CLI requested but not detected"
+      );
+    });
+  });
+
+  // ── 4. Directory structure ────────────────────────────────────────
+
+  describe("Codex directory structure", () => {
+    it("should create ~/.agents/skills/ hierarchy", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+      runCli("agent init --with-codex", testHomeDir);
+
+      expect(
+        fs.statSync(path.join(testHomeDir, ".agents", "skills")).isDirectory()
+      ).toBe(true);
+      expect(
+        fs.statSync(
+          path.join(testHomeDir, ".agents", "skills", "rafter")
+        ).isDirectory()
+      ).toBe(true);
+      expect(
+        fs.statSync(
+          path.join(
+            testHomeDir,
+            ".agents",
+            "skills",
+            "rafter-agent-security"
+          )
+        ).isDirectory()
+      ).toBe(true);
+    });
+
+    it("should not affect ~/.codex directory itself", () => {
+      const codexDir = path.join(testHomeDir, ".codex");
+      fs.mkdirSync(codexDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(codexDir, "config.json"),
+        '{"existing": true}'
+      );
+
+      runCli("agent init --with-codex", testHomeDir);
+
+      // .codex/config.json should be untouched
+      const config = JSON.parse(
+        fs.readFileSync(path.join(codexDir, "config.json"), "utf-8")
+      );
+      expect(config.existing).toBe(true);
+    });
+  });
+
+  // ── 5. Coexistence with Claude Code ───────────────────────────────
+
+  describe("Coexistence with Claude Code", () => {
+    it("should install both Codex and Claude Code skills independently", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+      fs.mkdirSync(path.join(testHomeDir, ".claude"), { recursive: true });
+
+      const result = runCli(
+        "agent init --with-codex --with-claude-code",
+        testHomeDir
+      );
+      expect(result.exitCode).toBe(0);
+
+      // Codex skills in ~/.agents/skills/
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".agents",
+            "skills",
+            "rafter",
+            "SKILL.md"
+          )
+        )
+      ).toBe(true);
+
+      // Claude Code skills in ~/.claude/skills/
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".claude",
+            "skills",
+            "rafter",
+            "SKILL.md"
+          )
+        )
+      ).toBe(true);
+
+      // Claude Code hooks in settings.json
+      const settings = JSON.parse(
+        fs.readFileSync(
+          path.join(testHomeDir, ".claude", "settings.json"),
+          "utf-8"
+        )
+      );
+      expect(settings.hooks).toBeDefined();
+      expect(settings.hooks.PreToolUse).toBeDefined();
+    });
+  });
+
+  // ── 6. Opt-in gating ─────────────────────────────────────────────
+
+  describe("Opt-in gating", () => {
+    it("plain 'agent init' should NOT install Codex skills", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+
+      const result = runCli("agent init", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".agents",
+            "skills",
+            "rafter",
+            "SKILL.md"
+          )
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/node/tests/openclaw-integration.test.ts
+++ b/node/tests/openclaw-integration.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { randomBytes } from "crypto";
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+
+// CLI integration tests spawn subprocesses — allow generous timeouts
+vi.setConfig({ testTimeout: 30_000 });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const CLI_ENTRY = path.join(PROJECT_ROOT, "src", "index.ts");
+
+function createTempDir(prefix: string): string {
+  const tmpDir = path.join(
+    os.tmpdir(),
+    `${prefix}-${Date.now()}-${randomBytes(6).toString("hex")}`
+  );
+  fs.mkdirSync(tmpDir, { recursive: true });
+  return tmpDir;
+}
+
+function cleanupDir(dir: string) {
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function runCli(
+  args: string,
+  homeDir: string,
+  timeout = 30_000
+): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execSync(`npx tsx ${CLI_ENTRY} ${args}`, {
+      cwd: PROJECT_ROOT,
+      encoding: "utf-8",
+      timeout,
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        XDG_CONFIG_HOME: path.join(homeDir, ".config"),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (e: any) {
+    return {
+      stdout: e.stdout || "",
+      stderr: e.stderr || "",
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+describe("OpenClaw Integration", () => {
+  let testHomeDir: string;
+
+  beforeEach(() => {
+    testHomeDir = createTempDir("rafter-openclaw-test");
+  });
+
+  afterEach(() => {
+    cleanupDir(testHomeDir);
+  });
+
+  // ── 1. Skill installation ─────────────────────────────────────────
+
+  describe("Skill installation (--with-openclaw)", () => {
+    it("should create rafter-security.md in ~/.openclaw/skills/", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+
+      const result = runCli("agent init --with-openclaw", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      const skillPath = path.join(
+        testHomeDir,
+        ".openclaw",
+        "skills",
+        "rafter-security.md"
+      );
+      expect(fs.existsSync(skillPath)).toBe(true);
+    });
+
+    it("skill should contain valid YAML frontmatter", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      runCli("agent init --with-openclaw", testHomeDir);
+
+      const skillContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".openclaw",
+          "skills",
+          "rafter-security.md"
+        ),
+        "utf-8"
+      );
+      expect(skillContent).toMatch(/^---\n/);
+      // OpenClaw uses openclaw.skillKey instead of name:
+      expect(skillContent).toContain("openclaw:");
+      expect(skillContent).toContain("skillKey: rafter-security");
+      expect(skillContent).toContain("version:");
+      // Should end with proper content after frontmatter
+      const parts = skillContent.split("---");
+      expect(parts.length).toBeGreaterThanOrEqual(3); // before, frontmatter, content
+    });
+
+    it("skill should contain rafter CLI references", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      runCli("agent init --with-openclaw", testHomeDir);
+
+      const skillContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".openclaw",
+          "skills",
+          "rafter-security.md"
+        ),
+        "utf-8"
+      );
+      expect(skillContent).toContain("rafter");
+    });
+
+    it("should create skills directory if it does not exist", () => {
+      // Only create .openclaw, not .openclaw/skills
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+
+      runCli("agent init --with-openclaw", testHomeDir);
+
+      expect(
+        fs.statSync(
+          path.join(testHomeDir, ".openclaw", "skills")
+        ).isDirectory()
+      ).toBe(true);
+    });
+  });
+
+  // ── 2. Environment detection ──────────────────────────────────────
+
+  describe("OpenClaw environment detection", () => {
+    it("should warn when --with-openclaw used without ~/.openclaw", () => {
+      // Do NOT create .openclaw dir
+      const result = runCli("agent init --with-openclaw", testHomeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(
+        "OpenClaw requested but not detected"
+      );
+    });
+
+    it("should NOT install skill when ~/.openclaw is absent", () => {
+      runCli("agent init --with-openclaw", testHomeDir);
+
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".openclaw",
+            "skills",
+            "rafter-security.md"
+          )
+        )
+      ).toBe(false);
+    });
+
+    it("should detect .openclaw and install when requested", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+
+      const result = runCli("agent init --with-openclaw", testHomeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain(
+        "OpenClaw requested but not detected"
+      );
+      expect(result.stdout).toContain("Installed Rafter Security skill");
+    });
+  });
+
+  // ── 3. Idempotency ────────────────────────────────────────────────
+
+  describe("OpenClaw idempotency", () => {
+    it("should not corrupt skill on repeated installs", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+
+      runCli("agent init --with-openclaw", testHomeDir);
+      const firstContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".openclaw",
+          "skills",
+          "rafter-security.md"
+        ),
+        "utf-8"
+      );
+
+      runCli("agent init --with-openclaw", testHomeDir);
+      const secondContent = fs.readFileSync(
+        path.join(
+          testHomeDir,
+          ".openclaw",
+          "skills",
+          "rafter-security.md"
+        ),
+        "utf-8"
+      );
+
+      // Content should be identical after re-install
+      expect(secondContent).toBe(firstContent);
+    });
+
+    it("should succeed silently when skill already installed", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+
+      const first = runCli("agent init --with-openclaw", testHomeDir);
+      expect(first.exitCode).toBe(0);
+
+      const second = runCli("agent init --with-openclaw", testHomeDir);
+      expect(second.exitCode).toBe(0);
+    });
+  });
+
+  // ── 4. Opt-in gating ─────────────────────────────────────────────
+
+  describe("Opt-in gating", () => {
+    it("plain 'agent init' should NOT install OpenClaw skill", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+
+      const result = runCli("agent init", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".openclaw",
+            "skills",
+            "rafter-security.md"
+          )
+        )
+      ).toBe(false);
+    });
+  });
+
+  // ── 5. Skill Manager unit tests ──────────────────────────────────
+
+  describe("SkillManager", () => {
+    it("parseSkillMetadata extracts name and version", async () => {
+      const { SkillManager } = await import("../src/utils/skill-manager.js");
+      const sm = new SkillManager();
+
+      const content =
+        '---\nname: rafter-security\nversion: 0.6.4\nrafter_cli_version: 0.6.4\nlast_updated: 2025-01-01\n---\n# Content\n';
+      const metadata = sm.parseSkillMetadata(content);
+
+      expect(metadata).not.toBeNull();
+      expect(metadata!.name).toBe("rafter-security");
+      expect(metadata!.version).toBe("0.6.4");
+    });
+
+    it("parseSkillMetadata returns null for missing frontmatter", async () => {
+      const { SkillManager } = await import("../src/utils/skill-manager.js");
+      const sm = new SkillManager();
+
+      const metadata = sm.parseSkillMetadata("# Just markdown\nNo frontmatter");
+      expect(metadata).toBeNull();
+    });
+
+    it("parseSkillMetadata returns null for incomplete frontmatter", async () => {
+      const { SkillManager } = await import("../src/utils/skill-manager.js");
+      const sm = new SkillManager();
+
+      const metadata = sm.parseSkillMetadata("---\nname: rafter\n---\n");
+      expect(metadata).toBeNull();
+    });
+
+    it("calculateContentHash ignores frontmatter", async () => {
+      const { SkillManager } = await import("../src/utils/skill-manager.js");
+      const sm = new SkillManager();
+
+      const content1 =
+        "---\nname: rafter\nversion: 1.0\n---\n# Same Content\n";
+      const content2 =
+        "---\nname: rafter\nversion: 2.0\n---\n# Same Content\n";
+
+      expect(sm.calculateContentHash(content1)).toBe(
+        sm.calculateContentHash(content2)
+      );
+    });
+
+    it("calculateContentHash detects body changes", async () => {
+      const { SkillManager } = await import("../src/utils/skill-manager.js");
+      const sm = new SkillManager();
+
+      const content1 =
+        "---\nname: rafter\nversion: 1.0\n---\n# Original Content\n";
+      const content2 =
+        "---\nname: rafter\nversion: 1.0\n---\n# Modified Content\n";
+
+      expect(sm.calculateContentHash(content1)).not.toBe(
+        sm.calculateContentHash(content2)
+      );
+    });
+
+    it("getOpenClawSkillsDir returns correct path", async () => {
+      const { SkillManager } = await import("../src/utils/skill-manager.js");
+      const sm = new SkillManager();
+
+      const expected = path.join(os.homedir(), ".openclaw", "skills");
+      expect(sm.getOpenClawSkillsDir()).toBe(expected);
+    });
+
+    it("getRafterSkillPath returns correct path", async () => {
+      const { SkillManager } = await import("../src/utils/skill-manager.js");
+      const sm = new SkillManager();
+
+      const expected = path.join(
+        os.homedir(),
+        ".openclaw",
+        "skills",
+        "rafter-security.md"
+      );
+      expect(sm.getRafterSkillPath()).toBe(expected);
+    });
+  });
+
+  // ── 6. Coexistence ────────────────────────────────────────────────
+
+  describe("Coexistence with other adapters", () => {
+    it("should install alongside Codex skills without conflict", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+
+      const result = runCli(
+        "agent init --with-openclaw --with-codex",
+        testHomeDir
+      );
+      expect(result.exitCode).toBe(0);
+
+      // OpenClaw skill
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".openclaw",
+            "skills",
+            "rafter-security.md"
+          )
+        )
+      ).toBe(true);
+
+      // Codex skills
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".agents",
+            "skills",
+            "rafter",
+            "SKILL.md"
+          )
+        )
+      ).toBe(true);
+    });
+
+    it("should install alongside MCP adapters without conflict", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      fs.mkdirSync(path.join(testHomeDir, ".gemini"), { recursive: true });
+
+      const result = runCli(
+        "agent init --with-openclaw --with-gemini",
+        testHomeDir
+      );
+      expect(result.exitCode).toBe(0);
+
+      // OpenClaw skill
+      expect(
+        fs.existsSync(
+          path.join(
+            testHomeDir,
+            ".openclaw",
+            "skills",
+            "rafter-security.md"
+          )
+        )
+      ).toBe(true);
+
+      // Gemini MCP
+      expect(
+        fs.existsSync(
+          path.join(testHomeDir, ".gemini", "settings.json")
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/node/tests/platform-integration.test.ts
+++ b/node/tests/platform-integration.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { randomBytes } from "crypto";
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
 import { fileURLToPath } from "url";
+
+// CLI integration tests spawn subprocesses — allow generous timeouts
+vi.setConfig({ testTimeout: 30_000 });
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -185,6 +188,51 @@ describe("Platform Integration — MCP Installs via CLI", () => {
     });
   });
 
+  // ── 2d. Gemini corrupted JSON recovery ────────────────────────────
+
+  describe("Gemini corrupted JSON recovery", () => {
+    it("should recover from corrupted settings.json", () => {
+      const geminiDir = path.join(testHomeDir, ".gemini");
+      fs.mkdirSync(geminiDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(geminiDir, "settings.json"),
+        "{not valid json!!"
+      );
+
+      const result = runCli("agent init --with-gemini", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      const settings = JSON.parse(
+        fs.readFileSync(path.join(geminiDir, "settings.json"), "utf-8")
+      );
+      expect(settings.mcpServers.rafter).toBeDefined();
+      expect(settings.mcpServers.rafter.command).toBe("rafter");
+    });
+
+    it("should update stale rafter entry on re-install", () => {
+      const geminiDir = path.join(testHomeDir, ".gemini");
+      fs.mkdirSync(geminiDir, { recursive: true });
+      // Write a stale rafter entry with wrong args
+      fs.writeFileSync(
+        path.join(geminiDir, "settings.json"),
+        JSON.stringify({
+          mcpServers: {
+            rafter: { command: "old-rafter", args: ["old-arg"] },
+          },
+        }, null, 2)
+      );
+
+      runCli("agent init --with-gemini", testHomeDir);
+
+      const settings = JSON.parse(
+        fs.readFileSync(path.join(geminiDir, "settings.json"), "utf-8")
+      );
+      // Should be updated to current values
+      expect(settings.mcpServers.rafter.command).toBe("rafter");
+      expect(settings.mcpServers.rafter.args).toEqual(["mcp", "serve"]);
+    });
+  });
+
   // ── 3. Cursor MCP install ──────────────────────────────────────────
 
   describe("Cursor MCP install (--with-cursor)", () => {
@@ -202,6 +250,91 @@ describe("Platform Integration — MCP Installs via CLI", () => {
       expect(config.mcpServers.rafter).toBeDefined();
       expect(config.mcpServers.rafter.command).toBe("rafter");
       expect(config.mcpServers.rafter.args).toEqual(["mcp", "serve"]);
+    });
+  });
+
+  // ── 3b. Cursor idempotency and preservation ───────────────────────
+
+  describe("Cursor MCP idempotency", () => {
+    it("should not duplicate rafter entry on repeated installs", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".cursor"), { recursive: true });
+
+      runCli("agent init --with-cursor", testHomeDir);
+      runCli("agent init --with-cursor", testHomeDir);
+
+      const mcpPath = path.join(testHomeDir, ".cursor", "mcp.json");
+      const config = JSON.parse(fs.readFileSync(mcpPath, "utf-8"));
+      expect(Object.keys(config.mcpServers)).toEqual(["rafter"]);
+    });
+
+    it("should preserve existing non-rafter MCP servers", () => {
+      const cursorDir = path.join(testHomeDir, ".cursor");
+      fs.mkdirSync(cursorDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(cursorDir, "mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            "some-other-mcp": { command: "other", args: ["run"] },
+          },
+        }, null, 2)
+      );
+
+      runCli("agent init --with-cursor", testHomeDir);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(cursorDir, "mcp.json"), "utf-8")
+      );
+      expect(config.mcpServers["some-other-mcp"]).toBeDefined();
+      expect(config.mcpServers.rafter).toBeDefined();
+    });
+
+    it("should preserve existing non-MCP settings", () => {
+      const cursorDir = path.join(testHomeDir, ".cursor");
+      fs.mkdirSync(cursorDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(cursorDir, "mcp.json"),
+        JSON.stringify({ theme: "monokai", fontSize: 14 }, null, 2)
+      );
+
+      runCli("agent init --with-cursor", testHomeDir);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(cursorDir, "mcp.json"), "utf-8")
+      );
+      expect(config.theme).toBe("monokai");
+      expect(config.fontSize).toBe(14);
+      expect(config.mcpServers.rafter).toBeDefined();
+    });
+  });
+
+  // ── 3c. Cursor environment detection ──────────────────────────────
+
+  describe("Cursor environment detection", () => {
+    it("should warn when --with-cursor used without ~/.cursor", () => {
+      const result = runCli("agent init --with-cursor", testHomeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Cursor requested but not detected");
+      expect(
+        fs.existsSync(path.join(testHomeDir, ".cursor", "mcp.json"))
+      ).toBe(false);
+    });
+  });
+
+  // ── 3d. Cursor corrupted JSON recovery ────────────────────────────
+
+  describe("Cursor corrupted JSON recovery", () => {
+    it("should recover from corrupted mcp.json", () => {
+      const cursorDir = path.join(testHomeDir, ".cursor");
+      fs.mkdirSync(cursorDir, { recursive: true });
+      fs.writeFileSync(path.join(cursorDir, "mcp.json"), "{{bad json}}");
+
+      const result = runCli("agent init --with-cursor", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(cursorDir, "mcp.json"), "utf-8")
+      );
+      expect(config.mcpServers.rafter.command).toBe("rafter");
     });
   });
 
@@ -232,10 +365,107 @@ describe("Platform Integration — MCP Installs via CLI", () => {
     });
   });
 
+  // ── 4b. Windsurf idempotency and preservation ─────────────────────
+
+  describe("Windsurf MCP idempotency", () => {
+    it("should not duplicate rafter entry on repeated installs", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), {
+        recursive: true,
+      });
+
+      runCli("agent init --with-windsurf", testHomeDir);
+      runCli("agent init --with-windsurf", testHomeDir);
+
+      const mcpPath = path.join(
+        testHomeDir,
+        ".codeium",
+        "windsurf",
+        "mcp_config.json"
+      );
+      const config = JSON.parse(fs.readFileSync(mcpPath, "utf-8"));
+      expect(Object.keys(config.mcpServers)).toEqual(["rafter"]);
+    });
+
+    it("should preserve existing non-rafter MCP servers", () => {
+      const windsurfDir = path.join(testHomeDir, ".codeium", "windsurf");
+      fs.mkdirSync(windsurfDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(windsurfDir, "mcp_config.json"),
+        JSON.stringify({
+          mcpServers: {
+            "copilot-mcp": { command: "copilot", args: ["serve"] },
+          },
+        }, null, 2)
+      );
+
+      runCli("agent init --with-windsurf", testHomeDir);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(windsurfDir, "mcp_config.json"), "utf-8")
+      );
+      expect(config.mcpServers["copilot-mcp"]).toBeDefined();
+      expect(config.mcpServers.rafter).toBeDefined();
+    });
+
+    it("should preserve existing non-MCP settings", () => {
+      const windsurfDir = path.join(testHomeDir, ".codeium", "windsurf");
+      fs.mkdirSync(windsurfDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(windsurfDir, "mcp_config.json"),
+        JSON.stringify({ editor: "windsurf", version: 2 }, null, 2)
+      );
+
+      runCli("agent init --with-windsurf", testHomeDir);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(windsurfDir, "mcp_config.json"), "utf-8")
+      );
+      expect(config.editor).toBe("windsurf");
+      expect(config.version).toBe(2);
+      expect(config.mcpServers.rafter).toBeDefined();
+    });
+  });
+
+  // ── 4c. Windsurf environment detection ────────────────────────────
+
+  describe("Windsurf environment detection", () => {
+    it("should warn when --with-windsurf used without ~/.codeium/windsurf", () => {
+      const result = runCli("agent init --with-windsurf", testHomeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Windsurf requested but not detected");
+      expect(
+        fs.existsSync(
+          path.join(testHomeDir, ".codeium", "windsurf", "mcp_config.json")
+        )
+      ).toBe(false);
+    });
+  });
+
+  // ── 4d. Windsurf corrupted JSON recovery ──────────────────────────
+
+  describe("Windsurf corrupted JSON recovery", () => {
+    it("should recover from corrupted mcp_config.json", () => {
+      const windsurfDir = path.join(testHomeDir, ".codeium", "windsurf");
+      fs.mkdirSync(windsurfDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(windsurfDir, "mcp_config.json"),
+        "not json at all"
+      );
+
+      const result = runCli("agent init --with-windsurf", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(windsurfDir, "mcp_config.json"), "utf-8")
+      );
+      expect(config.mcpServers.rafter.command).toBe("rafter");
+    });
+  });
+
   // ── 5. Continue.dev MCP install ────────────────────────────────────
 
   describe("Continue.dev MCP install (--with-continue)", () => {
-    it("should create config.json with mcpServers containing rafter", () => {
+    it("should create config.json with mcpServers containing rafter (fresh)", () => {
       fs.mkdirSync(path.join(testHomeDir, ".continue"), { recursive: true });
 
       const result = runCli("agent init --with-continue", testHomeDir);
@@ -264,6 +494,136 @@ describe("Platform Integration — MCP Installs via CLI", () => {
     });
   });
 
+  // ── 5b. Continue.dev idempotency and preservation ─────────────────
+
+  describe("Continue.dev MCP idempotency", () => {
+    it("should not duplicate rafter in array format on repeated installs", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".continue"), { recursive: true });
+
+      runCli("agent init --with-continue", testHomeDir);
+      runCli("agent init --with-continue", testHomeDir);
+
+      const configPath = path.join(testHomeDir, ".continue", "config.json");
+      const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+
+      if (Array.isArray(config.mcpServers)) {
+        const rafterEntries = config.mcpServers.filter(
+          (s: any) => s.name === "rafter"
+        );
+        expect(rafterEntries).toHaveLength(1);
+      } else {
+        expect(Object.keys(config.mcpServers).filter(k => k === "rafter")).toHaveLength(1);
+      }
+    });
+
+    it("should preserve existing non-rafter MCP servers (array format)", () => {
+      const continueDir = path.join(testHomeDir, ".continue");
+      fs.mkdirSync(continueDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(continueDir, "config.json"),
+        JSON.stringify({
+          mcpServers: [
+            { name: "other-tool", command: "other", args: ["run"] },
+          ],
+        }, null, 2)
+      );
+
+      runCli("agent init --with-continue", testHomeDir);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(continueDir, "config.json"), "utf-8")
+      );
+      expect(Array.isArray(config.mcpServers)).toBe(true);
+      const otherEntry = config.mcpServers.find(
+        (s: any) => s.name === "other-tool"
+      );
+      expect(otherEntry).toBeDefined();
+      const rafterEntry = config.mcpServers.find(
+        (s: any) => s.name === "rafter"
+      );
+      expect(rafterEntry).toBeDefined();
+    });
+
+    it("should handle object format mcpServers (newer Continue.dev)", () => {
+      const continueDir = path.join(testHomeDir, ".continue");
+      fs.mkdirSync(continueDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(continueDir, "config.json"),
+        JSON.stringify({
+          mcpServers: {
+            "existing-server": { command: "existing", args: ["serve"] },
+          },
+        }, null, 2)
+      );
+
+      runCli("agent init --with-continue", testHomeDir);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(continueDir, "config.json"), "utf-8")
+      );
+      // Should preserve object format, not convert to array
+      expect(Array.isArray(config.mcpServers)).toBe(false);
+      expect(config.mcpServers["existing-server"]).toBeDefined();
+      expect(config.mcpServers.rafter).toBeDefined();
+      expect(config.mcpServers.rafter.command).toBe("rafter");
+    });
+
+    it("should preserve existing non-MCP settings", () => {
+      const continueDir = path.join(testHomeDir, ".continue");
+      fs.mkdirSync(continueDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(continueDir, "config.json"),
+        JSON.stringify({
+          models: [{ title: "GPT-4" }],
+          allowAnonymousTelemetry: false,
+        }, null, 2)
+      );
+
+      runCli("agent init --with-continue", testHomeDir);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(continueDir, "config.json"), "utf-8")
+      );
+      expect(config.models).toEqual([{ title: "GPT-4" }]);
+      expect(config.allowAnonymousTelemetry).toBe(false);
+      expect(config.mcpServers).toBeDefined();
+    });
+  });
+
+  // ── 5c. Continue.dev environment detection ────────────────────────
+
+  describe("Continue.dev environment detection", () => {
+    it("should warn when --with-continue used without ~/.continue", () => {
+      const result = runCli("agent init --with-continue", testHomeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Continue.dev requested but not detected");
+      expect(
+        fs.existsSync(path.join(testHomeDir, ".continue", "config.json"))
+      ).toBe(false);
+    });
+  });
+
+  // ── 5d. Continue.dev corrupted JSON recovery ──────────────────────
+
+  describe("Continue.dev corrupted JSON recovery", () => {
+    it("should recover from corrupted config.json", () => {
+      const continueDir = path.join(testHomeDir, ".continue");
+      fs.mkdirSync(continueDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(continueDir, "config.json"),
+        "totally broken json{{"
+      );
+
+      const result = runCli("agent init --with-continue", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(continueDir, "config.json"), "utf-8")
+      );
+      expect(config.mcpServers).toBeDefined();
+    });
+  });
+
   // ── 6. Aider MCP install ───────────────────────────────────────────
 
   describe("Aider MCP install (--with-aider)", () => {
@@ -285,6 +645,64 @@ describe("Platform Integration — MCP Installs via CLI", () => {
       expect(content).toContain("mcp-server-command: rafter mcp serve");
       // Should preserve existing content
       expect(content).toContain("# existing aider config");
+    });
+  });
+
+  // ── 6b. Aider idempotency and preservation ────────────────────────
+
+  describe("Aider MCP idempotency", () => {
+    it("should not duplicate mcp-server-command on repeated installs", () => {
+      fs.writeFileSync(
+        path.join(testHomeDir, ".aider.conf.yml"),
+        "# aider config\n"
+      );
+
+      runCli("agent init --with-aider", testHomeDir);
+      runCli("agent init --with-aider", testHomeDir);
+
+      const content = fs.readFileSync(
+        path.join(testHomeDir, ".aider.conf.yml"),
+        "utf-8"
+      );
+      // Count occurrences of the mcp line
+      const matches = content.match(/mcp-server-command: rafter mcp serve/g);
+      expect(matches).toHaveLength(1);
+    });
+
+    it("should preserve all existing YAML config", () => {
+      const existingConfig = [
+        "model: gpt-4-turbo",
+        "auto-commits: false",
+        "dark-mode: true",
+        "map-tokens: 1024",
+      ].join("\n") + "\n";
+      fs.writeFileSync(
+        path.join(testHomeDir, ".aider.conf.yml"),
+        existingConfig
+      );
+
+      runCli("agent init --with-aider", testHomeDir);
+
+      const content = fs.readFileSync(
+        path.join(testHomeDir, ".aider.conf.yml"),
+        "utf-8"
+      );
+      expect(content).toContain("model: gpt-4-turbo");
+      expect(content).toContain("auto-commits: false");
+      expect(content).toContain("dark-mode: true");
+      expect(content).toContain("map-tokens: 1024");
+      expect(content).toContain("rafter mcp serve");
+    });
+  });
+
+  // ── 6c. Aider environment detection ───────────────────────────────
+
+  describe("Aider environment detection", () => {
+    it("should warn when --with-aider used without ~/.aider.conf.yml", () => {
+      // Do NOT create .aider.conf.yml
+      const result = runCli("agent init --with-aider", testHomeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Aider requested but not detected");
     });
   });
 
@@ -396,6 +814,131 @@ describe("Platform Integration — MCP Installs via CLI", () => {
         "utf-8"
       );
       expect(aiderContent).toContain("rafter mcp serve");
+    });
+  });
+
+  // ── 9. Mixed flag combinations ────────────────────────────────────
+
+  describe("Mixed flag combinations", () => {
+    it("should install only the requested platforms", () => {
+      // Create ALL platform dirs
+      fs.mkdirSync(path.join(testHomeDir, ".gemini"), { recursive: true });
+      fs.mkdirSync(path.join(testHomeDir, ".cursor"), { recursive: true });
+      fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), {
+        recursive: true,
+      });
+      fs.mkdirSync(path.join(testHomeDir, ".continue"), { recursive: true });
+      fs.writeFileSync(
+        path.join(testHomeDir, ".aider.conf.yml"),
+        "# config\n"
+      );
+
+      // Only request gemini + cursor
+      const result = runCli(
+        "agent init --with-gemini --with-cursor",
+        testHomeDir
+      );
+      expect(result.exitCode).toBe(0);
+
+      // Gemini and Cursor should be installed
+      expect(
+        fs.existsSync(path.join(testHomeDir, ".gemini", "settings.json"))
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(testHomeDir, ".cursor", "mcp.json"))
+      ).toBe(true);
+
+      // Others should NOT be installed
+      expect(
+        fs.existsSync(
+          path.join(testHomeDir, ".codeium", "windsurf", "mcp_config.json")
+        )
+      ).toBe(false);
+      expect(
+        fs.existsSync(path.join(testHomeDir, ".continue", "config.json"))
+      ).toBe(false);
+      const aiderContent = fs.readFileSync(
+        path.join(testHomeDir, ".aider.conf.yml"),
+        "utf-8"
+      );
+      expect(aiderContent).not.toContain("rafter mcp serve");
+    });
+
+    it("should handle --with-windsurf --with-aider together", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(testHomeDir, ".aider.conf.yml"),
+        "# config\n"
+      );
+
+      const result = runCli(
+        "agent init --with-windsurf --with-aider",
+        testHomeDir
+      );
+      expect(result.exitCode).toBe(0);
+
+      // Both should be installed
+      expect(
+        fs.existsSync(
+          path.join(testHomeDir, ".codeium", "windsurf", "mcp_config.json")
+        )
+      ).toBe(true);
+      const aiderContent = fs.readFileSync(
+        path.join(testHomeDir, ".aider.conf.yml"),
+        "utf-8"
+      );
+      expect(aiderContent).toContain("rafter mcp serve");
+    });
+  });
+
+  // ── 10. MCP entry structure validation ────────────────────────────
+
+  describe("MCP entry structure validation", () => {
+    it("all MCP adapters should produce identical rafter entry shape", () => {
+      // Set up all MCP platforms
+      fs.mkdirSync(path.join(testHomeDir, ".gemini"), { recursive: true });
+      fs.mkdirSync(path.join(testHomeDir, ".cursor"), { recursive: true });
+      fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), {
+        recursive: true,
+      });
+
+      runCli(
+        "agent init --with-gemini --with-cursor --with-windsurf",
+        testHomeDir
+      );
+
+      const expected = { command: "rafter", args: ["mcp", "serve"] };
+
+      const gemini = JSON.parse(
+        fs.readFileSync(
+          path.join(testHomeDir, ".gemini", "settings.json"),
+          "utf-8"
+        )
+      );
+      expect(gemini.mcpServers.rafter).toEqual(expected);
+
+      const cursor = JSON.parse(
+        fs.readFileSync(
+          path.join(testHomeDir, ".cursor", "mcp.json"),
+          "utf-8"
+        )
+      );
+      expect(cursor.mcpServers.rafter).toEqual(expected);
+
+      const windsurf = JSON.parse(
+        fs.readFileSync(
+          path.join(
+            testHomeDir,
+            ".codeium",
+            "windsurf",
+            "mcp_config.json"
+          ),
+          "utf-8"
+        )
+      );
+      expect(windsurf.mcpServers.rafter).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Brings every adapter to Gemini-level test depth: idempotency, preservation, environment detection, corrupted config recovery
- New dedicated test suites for **Codex** (12 tests) and **OpenClaw** (19 tests) — previously 0 coverage
- Expands **Cursor, Windsurf, Continue.dev, Aider** from 1 test each to 6-7 each
- Adds cross-adapter tests: mixed flag combinations, MCP entry shape validation
- **605 passing, 6 skipped (API key gated), 0 failures**

| Adapter | Before | After |
|---------|--------|-------|
| Gemini | 6 | 9 |
| Cursor | 1 | 6 |
| Windsurf | 1 | 6 |
| Continue.dev | 1 | 7 |
| Aider | 1 | 4 |
| Codex | 0 | 12 |
| OpenClaw | 0 | 19 |
| Cross-adapter | 2 | 5 |

## Test plan
- [x] Full suite green locally (605 pass, 6 skip)
- [x] Each new test validates a distinct behavior path
- [x] All CLI integration tests use `vi.setConfig({ testTimeout: 30_000 })` for subprocess overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)