### PR TITLE
feat(agent init): --local flag + wire all 4 skills

### DIFF
--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -17,24 +17,36 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
+ * Skills installed by `rafter agent init` for Claude Code / Codex.
+ *
+ * Sourced from `resources/skills/<name>/SKILL.md` in the shipped package.
+ * Keep this list in sync with Python's installer and the skills that actually
+ * ship in both resources/skills/ trees.
+ */
+const AGENT_SKILLS: { name: string; description: string }[] = [
+  { name: "rafter", description: "Rafter Remote" },
+  { name: "rafter-agent-security", description: "Rafter Agent Security" },
+  { name: "rafter-secure-design", description: "Rafter Secure Design" },
+  { name: "rafter-code-review", description: "Rafter Code Review" },
+];
+
+/**
  * Install global instruction files for platforms that support them.
  *
- * Only Claude Code (~/.claude/CLAUDE.md) and Cursor (~/.cursor/rules/*.mdc)
- * have confirmed global instruction file paths. Other platforms (Codex, Gemini,
- * Windsurf, Continue.dev, Aider) only support project-level instruction files
- * (AGENTS.md, GEMINI.md, .windsurfrules, .continuerules, .aider/conventions.md)
- * which are handled by `rafter agent init-project` (not yet implemented).
+ * User scope: Claude Code (~/.claude/CLAUDE.md), Cursor (~/.cursor/rules/*.mdc).
+ * Project scope: both platforms also honor <cwd>/.claude/CLAUDE.md and
+ * <cwd>/.cursor/rules/*.mdc. Other platforms (Codex, Gemini, Windsurf,
+ * Continue.dev, Aider) have project-only instruction file conventions
+ * (AGENTS.md, GEMINI.md, etc.) handled by `rafter agent init-project`.
  */
 function installGlobalInstructions(platforms: {
   claudeCode?: boolean;
   cursor?: boolean;
-}): void {
-  const homeDir = os.homedir();
-
-  // Claude Code — ~/.claude/CLAUDE.md (confirmed global instruction file)
+}, root: string): void {
+  // Claude Code — <root>/.claude/CLAUDE.md
   if (platforms.claudeCode) {
     try {
-      const filePath = path.join(homeDir, ".claude", "CLAUDE.md");
+      const filePath = path.join(root, ".claude", "CLAUDE.md");
       injectInstructionFile(filePath);
       console.log(fmt.success(`Installed Rafter instructions to ${filePath}`));
     } catch (e) {
@@ -42,10 +54,10 @@ function installGlobalInstructions(platforms: {
     }
   }
 
-  // Cursor — ~/.cursor/rules/rafter-security.mdc (global rules directory, markdown format)
+  // Cursor — <root>/.cursor/rules/rafter-security.mdc
   if (platforms.cursor) {
     try {
-      const filePath = path.join(homeDir, ".cursor", "rules", "rafter-security.mdc");
+      const filePath = path.join(root, ".cursor", "rules", "rafter-security.mdc");
       injectInstructionFile(filePath);
       console.log(fmt.success(`Installed Rafter instructions to ${filePath}`));
     } catch (e) {
@@ -54,10 +66,9 @@ function installGlobalInstructions(platforms: {
   }
 }
 
-function installClaudeCodeHooks(): void {
-  const homeDir = os.homedir();
-  const settingsPath = path.join(homeDir, ".claude", "settings.json");
-  const claudeDir = path.join(homeDir, ".claude");
+function installClaudeCodeHooks(root: string): void {
+  const settingsPath = path.join(root, ".claude", "settings.json");
+  const claudeDir = path.join(root, ".claude");
 
   if (!fs.existsSync(claudeDir)) {
     fs.mkdirSync(claudeDir, { recursive: true });
@@ -110,9 +121,8 @@ function installClaudeCodeHooks(): void {
   console.log(fmt.success(`Installed PostToolUse hooks to ${settingsPath}`));
 }
 
-function installCodexHooks(): void {
-  const homeDir = os.homedir();
-  const codexDir = path.join(homeDir, ".codex");
+function installCodexHooks(root: string): void {
+  const codexDir = path.join(root, ".codex");
 
   if (!fs.existsSync(codexDir)) {
     fs.mkdirSync(codexDir, { recursive: true });
@@ -156,9 +166,8 @@ function installCodexHooks(): void {
   console.log(fmt.success(`Installed hooks to ${hooksPath}`));
 }
 
-function installCursorHooks(): void {
-  const homeDir = os.homedir();
-  const cursorDir = path.join(homeDir, ".cursor");
+function installCursorHooks(root: string): void {
+  const cursorDir = path.join(root, ".cursor");
 
   if (!fs.existsSync(cursorDir)) {
     fs.mkdirSync(cursorDir, { recursive: true });
@@ -194,9 +203,8 @@ function installCursorHooks(): void {
   console.log(fmt.success(`Installed hooks to ${hooksPath}`));
 }
 
-function installGeminiHooks(): void {
-  const homeDir = os.homedir();
-  const geminiDir = path.join(homeDir, ".gemini");
+function installGeminiHooks(root: string): void {
+  const geminiDir = path.join(root, ".gemini");
 
   if (!fs.existsSync(geminiDir)) {
     fs.mkdirSync(geminiDir, { recursive: true });
@@ -238,9 +246,8 @@ function installGeminiHooks(): void {
   console.log(fmt.success(`Installed hooks to ${settingsPath}`));
 }
 
-function installWindsurfHooks(): void {
-  const homeDir = os.homedir();
-  const windsurfDir = path.join(homeDir, ".windsurf");
+function installWindsurfHooks(root: string): void {
+  const windsurfDir = path.join(root, ".windsurf");
 
   if (!fs.existsSync(windsurfDir)) {
     fs.mkdirSync(windsurfDir, { recursive: true });
@@ -282,9 +289,8 @@ function installWindsurfHooks(): void {
   console.log(fmt.success(`Installed hooks to ${hooksPath}`));
 }
 
-function installContinueDevHooks(): void {
-  const homeDir = os.homedir();
-  const continueDir = path.join(homeDir, ".continue");
+function installContinueDevHooks(root: string): void {
+  const continueDir = path.join(root, ".continue");
 
   if (!fs.existsSync(continueDir)) {
     fs.mkdirSync(continueDir, { recursive: true });
@@ -337,9 +343,8 @@ const RAFTER_MCP_ENTRY = {
 /**
  * Install MCP server config for Gemini CLI (~/.gemini/settings.json)
  */
-function installGeminiMcp(): boolean {
-  const homeDir = os.homedir();
-  const geminiDir = path.join(homeDir, ".gemini");
+function installGeminiMcp(root: string): boolean {
+  const geminiDir = path.join(root, ".gemini");
   const settingsPath = path.join(geminiDir, "settings.json");
 
   if (!fs.existsSync(geminiDir)) {
@@ -366,9 +371,8 @@ function installGeminiMcp(): boolean {
 /**
  * Install MCP server config for Cursor (~/.cursor/mcp.json)
  */
-function installCursorMcp(): boolean {
-  const homeDir = os.homedir();
-  const cursorDir = path.join(homeDir, ".cursor");
+function installCursorMcp(root: string): boolean {
+  const cursorDir = path.join(root, ".cursor");
   const mcpPath = path.join(cursorDir, "mcp.json");
 
   if (!fs.existsSync(cursorDir)) {
@@ -395,9 +399,8 @@ function installCursorMcp(): boolean {
 /**
  * Install MCP server config for Windsurf (~/.codeium/windsurf/mcp_config.json)
  */
-function installWindsurfMcp(): boolean {
-  const homeDir = os.homedir();
-  const windsurfDir = path.join(homeDir, ".codeium", "windsurf");
+function installWindsurfMcp(root: string): boolean {
+  const windsurfDir = path.join(root, ".codeium", "windsurf");
   const mcpPath = path.join(windsurfDir, "mcp_config.json");
 
   if (!fs.existsSync(windsurfDir)) {
@@ -424,9 +427,8 @@ function installWindsurfMcp(): boolean {
 /**
  * Install MCP server config for Continue.dev (~/.continue/config.json)
  */
-function installContinueDevMcp(): boolean {
-  const homeDir = os.homedir();
-  const continueDir = path.join(homeDir, ".continue");
+function installContinueDevMcp(root: string): boolean {
+  const continueDir = path.join(root, ".continue");
   const configPath = path.join(continueDir, "config.json");
 
   if (!fs.existsSync(continueDir)) {
@@ -468,9 +470,8 @@ function installContinueDevMcp(): boolean {
  * Install MCP config for Aider (~/.aider.conf.yml)
  * Aider uses YAML config with mcpServers list
  */
-function installAiderMcp(): boolean {
-  const homeDir = os.homedir();
-  const configPath = path.join(homeDir, ".aider.conf.yml");
+function installAiderMcp(root: string): boolean {
+  const configPath = path.join(root, ".aider.conf.yml");
 
   // Aider's YAML config is simple — we append the MCP flag if not present
   let content = "";
@@ -491,83 +492,34 @@ function installAiderMcp(): boolean {
   return true;
 }
 
-async function installClaudeCodeSkills(): Promise<void> {
-  const homeDir = os.homedir();
-  const claudeSkillsDir = path.join(homeDir, ".claude", "skills");
-
-  // Ensure .claude/skills directory exists
-  if (!fs.existsSync(claudeSkillsDir)) {
-    fs.mkdirSync(claudeSkillsDir, { recursive: true });
+function installSkillsTo(skillsDir: string): void {
+  if (!fs.existsSync(skillsDir)) {
+    fs.mkdirSync(skillsDir, { recursive: true });
   }
-
-  // Install Backend Skill
-  const backendSkillDir = path.join(claudeSkillsDir, "rafter");
-  const backendSkillPath = path.join(backendSkillDir, "SKILL.md");
-  const backendTemplatePath = path.join(__dirname, "..", "..", "..", "resources", "skills", "rafter", "SKILL.md");
-
-  if (!fs.existsSync(backendSkillDir)) {
-    fs.mkdirSync(backendSkillDir, { recursive: true });
-  }
-
-  if (fs.existsSync(backendTemplatePath)) {
-    fs.copyFileSync(backendTemplatePath, backendSkillPath);
-    console.log(fmt.success(`Installed Rafter Remote skill to ${backendSkillPath}`));
-  } else {
-    console.log(fmt.warning(`Remote skill template not found at ${backendTemplatePath}`));
-  }
-
-  // Install Agent Security Skill
-  const agentSkillDir = path.join(claudeSkillsDir, "rafter-agent-security");
-  const agentSkillPath = path.join(agentSkillDir, "SKILL.md");
-  const agentTemplatePath = path.join(__dirname, "..", "..", "..", "resources", "skills", "rafter-agent-security", "SKILL.md");
-
-  if (!fs.existsSync(agentSkillDir)) {
-    fs.mkdirSync(agentSkillDir, { recursive: true });
-  }
-
-  if (fs.existsSync(agentTemplatePath)) {
-    fs.copyFileSync(agentTemplatePath, agentSkillPath);
-    console.log(fmt.success(`Installed Rafter Agent Security skill to ${agentSkillPath}`));
-  } else {
-    console.log(fmt.warning(`Agent Security skill template not found at ${agentTemplatePath}`));
+  for (const skill of AGENT_SKILLS) {
+    const destDir = path.join(skillsDir, skill.name);
+    const destPath = path.join(destDir, "SKILL.md");
+    const srcPath = path.join(
+      __dirname, "..", "..", "..", "resources", "skills", skill.name, "SKILL.md",
+    );
+    if (!fs.existsSync(destDir)) {
+      fs.mkdirSync(destDir, { recursive: true });
+    }
+    if (fs.existsSync(srcPath)) {
+      fs.copyFileSync(srcPath, destPath);
+      console.log(fmt.success(`Installed ${skill.description} skill to ${destPath}`));
+    } else {
+      console.log(fmt.warning(`${skill.description} skill template not found at ${srcPath}`));
+    }
   }
 }
 
-function installCodexSkills(): void {
-  const homeDir = os.homedir();
-  const agentsSkillsDir = path.join(homeDir, ".agents", "skills");
+async function installClaudeCodeSkills(root: string): Promise<void> {
+  installSkillsTo(path.join(root, ".claude", "skills"));
+}
 
-  // Install Backend Skill
-  const backendDir = path.join(agentsSkillsDir, "rafter");
-  const backendSkillPath = path.join(backendDir, "SKILL.md");
-  const backendTemplatePath = path.join(__dirname, "..", "..", "..", "resources", "skills", "rafter", "SKILL.md");
-
-  if (!fs.existsSync(backendDir)) {
-    fs.mkdirSync(backendDir, { recursive: true });
-  }
-
-  if (fs.existsSync(backendTemplatePath)) {
-    fs.copyFileSync(backendTemplatePath, backendSkillPath);
-    console.log(fmt.success(`Installed Rafter Remote skill to ${backendSkillPath}`));
-  } else {
-    console.log(fmt.warning(`Remote skill template not found at ${backendTemplatePath}`));
-  }
-
-  // Install Agent Security Skill
-  const agentDir = path.join(agentsSkillsDir, "rafter-agent-security");
-  const agentSkillPath = path.join(agentDir, "SKILL.md");
-  const agentTemplatePath = path.join(__dirname, "..", "..", "..", "resources", "skills", "rafter-agent-security", "SKILL.md");
-
-  if (!fs.existsSync(agentDir)) {
-    fs.mkdirSync(agentDir, { recursive: true });
-  }
-
-  if (fs.existsSync(agentTemplatePath)) {
-    fs.copyFileSync(agentTemplatePath, agentSkillPath);
-    console.log(fmt.success(`Installed Rafter Agent Security skill to ${agentSkillPath}`));
-  } else {
-    console.log(fmt.warning(`Agent Security skill template not found at ${agentTemplatePath}`));
-  }
+function installCodexSkills(root: string): void {
+  installSkillsTo(path.join(root, ".agents", "skills"));
 }
 
 async function askYesNo(question: string, defaultYes = true): Promise<boolean> {
@@ -599,33 +551,50 @@ export function createInitCommand(): Command {
     .option("--all", "Install all detected integrations and download Gitleaks")
     .option("-i, --interactive", "Guided setup — prompts for each detected integration")
     .option("--update", "Re-download gitleaks and reinstall integrations without resetting config")
+    .option(
+      "--local",
+      "Install integration configs project-locally (in CWD) instead of user-globally. " +
+      "Supported for Claude Code, Codex, Gemini, Cursor. Other platforms are skipped in local mode.",
+    )
     .action(async (opts) => {
       console.log(fmt.header("Rafter Agent Security Setup"));
       console.log(fmt.divider());
       console.log();
 
       const manager = new ConfigManager();
+      const root = opts.local ? process.cwd() : os.homedir();
+      const scope: "project" | "user" = opts.local ? "project" : "user";
+      if (opts.local) {
+        console.log(fmt.info(`Project-local install — writing configs under ${root}`));
+      }
 
-      // Detect environments
-      const hasOpenClaw = fs.existsSync(path.join(os.homedir(), ".openclaw"));
-      const hasClaudeCode = fs.existsSync(path.join(os.homedir(), ".claude"));
-      const hasCodex = fs.existsSync(path.join(os.homedir(), ".codex"));
-      const hasGemini = fs.existsSync(path.join(os.homedir(), ".gemini"));
-      const hasCursor = fs.existsSync(path.join(os.homedir(), ".cursor"));
-      const hasWindsurf = fs.existsSync(path.join(os.homedir(), ".codeium", "windsurf"));
-      const hasContinueDev = fs.existsSync(path.join(os.homedir(), ".continue"));
-      const hasAider = fs.existsSync(path.join(os.homedir(), ".aider.conf.yml"));
+      // Platforms supported in --local scope: Claude Code, Codex, Gemini, Cursor.
+      // Windsurf, Continue.dev, Aider are skipped in --local because their
+      // project-local config story is not established in their CLIs today.
 
-      // Resolve opt-in flags (--all enables all detected, --interactive prompts)
-      let wantOpenClaw = opts.withOpenclaw || opts.all;
+      // Detect environments. In local scope, don't probe user-global paths —
+      // the user must opt in explicitly via --with-<platform>.
+      const hasOpenClaw = scope === "user" && fs.existsSync(path.join(os.homedir(), ".openclaw"));
+      const hasClaudeCode = scope === "user" && fs.existsSync(path.join(os.homedir(), ".claude"));
+      const hasCodex = scope === "user" && fs.existsSync(path.join(os.homedir(), ".codex"));
+      const hasGemini = scope === "user" && fs.existsSync(path.join(os.homedir(), ".gemini"));
+      const hasCursor = scope === "user" && fs.existsSync(path.join(os.homedir(), ".cursor"));
+      const hasWindsurf = scope === "user" && fs.existsSync(path.join(os.homedir(), ".codeium", "windsurf"));
+      const hasContinueDev = scope === "user" && fs.existsSync(path.join(os.homedir(), ".continue"));
+      const hasAider = scope === "user" && fs.existsSync(path.join(os.homedir(), ".aider.conf.yml"));
+
+      // Resolve opt-in flags (--all enables all detected, --interactive prompts).
+      // In --local scope, --all is restricted to platforms that have a project-local
+      // config story (claudeCode, codex, gemini, cursor). The rest require user scope.
+      let wantOpenClaw = opts.withOpenclaw || (opts.all && !opts.local);
       let wantClaudeCode = opts.withClaudeCode || opts.all;
       let wantCodex = opts.withCodex || opts.all;
       let wantGemini = opts.withGemini || opts.all;
       let wantCursor = opts.withCursor || opts.all;
-      let wantWindsurf = opts.withWindsurf || opts.all;
-      let wantContinue = opts.withContinue || opts.all;
-      let wantAider = opts.withAider || opts.all;
-      let wantGitleaks = opts.withGitleaks || opts.all;
+      let wantWindsurf = opts.withWindsurf || (opts.all && !opts.local);
+      let wantContinue = opts.withContinue || (opts.all && !opts.local);
+      let wantAider = opts.withAider || (opts.all && !opts.local);
+      let wantGitleaks = opts.withGitleaks || (opts.all && !opts.local);
 
       // Interactive mode: prompt for each detected integration
       if (opts.interactive && !opts.all) {
@@ -661,15 +630,18 @@ export function createInitCommand(): Command {
         console.log(fmt.info("No agent environments detected"));
       }
 
-      // Warn about requested but undetected environments
-      if (wantOpenClaw && !hasOpenClaw) console.log(fmt.warning("OpenClaw requested but not detected (~/.openclaw not found)"));
-      if (wantClaudeCode && !hasClaudeCode) console.log(fmt.warning("Claude Code requested but not detected (~/.claude not found)"));
-      if (wantCodex && !hasCodex) console.log(fmt.warning("Codex CLI requested but not detected (~/.codex not found)"));
-      if (wantGemini && !hasGemini) console.log(fmt.warning("Gemini CLI requested but not detected (~/.gemini not found)"));
-      if (wantCursor && !hasCursor) console.log(fmt.warning("Cursor requested but not detected (~/.cursor not found)"));
-      if (wantWindsurf && !hasWindsurf) console.log(fmt.warning("Windsurf requested but not detected (~/.codeium/windsurf not found)"));
-      if (wantContinue && !hasContinueDev) console.log(fmt.warning("Continue.dev requested but not detected (~/.continue not found)"));
-      if (wantAider && !hasAider) console.log(fmt.warning("Aider requested but not detected (~/.aider.conf.yml not found)"));
+      // Warn about requested but undetected environments (user scope only —
+      // in --local scope we create the directories in CWD as needed).
+      if (scope === "user") {
+        if (wantOpenClaw && !hasOpenClaw) console.log(fmt.warning("OpenClaw requested but not detected (~/.openclaw not found)"));
+        if (wantClaudeCode && !hasClaudeCode) console.log(fmt.warning("Claude Code requested but not detected (~/.claude not found)"));
+        if (wantCodex && !hasCodex) console.log(fmt.warning("Codex CLI requested but not detected (~/.codex not found)"));
+        if (wantGemini && !hasGemini) console.log(fmt.warning("Gemini CLI requested but not detected (~/.gemini not found)"));
+        if (wantCursor && !hasCursor) console.log(fmt.warning("Cursor requested but not detected (~/.cursor not found)"));
+        if (wantWindsurf && !hasWindsurf) console.log(fmt.warning("Windsurf requested but not detected (~/.codeium/windsurf not found)"));
+        if (wantContinue && !hasContinueDev) console.log(fmt.warning("Continue.dev requested but not detected (~/.continue not found)"));
+        if (wantAider && !hasAider) console.log(fmt.warning("Aider requested but not detected (~/.aider.conf.yml not found)"));
+      }
 
       // Initialize directory structure
       try {
@@ -776,14 +748,22 @@ export function createInitCommand(): Command {
         }
       }
 
+      // Helper: warn that a platform is not supported in --local mode.
+      const localUnsupported = (label: string): void => {
+        console.log(fmt.warning(
+          `${label} is not supported in --local mode yet. Skipping. ` +
+          `Re-run without --local to install for this platform user-globally.`,
+        ));
+      };
+
       // Install Claude Code skills + hooks if opted in
-      // When --with-claude-code is explicitly passed, install even if .claude doesn't exist yet
+      // When --with-claude-code is explicitly passed (or --local), install even if <root>/.claude doesn't exist yet
       let claudeCodeOk = false;
-      if ((hasClaudeCode || opts.withClaudeCode) && wantClaudeCode) {
+      if ((hasClaudeCode || opts.withClaudeCode || (opts.local && wantClaudeCode)) && wantClaudeCode) {
         try {
-          await installClaudeCodeSkills();
-          installClaudeCodeHooks();
-          manager.set("agent.environments.claudeCode.enabled", true);
+          await installClaudeCodeSkills(root);
+          installClaudeCodeHooks(root);
+          if (scope === "user") manager.set("agent.environments.claudeCode.enabled", true);
           claudeCodeOk = true;
         } catch (e) {
           console.error(fmt.error(`Failed to install Claude Code integration: ${e}`));
@@ -792,11 +772,11 @@ export function createInitCommand(): Command {
 
       // Install Codex CLI skills + hooks if opted in
       let codexOk = false;
-      if (hasCodex && wantCodex) {
+      if ((hasCodex || (opts.local && wantCodex)) && wantCodex) {
         try {
-          installCodexSkills();
-          installCodexHooks();
-          manager.set("agent.environments.codex.enabled", true);
+          installCodexSkills(root);
+          installCodexHooks(root);
+          if (scope === "user") manager.set("agent.environments.codex.enabled", true);
           codexOk = true;
         } catch (e) {
           console.error(fmt.error(`Failed to install Codex CLI integration: ${e}`));
@@ -805,11 +785,11 @@ export function createInitCommand(): Command {
 
       // Install Gemini CLI MCP + hooks if opted in
       let geminiOk = false;
-      if (hasGemini && wantGemini) {
+      if ((hasGemini || (opts.local && wantGemini)) && wantGemini) {
         try {
-          geminiOk = installGeminiMcp();
-          installGeminiHooks();
-          if (geminiOk) manager.set("agent.environments.gemini.enabled", true);
+          geminiOk = installGeminiMcp(root);
+          installGeminiHooks(root);
+          if (geminiOk && scope === "user") manager.set("agent.environments.gemini.enabled", true);
         } catch (e) {
           console.error(fmt.error(`Failed to install Gemini CLI integration: ${e}`));
         }
@@ -817,11 +797,11 @@ export function createInitCommand(): Command {
 
       // Install Cursor MCP + hooks if opted in
       let cursorOk = false;
-      if (hasCursor && wantCursor) {
+      if ((hasCursor || (opts.local && wantCursor)) && wantCursor) {
         try {
-          cursorOk = installCursorMcp();
-          installCursorHooks();
-          if (cursorOk) manager.set("agent.environments.cursor.enabled", true);
+          cursorOk = installCursorMcp(root);
+          installCursorHooks(root);
+          if (cursorOk && scope === "user") manager.set("agent.environments.cursor.enabled", true);
         } catch (e) {
           console.error(fmt.error(`Failed to install Cursor integration: ${e}`));
         }
@@ -831,42 +811,48 @@ export function createInitCommand(): Command {
       let windsurfOk = false;
       if (hasWindsurf && wantWindsurf) {
         try {
-          windsurfOk = installWindsurfMcp();
-          installWindsurfHooks();
+          windsurfOk = installWindsurfMcp(root);
+          installWindsurfHooks(root);
           if (windsurfOk) manager.set("agent.environments.windsurf.enabled", true);
         } catch (e) {
           console.error(fmt.error(`Failed to install Windsurf integration: ${e}`));
         }
+      } else if (opts.local && wantWindsurf) {
+        localUnsupported("Windsurf");
       }
 
       // Install Continue.dev MCP + hooks if opted in
       let continueOk = false;
       if (hasContinueDev && wantContinue) {
         try {
-          continueOk = installContinueDevMcp();
-          installContinueDevHooks();
+          continueOk = installContinueDevMcp(root);
+          installContinueDevHooks(root);
           if (continueOk) manager.set("agent.environments.continueDev.enabled", true);
         } catch (e) {
           console.error(fmt.error(`Failed to install Continue.dev integration: ${e}`));
         }
+      } else if (opts.local && wantContinue) {
+        localUnsupported("Continue.dev");
       }
 
       // Install Aider MCP if opted in
       let aiderOk = false;
       if (hasAider && wantAider) {
         try {
-          aiderOk = installAiderMcp();
+          aiderOk = installAiderMcp(root);
           if (aiderOk) manager.set("agent.environments.aider.enabled", true);
         } catch (e) {
           console.error(fmt.error(`Failed to install Aider integration: ${e}`));
         }
+      } else if (opts.local && wantAider) {
+        localUnsupported("Aider");
       }
 
       // Install global instruction files for platforms that support them
       installGlobalInstructions({
         claudeCode: claudeCodeOk,
         cursor: cursorOk,
-      });
+      }, root);
 
       console.log();
       console.log(fmt.success("Agent security initialized!"));
@@ -884,6 +870,12 @@ export function createInitCommand(): Command {
         if (windsurfOk) console.log("  - Restart Windsurf to load MCP server");
         if (continueOk) console.log("  - Restart Continue.dev to load MCP server");
         if (aiderOk) console.log("  - Restart Aider to load MCP server");
+      } else if (scope === "project") {
+        console.log("No integrations were installed. In --local mode, pass one or more opt-in flags:");
+        console.log("  rafter agent init --local --with-claude-code");
+        console.log("  rafter agent init --local --with-codex");
+        console.log("  rafter agent init --local --with-gemini");
+        console.log("  rafter agent init --local --with-cursor");
       } else if (detected.length > 0) {
         console.log("No integrations were installed. To install, re-run with opt-in flags:");
         console.log("  rafter agent init --all                  # Install all detected");

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -109,10 +109,20 @@ def _resolve_rafter_path() -> str:
     return "rafter"
 
 
-def _install_claude_code_hooks() -> None:
-    """Install Rafter PreToolUse hooks into ~/.claude/settings.json."""
-    home = Path.home()
-    claude_dir = home / ".claude"
+# Skills installed by `rafter agent init` for Claude Code / Codex.
+# Keep this list in sync with Node's AGENT_SKILLS and the SKILL.md files
+# actually shipped under rafter_cli/resources/skills/.
+_AGENT_SKILLS: list[dict[str, str]] = [
+    {"name": "rafter", "description": "Rafter Remote"},
+    {"name": "rafter-agent-security", "description": "Rafter Agent Security"},
+    {"name": "rafter-secure-design", "description": "Rafter Secure Design"},
+    {"name": "rafter-code-review", "description": "Rafter Code Review"},
+]
+
+
+def _install_claude_code_hooks(root: Path) -> None:
+    """Install Rafter PreToolUse hooks into <root>/.claude/settings.json."""
+    claude_dir = root / ".claude"
     settings_path = claude_dir / "settings.json"
 
     claude_dir.mkdir(parents=True, exist_ok=True)
@@ -181,6 +191,54 @@ def _install_claude_code_hooks() -> None:
 # ── init ─────────────────────────────────────────────────────────────
 
 
+def _install_skills_to(skills_dir: Path) -> None:
+    """Copy all four AGENT_SKILLS into <skills_dir>/<skill>/SKILL.md."""
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    res = importlib.resources.files("rafter_cli.resources")
+    for skill in _AGENT_SKILLS:
+        dest_dir = skills_dir / skill["name"]
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest_path = dest_dir / "SKILL.md"
+        try:
+            content = res.joinpath("skills", skill["name"], "SKILL.md").read_text(encoding="utf-8")
+            dest_path.write_text(content, encoding="utf-8")
+            rprint(fmt.success(f"Installed {skill['description']} skill to {dest_path}"))
+        except Exception:
+            rprint(fmt.warning(f"{skill['description']} skill template not found in package resources"))
+
+
+def _install_claude_code_skills(root: Path) -> None:
+    """Copy all four Rafter skills into <root>/.claude/skills/."""
+    _install_skills_to(root / ".claude" / "skills")
+
+
+def _install_global_instructions(
+    claude_code: bool,
+    cursor: bool,
+    root: Path,
+) -> None:
+    """Install Rafter instruction files for platforms that support them.
+
+    Claude Code: <root>/.claude/CLAUDE.md
+    Cursor: <root>/.cursor/rules/rafter-security.mdc
+    """
+    if claude_code:
+        try:
+            file_path = root / ".claude" / "CLAUDE.md"
+            _inject_instruction_file(file_path)
+            rprint(fmt.success(f"Installed Rafter instructions to {file_path}"))
+        except Exception as e:
+            rprint(fmt.warning(f"Failed to write Claude Code instructions: {e}"))
+
+    if cursor:
+        try:
+            file_path = root / ".cursor" / "rules" / "rafter-security.mdc"
+            _inject_instruction_file(file_path)
+            rprint(fmt.success(f"Installed Rafter instructions to {file_path}"))
+        except Exception as e:
+            rprint(fmt.warning(f"Failed to write Cursor instructions: {e}"))
+
+
 def _install_openclaw_skill() -> tuple[bool, str, str, str]:
     """Install Rafter Security skill to OpenClaw. Returns (ok, source, dest, error)."""
     home = Path.home()
@@ -213,33 +271,10 @@ def _install_openclaw_skill() -> tuple[bool, str, str, str]:
         return False, source_path, str(dest_path), str(e)
 
 
-def _install_codex_skills() -> tuple[bool, str]:
-    """Install Rafter skills to ~/.agents/skills/ for Codex CLI. Returns (ok, error)."""
-    home = Path.home()
-    agents_skills_dir = home / ".agents" / "skills"
-
+def _install_codex_skills(root: Path) -> tuple[bool, str]:
+    """Install all Rafter skills to <root>/.agents/skills/ for Codex CLI."""
     try:
-        # Install backend skill
-        backend_dir = agents_skills_dir / "rafter"
-        backend_dir.mkdir(parents=True, exist_ok=True)
-        res = importlib.resources.files("rafter_cli.resources")
-        try:
-            content = res.joinpath("skills", "rafter", "SKILL.md").read_text(encoding="utf-8")
-            (backend_dir / "SKILL.md").write_text(content, encoding="utf-8")
-            rprint(fmt.success(f"Installed Rafter Remote skill to {backend_dir / 'SKILL.md'}"))
-        except Exception:
-            rprint(fmt.warning("Remote skill template not found in package resources"))
-
-        # Install agent security skill
-        agent_dir = agents_skills_dir / "rafter-agent-security"
-        agent_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            content = res.joinpath("skills", "rafter-agent-security", "SKILL.md").read_text(encoding="utf-8")
-            (agent_dir / "SKILL.md").write_text(content, encoding="utf-8")
-            rprint(fmt.success(f"Installed Rafter Agent Security skill to {agent_dir / 'SKILL.md'}"))
-        except Exception:
-            rprint(fmt.warning("Agent Security skill template not found in package resources"))
-
+        _install_skills_to(root / ".agents" / "skills")
         return True, ""
     except Exception as e:
         return False, str(e)
@@ -253,10 +288,9 @@ _RAFTER_MCP_ENTRY = {
 }
 
 
-def _install_gemini_mcp() -> bool:
-    """Install MCP server config for Gemini CLI (~/.gemini/settings.json)."""
-    home = Path.home()
-    gemini_dir = home / ".gemini"
+def _install_gemini_mcp(root: Path) -> bool:
+    """Install MCP server config for Gemini CLI (<root>/.gemini/settings.json)."""
+    gemini_dir = root / ".gemini"
     settings_path = gemini_dir / "settings.json"
 
     gemini_dir.mkdir(parents=True, exist_ok=True)
@@ -277,10 +311,9 @@ def _install_gemini_mcp() -> bool:
     return True
 
 
-def _install_cursor_mcp() -> bool:
-    """Install MCP server config for Cursor (~/.cursor/mcp.json)."""
-    home = Path.home()
-    cursor_dir = home / ".cursor"
+def _install_cursor_mcp(root: Path) -> bool:
+    """Install MCP server config for Cursor (<root>/.cursor/mcp.json)."""
+    cursor_dir = root / ".cursor"
     mcp_path = cursor_dir / "mcp.json"
 
     cursor_dir.mkdir(parents=True, exist_ok=True)
@@ -301,10 +334,9 @@ def _install_cursor_mcp() -> bool:
     return True
 
 
-def _install_windsurf_mcp() -> bool:
-    """Install MCP server config for Windsurf (~/.codeium/windsurf/mcp_config.json)."""
-    home = Path.home()
-    windsurf_dir = home / ".codeium" / "windsurf"
+def _install_windsurf_mcp(root: Path) -> bool:
+    """Install MCP server config for Windsurf (<root>/.codeium/windsurf/mcp_config.json)."""
+    windsurf_dir = root / ".codeium" / "windsurf"
     mcp_path = windsurf_dir / "mcp_config.json"
 
     windsurf_dir.mkdir(parents=True, exist_ok=True)
@@ -325,10 +357,9 @@ def _install_windsurf_mcp() -> bool:
     return True
 
 
-def _install_continue_dev_mcp() -> bool:
-    """Install MCP server config for Continue.dev (~/.continue/config.json)."""
-    home = Path.home()
-    continue_dir = home / ".continue"
+def _install_continue_dev_mcp(root: Path) -> bool:
+    """Install MCP server config for Continue.dev (<root>/.continue/config.json)."""
+    continue_dir = root / ".continue"
     config_path = continue_dir / "config.json"
 
     continue_dir.mkdir(parents=True, exist_ok=True)
@@ -359,10 +390,9 @@ def _install_continue_dev_mcp() -> bool:
     return True
 
 
-def _install_aider_mcp() -> bool:
-    """Install MCP config for Aider (~/.aider.conf.yml)."""
-    home = Path.home()
-    config_path = home / ".aider.conf.yml"
+def _install_aider_mcp(root: Path) -> bool:
+    """Install MCP config for Aider (<root>/.aider.conf.yml)."""
+    config_path = root / ".aider.conf.yml"
 
     content = ""
     if config_path.exists():
@@ -392,6 +422,14 @@ def init(
     with_continue: bool = typer.Option(False, "--with-continue", help="Install Continue.dev integration"),
     all_integrations: bool = typer.Option(False, "--all", help="Install all detected integrations and download Gitleaks"),
     update: bool = typer.Option(False, "--update", help="Re-download gitleaks and reinstall integrations without resetting config"),
+    local: bool = typer.Option(
+        False,
+        "--local",
+        help=(
+            "Install integration configs project-locally (in CWD) instead of user-globally. "
+            "Supported for Claude Code, Codex, Gemini, Cursor. Other platforms are skipped in local mode."
+        ),
+    ),
 ):
     """Initialize agent security system."""
     rprint(fmt.header("Rafter Agent Security Setup"))
@@ -399,28 +437,34 @@ def init(
     rprint()
 
     manager = ConfigManager()
+    root = Path.cwd() if local else Path.home()
+    scope = "project" if local else "user"
+    if local:
+        rprint(fmt.info(f"Project-local install — writing configs under {root}"))
 
-    # Detect environments
+    # Detect environments. In local scope, don't probe user-global paths —
+    # the user must opt in explicitly via --with-<platform>.
     home = Path.home()
-    has_openclaw = (home / ".openclaw").exists()
-    has_claude_code = (home / ".claude").exists()
-    has_codex = (home / ".codex").exists()
-    has_gemini = (home / ".gemini").exists()
-    has_cursor = (home / ".cursor").exists()
-    has_windsurf = (home / ".codeium" / "windsurf").exists()
-    has_continue_dev = (home / ".continue").exists()
-    has_aider = (home / ".aider.conf.yml").exists()
+    has_openclaw = scope == "user" and (home / ".openclaw").exists()
+    has_claude_code = scope == "user" and (home / ".claude").exists()
+    has_codex = scope == "user" and (home / ".codex").exists()
+    has_gemini = scope == "user" and (home / ".gemini").exists()
+    has_cursor = scope == "user" and (home / ".cursor").exists()
+    has_windsurf = scope == "user" and (home / ".codeium" / "windsurf").exists()
+    has_continue_dev = scope == "user" and (home / ".continue").exists()
+    has_aider = scope == "user" and (home / ".aider.conf.yml").exists()
 
-    # Resolve opt-in flags (--all enables all detected)
-    want_openclaw = with_openclaw or all_integrations
+    # Resolve opt-in flags. In --local scope, --all is restricted to platforms with
+    # a project-local config story (claudeCode, codex, gemini, cursor).
+    want_openclaw = with_openclaw or (all_integrations and not local)
     want_claude_code = with_claude_code or all_integrations
     want_codex = with_codex or all_integrations
     want_gemini = with_gemini or all_integrations
     want_cursor = with_cursor or all_integrations
-    want_windsurf = with_windsurf or all_integrations
-    want_continue = with_continue or all_integrations
-    want_aider = with_aider or all_integrations
-    want_gitleaks = with_gitleaks or all_integrations
+    want_windsurf = with_windsurf or (all_integrations and not local)
+    want_continue = with_continue or (all_integrations and not local)
+    want_aider = with_aider or (all_integrations and not local)
+    want_gitleaks = with_gitleaks or (all_integrations and not local)
 
     # Show detected environments
     detected = []
@@ -446,23 +490,25 @@ def init(
     else:
         rprint(fmt.info("No agent environments detected"))
 
-    # Warn about requested but undetected environments
-    if want_openclaw and not has_openclaw:
-        rprint(fmt.warning("OpenClaw requested but not detected (~/.openclaw not found)"))
-    if want_claude_code and not has_claude_code:
-        rprint(fmt.warning("Claude Code requested but not detected (~/.claude not found)"))
-    if want_codex and not has_codex:
-        rprint(fmt.warning("Codex CLI requested but not detected (~/.codex not found)"))
-    if want_gemini and not has_gemini:
-        rprint(fmt.warning("Gemini CLI requested but not detected (~/.gemini not found)"))
-    if want_cursor and not has_cursor:
-        rprint(fmt.warning("Cursor requested but not detected (~/.cursor not found)"))
-    if want_windsurf and not has_windsurf:
-        rprint(fmt.warning("Windsurf requested but not detected (~/.codeium/windsurf not found)"))
-    if want_continue and not has_continue_dev:
-        rprint(fmt.warning("Continue.dev requested but not detected (~/.continue not found)"))
-    if want_aider and not has_aider:
-        rprint(fmt.warning("Aider requested but not detected (~/.aider.conf.yml not found)"))
+    # Warn about requested but undetected environments (user scope only —
+    # in --local scope we create the directories in CWD as needed).
+    if scope == "user":
+        if want_openclaw and not has_openclaw:
+            rprint(fmt.warning("OpenClaw requested but not detected (~/.openclaw not found)"))
+        if want_claude_code and not has_claude_code:
+            rprint(fmt.warning("Claude Code requested but not detected (~/.claude not found)"))
+        if want_codex and not has_codex:
+            rprint(fmt.warning("Codex CLI requested but not detected (~/.codex not found)"))
+        if want_gemini and not has_gemini:
+            rprint(fmt.warning("Gemini CLI requested but not detected (~/.gemini not found)"))
+        if want_cursor and not has_cursor:
+            rprint(fmt.warning("Cursor requested but not detected (~/.cursor not found)"))
+        if want_windsurf and not has_windsurf:
+            rprint(fmt.warning("Windsurf requested but not detected (~/.codeium/windsurf not found)"))
+        if want_continue and not has_continue_dev:
+            rprint(fmt.warning("Continue.dev requested but not detected (~/.continue not found)"))
+        if want_aider and not has_aider:
+            rprint(fmt.warning("Aider requested but not detected (~/.aider.conf.yml not found)"))
 
     # Initialize
     manager.initialize()
@@ -528,45 +574,54 @@ def init(
             if error:
                 rprint(fmt.warning(f"  Error: {error}"))
 
-    # Install Claude Code hooks if opted in
+    def _local_unsupported(label: str) -> None:
+        rprint(fmt.warning(
+            f"{label} is not supported in --local mode yet. Skipping. "
+            "Re-run without --local to install for this platform user-globally."
+        ))
+
+    # Install Claude Code skills + hooks if opted in
+    # When --with-claude-code is explicitly passed (or --local), install even if <root>/.claude doesn't exist yet
     claude_code_ok = False
-    if has_claude_code and want_claude_code:
+    if (has_claude_code or with_claude_code or (local and want_claude_code)) and want_claude_code:
         try:
-            _install_claude_code_hooks()
-            manager.set("agent.environments.claude_code.enabled", True)
+            _install_claude_code_skills(root)
+            _install_claude_code_hooks(root)
+            if scope == "user":
+                manager.set("agent.environments.claude_code.enabled", True)
             claude_code_ok = True
         except Exception as e:
-            rprint(fmt.error(f"Failed to install Claude Code hooks: {e}"))
+            rprint(fmt.error(f"Failed to install Claude Code integration: {e}"))
 
-    # Install Codex CLI skills if opted in
+    # Install Codex CLI skills + hooks if opted in
     codex_ok = False
-    if has_codex and want_codex:
+    if (has_codex or (local and want_codex)) and want_codex:
         try:
-            ok, error = _install_codex_skills()
+            ok, error = _install_codex_skills(root)
             codex_ok = ok
-            if ok:
+            if ok and scope == "user":
                 manager.set("agent.environments.codex.enabled", True)
-            else:
+            elif not ok:
                 rprint(fmt.error(f"Failed to install Codex CLI skills: {error}"))
         except Exception as e:
             rprint(fmt.error(f"Failed to install Codex CLI integration: {e}"))
 
     # Install Gemini CLI MCP if opted in
     gemini_ok = False
-    if has_gemini and want_gemini:
+    if (has_gemini or (local and want_gemini)) and want_gemini:
         try:
-            gemini_ok = _install_gemini_mcp()
-            if gemini_ok:
+            gemini_ok = _install_gemini_mcp(root)
+            if gemini_ok and scope == "user":
                 manager.set("agent.environments.gemini.enabled", True)
         except Exception as e:
             rprint(fmt.error(f"Failed to install Gemini CLI integration: {e}"))
 
     # Install Cursor MCP if opted in
     cursor_ok = False
-    if has_cursor and want_cursor:
+    if (has_cursor or (local and want_cursor)) and want_cursor:
         try:
-            cursor_ok = _install_cursor_mcp()
-            if cursor_ok:
+            cursor_ok = _install_cursor_mcp(root)
+            if cursor_ok and scope == "user":
                 manager.set("agent.environments.cursor.enabled", True)
         except Exception as e:
             rprint(fmt.error(f"Failed to install Cursor integration: {e}"))
@@ -575,31 +630,44 @@ def init(
     windsurf_ok = False
     if has_windsurf and want_windsurf:
         try:
-            windsurf_ok = _install_windsurf_mcp()
+            windsurf_ok = _install_windsurf_mcp(root)
             if windsurf_ok:
                 manager.set("agent.environments.windsurf.enabled", True)
         except Exception as e:
             rprint(fmt.error(f"Failed to install Windsurf integration: {e}"))
+    elif local and want_windsurf:
+        _local_unsupported("Windsurf")
 
     # Install Continue.dev MCP if opted in
     continue_ok = False
     if has_continue_dev and want_continue:
         try:
-            continue_ok = _install_continue_dev_mcp()
+            continue_ok = _install_continue_dev_mcp(root)
             if continue_ok:
                 manager.set("agent.environments.continue_dev.enabled", True)
         except Exception as e:
             rprint(fmt.error(f"Failed to install Continue.dev integration: {e}"))
+    elif local and want_continue:
+        _local_unsupported("Continue.dev")
 
     # Install Aider MCP if opted in
     aider_ok = False
     if has_aider and want_aider:
         try:
-            aider_ok = _install_aider_mcp()
+            aider_ok = _install_aider_mcp(root)
             if aider_ok:
                 manager.set("agent.environments.aider.enabled", True)
         except Exception as e:
             rprint(fmt.error(f"Failed to install Aider integration: {e}"))
+    elif local and want_aider:
+        _local_unsupported("Aider")
+
+    # Install global instruction files for platforms that support them
+    _install_global_instructions(
+        claude_code=claude_code_ok,
+        cursor=cursor_ok,
+        root=root,
+    )
 
     rprint()
     rprint(fmt.success("Agent security initialized!"))
@@ -625,6 +693,12 @@ def init(
             rprint("  - Restart Continue.dev to load MCP server")
         if aider_ok:
             rprint("  - Restart Aider to load MCP server")
+    elif scope == "project":
+        rprint("No integrations were installed. In --local mode, pass one or more opt-in flags:")
+        rprint("  rafter agent init --local --with-claude-code")
+        rprint("  rafter agent init --local --with-codex")
+        rprint("  rafter agent init --local --with-gemini")
+        rprint("  rafter agent init --local --with-cursor")
     elif detected:
         rprint("No integrations were installed. To install, re-run with opt-in flags:")
         rprint("  rafter agent init --all                  # Install all detected")
@@ -2133,6 +2207,7 @@ def baseline_add(
 # ── components: list / enable / disable ──────────────────────────────
 
 from .agent_components import (  # noqa: E402
+    _inject_instruction_file,
     get_registry as _components_get_registry,
     record_component_state as _components_record_state,
     resolve_component as _components_resolve,

--- a/python/tests/test_agent_init.py
+++ b/python/tests/test_agent_init.py
@@ -17,7 +17,7 @@ from rafter_cli.commands.agent import (
 class TestInstallClaudeCodeHooks:
     def test_creates_settings_from_scratch(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        _install_claude_code_hooks()
+        _install_claude_code_hooks(tmp_path)
 
         settings_path = tmp_path / ".claude" / "settings.json"
         assert settings_path.exists()
@@ -45,7 +45,7 @@ class TestInstallClaudeCodeHooks:
         }
         (claude_dir / "settings.json").write_text(json.dumps(existing))
 
-        _install_claude_code_hooks()
+        _install_claude_code_hooks(tmp_path)
 
         settings = json.loads((claude_dir / "settings.json").read_text())
         # Should have 3 entries: existing other-tool + 2 Rafter hooks
@@ -67,7 +67,7 @@ class TestInstallClaudeCodeHooks:
         }
         (claude_dir / "settings.json").write_text(json.dumps(existing))
 
-        _install_claude_code_hooks()
+        _install_claude_code_hooks(tmp_path)
 
         settings = json.loads((claude_dir / "settings.json").read_text())
         # Old ones removed, 2 new ones added = exactly 2
@@ -81,7 +81,7 @@ class TestInstallClaudeCodeHooks:
         existing = {"theme": "dark", "hooks": {}}
         (claude_dir / "settings.json").write_text(json.dumps(existing))
 
-        _install_claude_code_hooks()
+        _install_claude_code_hooks(tmp_path)
 
         settings = json.loads((claude_dir / "settings.json").read_text())
         assert settings["theme"] == "dark"
@@ -91,7 +91,7 @@ class TestInstallClaudeCodeHooks:
 class TestInstallGeminiMcp:
     def test_creates_settings_from_scratch(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        assert _install_gemini_mcp()
+        assert _install_gemini_mcp(tmp_path)
 
         settings_path = tmp_path / ".gemini" / "settings.json"
         assert settings_path.exists()
@@ -105,7 +105,7 @@ class TestInstallGeminiMcp:
         gemini_dir.mkdir()
         (gemini_dir / "settings.json").write_text(json.dumps({"model": "gemini-pro"}))
 
-        _install_gemini_mcp()
+        _install_gemini_mcp(tmp_path)
 
         settings = json.loads((gemini_dir / "settings.json").read_text())
         assert settings["model"] == "gemini-pro"
@@ -115,7 +115,7 @@ class TestInstallGeminiMcp:
 class TestInstallCursorMcp:
     def test_creates_config_from_scratch(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        assert _install_cursor_mcp()
+        assert _install_cursor_mcp(tmp_path)
 
         mcp_path = tmp_path / ".cursor" / "mcp.json"
         assert mcp_path.exists()
@@ -128,7 +128,7 @@ class TestInstallCursorMcp:
         cursor_dir.mkdir()
         (cursor_dir / "mcp.json").write_text(json.dumps({"mcpServers": {"other": {"command": "other"}}}))
 
-        _install_cursor_mcp()
+        _install_cursor_mcp(tmp_path)
 
         config = json.loads((cursor_dir / "mcp.json").read_text())
         assert "other" in config["mcpServers"]
@@ -138,7 +138,7 @@ class TestInstallCursorMcp:
 class TestInstallWindsurfMcp:
     def test_creates_config_from_scratch(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        assert _install_windsurf_mcp()
+        assert _install_windsurf_mcp(tmp_path)
 
         mcp_path = tmp_path / ".codeium" / "windsurf" / "mcp_config.json"
         assert mcp_path.exists()
@@ -149,7 +149,7 @@ class TestInstallWindsurfMcp:
 class TestInstallContinueDevMcp:
     def test_creates_config_with_array_format(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        assert _install_continue_dev_mcp()
+        assert _install_continue_dev_mcp(tmp_path)
 
         config_path = tmp_path / ".continue" / "config.json"
         assert config_path.exists()
@@ -164,7 +164,7 @@ class TestInstallContinueDevMcp:
         existing = {"mcpServers": [{"name": "rafter", "command": "old"}]}
         (continue_dir / "config.json").write_text(json.dumps(existing))
 
-        _install_continue_dev_mcp()
+        _install_continue_dev_mcp(tmp_path)
 
         config = json.loads((continue_dir / "config.json").read_text())
         rafter_entries = [s for s in config["mcpServers"] if s["name"] == "rafter"]
@@ -178,7 +178,7 @@ class TestInstallContinueDevMcp:
         existing = {"mcpServers": {"other": {"command": "other"}}}
         (continue_dir / "config.json").write_text(json.dumps(existing))
 
-        _install_continue_dev_mcp()
+        _install_continue_dev_mcp(tmp_path)
 
         config = json.loads((continue_dir / "config.json").read_text())
         assert config["mcpServers"]["rafter"]["command"] == "rafter"
@@ -188,7 +188,7 @@ class TestInstallContinueDevMcp:
 class TestInstallAiderMcp:
     def test_creates_config_from_scratch(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        assert _install_aider_mcp()
+        assert _install_aider_mcp(tmp_path)
 
         config_path = tmp_path / ".aider.conf.yml"
         assert config_path.exists()
@@ -200,7 +200,7 @@ class TestInstallAiderMcp:
         config_path = tmp_path / ".aider.conf.yml"
         config_path.write_text("mcp-server-command: rafter mcp serve\n")
 
-        assert _install_aider_mcp()
+        assert _install_aider_mcp(tmp_path)
 
         content = config_path.read_text()
         assert content.count("rafter mcp serve") == 1
@@ -210,7 +210,7 @@ class TestInstallAiderMcp:
         config_path = tmp_path / ".aider.conf.yml"
         config_path.write_text("model: gpt-4\n")
 
-        _install_aider_mcp()
+        _install_aider_mcp(tmp_path)
 
         content = config_path.read_text()
         assert "model: gpt-4" in content
@@ -306,7 +306,7 @@ from rafter_cli.commands.agent import _install_codex_skills
 class TestInstallCodexSkills:
     def test_creates_skills_from_scratch(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        ok, error = _install_codex_skills()
+        ok, error = _install_codex_skills(tmp_path)
         assert ok, f"Expected success, got error: {error}"
         assert error == ""
 
@@ -328,7 +328,7 @@ class TestInstallCodexSkills:
         backend_dir.mkdir(parents=True)
         (backend_dir / "SKILL.md").write_text("old content")
 
-        ok, error = _install_codex_skills()
+        ok, error = _install_codex_skills(tmp_path)
         assert ok
 
         content = (backend_dir / "SKILL.md").read_text()

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -157,6 +157,7 @@ Initialize local security system. Creates config and detects available developme
 - `--all` — install all detected integrations and download Gitleaks
 - `-i, --interactive` — guided setup — prompts for each detected integration (Node only)
 - `--update` — re-download gitleaks and reinstall integrations without resetting config
+- `--local` — install integration configs into the current working directory instead of the user home. Writes to `./.claude/`, `./.agents/`, `./.gemini/`, `./.cursor/` etc. Supports `--with-claude-code`, `--with-codex`, `--with-gemini`, `--with-cursor`. User-level side effects (global config, `agent.environments.*.enabled`, auto-detection, gitleaks download) are suppressed in this mode. Intended for benchmark harnesses, one-off project setup, and ephemeral containers.
 
 ### rafter agent list [OPTIONS]
 


### PR DESCRIPTION
## Summary

- **rf-n9l**: `rafter agent init --local` installs integration configs into CWD instead of the user home. Supports `--with-claude-code`, `--with-codex`, `--with-gemini`, `--with-cursor`. User-scope side effects (auto-detection, `agent.environments.*.enabled`, gitleaks download) are suppressed in `--local` mode. Unblocks benchmark harnesses, CI runners, and ephemeral containers that need per-repo opt-in without mutating user-global config.
- **rf-6m3**: replace hardcoded 2-skill install with table-driven `AGENT_SKILLS` so v0.7.1 actually ships `rafter-secure-design` + `rafter-code-review` via `agent init`. Python had deeper drift — no Claude Code skills installer and no global instructions installer existed. Both added.
- Refactored all hook/MCP installers to take an explicit `root` parameter instead of calling `os.homedir()` / `Path.home()` directly, so `--local` can reuse them.
- `shared-docs/CLI_SPEC.md` documents the new flag.

## Test plan

- [x] `pnpm run build` passes in `node/`
- [x] Full Node test suite passes (2 known pre-existing flakes under parallel load, both pass in isolation)
- [x] Full Python test suite passes — 1140 passed; 18 pre-existing failures are env-specific (test subprocesses override `HOME`, which strips `~/.local` from `sys.path` and breaks `import typer`; unrelated to this PR)
- [x] Manual end-to-end: `rafter agent init --local --with-claude-code` installs 4 skills + hooks + CLAUDE.md under `/tmp/rafter-local-test/.claude/` for both Node and Python
- [ ] Follow-up: v0.7.1 publish (rf-ktp) before this gets used by the benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)