### PR TITLE
fix(tests): fix CI race in node test-node (rf-9bd)

### DIFF
--- a/node/tests/agent-commands.test.ts
+++ b/node/tests/agent-commands.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from "vitest";
-import { execSync } from "child_process";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -20,12 +20,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch { /* dist may already exist */ }
-}, 60000);
 
 function createTempHome(): string {
   const dir = path.join(

--- a/node/tests/agent-components.test.ts
+++ b/node/tests/agent-components.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { execSync, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
 import { randomBytes } from "crypto";
 
@@ -18,14 +18,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch {
-    /* dist may already exist */
-  }
-}, 60000);
 
 function makeHome(): string {
   const dir = path.join(os.tmpdir(), `rafter-comp-${Date.now()}-${randomBytes(4).toString("hex")}`);

--- a/node/tests/audit-skill.test.ts
+++ b/node/tests/audit-skill.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
-import { execSync, spawnSync } from "child_process";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -9,12 +9,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch { /* dist may already exist */ }
-}, 60000);
 
 let tmpDir: string;
 

--- a/node/tests/codex-integration.test.ts
+++ b/node/tests/codex-integration.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { randomBytes } from "crypto";
-import { execSync, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -13,12 +13,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch { /* dist may already exist */ }
-}, 60000);
 
 function createTempDir(prefix: string): string {
   const tmpDir = path.join(

--- a/node/tests/cross-runtime-parity.test.ts
+++ b/node/tests/cross-runtime-parity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execSync, execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -89,19 +89,6 @@ function runBoth(args: string[], opts?: { cwd?: string; env?: Record<string, str
     python: runPython(args, opts),
   };
 }
-
-// Build Node CLI before running tests
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", {
-      cwd: path.resolve(__dirname, ".."),
-      stdio: "ignore",
-      timeout: 30000,
-    });
-  } catch {
-    // Build may already be done
-  }
-}, 60000);
 
 // Skip all parity tests when Python + rafter_cli deps aren't available
 const describeIfPython = PYTHON_AVAILABLE ? describe : describe.skip;

--- a/node/tests/e2e-cli.test.ts
+++ b/node/tests/e2e-cli.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
-import { execSync, execFileSync, spawnSync } from "child_process";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync, spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -34,15 +34,6 @@ function rafter(args: string | string[], opts?: { cwd?: string; env?: Record<str
     exitCode: result.status ?? 1,
   };
 }
-
-// Build before running e2e tests — use beforeAll at file level
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: path.resolve(__dirname, ".."), stdio: "ignore", timeout: 30000 });
-  } catch {
-    // Build may have already been done or dist may exist
-  }
-}, 60000);
 
 describe("CLI e2e — version and help", () => {
 

--- a/node/tests/formatter-commands.test.ts
+++ b/node/tests/formatter-commands.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
-import { execSync, execFileSync } from "child_process";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -40,18 +40,6 @@ function rafter(
     };
   }
 }
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", {
-      cwd: path.resolve(__dirname, ".."),
-      stdio: "ignore",
-      timeout: 30000,
-    });
-  } catch {
-    // dist may already exist
-  }
-}, 60000);
 
 // ── scan local: agent vs human mode ──────────────────────────────────
 

--- a/node/tests/global-setup.ts
+++ b/node/tests/global-setup.ts
@@ -1,0 +1,14 @@
+import { execSync } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+
+export default function globalSetup() {
+  execSync("pnpm run build", {
+    cwd: PROJECT_ROOT,
+    stdio: "ignore",
+    timeout: 120_000,
+  });
+}

--- a/node/tests/openclaw-integration.test.ts
+++ b/node/tests/openclaw-integration.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { randomBytes } from "crypto";
-import { execSync, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -13,12 +13,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch { /* dist may already exist */ }
-}, 60000);
 
 function createTempDir(prefix: string): string {
   const tmpDir = path.join(

--- a/node/tests/platform-integration.test.ts
+++ b/node/tests/platform-integration.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { randomBytes } from "crypto";
-import { execSync, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -13,12 +13,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch { /* dist may already exist */ }
-}, 60000);
 
 // Test helper to create temporary directories
 function createTempDir(prefix: string): string {

--- a/node/tests/report.test.ts
+++ b/node/tests/report.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
-import { execFileSync, execSync } from "child_process";
+import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -28,18 +28,6 @@ function rafter(
     };
   }
 }
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", {
-      cwd: path.resolve(__dirname, ".."),
-      stdio: "ignore",
-      timeout: 30000,
-    });
-  } catch {
-    // Build may have already been done
-  }
-}, 60000);
 
 const sampleResults = JSON.stringify([
   {

--- a/node/tests/scan-sarif.test.ts
+++ b/node/tests/scan-sarif.test.ts
@@ -1,17 +1,11 @@
-import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
-import { execSync, spawnSync } from "child_process";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
 import path from "path";
 import fs from "fs";
 import os from "os";
 
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_PATH = path.resolve(PROJECT_ROOT, "dist/index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch { /* dist may already exist */ }
-}, 60000);
 
 /**
  * Helper to run the CLI scan command and return parsed output.

--- a/node/tests/secret-scanning-e2e.test.ts
+++ b/node/tests/secret-scanning-e2e.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execSync, execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -41,18 +41,6 @@ function rafter(
     };
   }
 }
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", {
-      cwd: path.resolve(__dirname, ".."),
-      stdio: "ignore",
-      timeout: 30000,
-    });
-  } catch {
-    // Build may already be done
-  }
-}, 60000);
 
 // ── Realistic project structure scanning ────────────────────────────
 

--- a/node/tests/skill-review-installed.test.ts
+++ b/node/tests/skill-review-installed.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
-import { execSync, spawnSync } from "child_process";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -16,14 +16,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch {
-    /* dist may already exist */
-  }
-}, 60000);
 
 let tmpDir: string;
 

--- a/node/tests/skill-review.test.ts
+++ b/node/tests/skill-review.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
-import { execSync, spawnSync } from "child_process";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -9,12 +9,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch { /* dist may already exist */ }
-}, 60000);
 
 let tmpDir: string;
 

--- a/node/tests/skill.test.ts
+++ b/node/tests/skill.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { execSync, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
 import { randomBytes } from "crypto";
 
@@ -17,14 +17,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
-
-beforeAll(() => {
-  try {
-    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "ignore", timeout: 30000 });
-  } catch {
-    /* dist may already exist */
-  }
-}, 60000);
 
 function makeHome(): string {
   const dir = path.join(os.tmpdir(), `rafter-skill-${Date.now()}-${randomBytes(4).toString("hex")}`);

--- a/node/vitest.config.ts
+++ b/node/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     testTimeout: 30_000,
     hookTimeout: 15_000,
     fileParallelism: true,
+    globalSetup: "./tests/global-setup.ts",
   },
 });


### PR DESCRIPTION
## Summary

- CI's `test-node` job flaked on v0.7.1 with a `SyntaxError: './policy-loader.js' does not provide an export named 'loadPolicy'` when tests spawned the built CLI. Root cause: 15 test files each ran `execSync('pnpm run build')` in `beforeAll`, and `vitest.config.ts` has `fileParallelism: true`. Concurrent `tsc` writes to `dist/*.js` intermittently left `policy-loader.js` half-written when another test imported it through `dist/index.js`.
- Moves the build to a single `vitest` `globalSetup` hook and drops every per-file `beforeAll` build. Also prunes now-unused `beforeAll`/`execSync` imports where they were only used for that call.
- Runtime impact is positive: 15 `tsc` invocations → 1.

## Why a PR against `main`

rf-9bd reproduces intermittently on `main` at v0.7.1 — the v0.7.1 promote PR (#47) is still waiting on review. Landing here first so the next promote-to-prod ships a green test-node job.

## Test plan

- [x] `rm -rf node/dist && pnpm test` runs globalSetup once and reaches the full suite.
- [x] `pnpm exec vitest run tests/platform-integration.test.ts` — 57/57 pass (was the failing test in the CI flake).
- [x] 27 unrelated failures in `tests/agent-compatibility.test.ts` are pre-existing (`expected 'deny' got 'allow'` — command-interceptor behavior bug, not a build race) — out of scope for this PR, see rf-luk / follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)