### PR TITLE
chore(release): bump to v0.7.2 (rf-2cs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-04-17
+
+### Changed
+- **Version bump only.** 0.7.1 published to npm successfully but PyPI upload failed (400 Bad Request). Re-publishing under 0.7.2 to keep Node + Python in parity — no code changes vs 0.7.1.
+
 ## [0.7.1] - 2026-04-17
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.7.1"
+version = "0.7.2"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- v0.7.1 npm publish succeeded, but PyPI upload returned 400 Bad Request (PyPI disallows re-uploading the same version number)
- Bumping to 0.7.2 to restore Node + Python parity
- No code changes vs 0.7.1 — version bump in \`node/package.json\` + \`python/pyproject.toml\` + CHANGELOG entry only

## Test plan
- [ ] CI green (test-node, test-python, validate-release)
- [ ] After merge to \`main\`, open main → prod PR to trigger publish workflow
- [ ] Verify npm shows \`@rafter-security/cli@0.7.2\` and PyPI shows \`rafter-cli==0.7.2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)