### PR TITLE
chore(release): bump to v0.7.4 (rf-yit) — gemini skills registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-04-21
+
+### Added
+- **`rafter agent init --with-gemini` now installs and registers skills** (Node + Python, rf-yit): Gemini adapter previously only wrote MCP config and GEMINI.md — gemini never saw rafter's SKILL.md files. Now mirrors the Codex installer: copies `rafter`, `rafter-secure-design`, and `rafter-code-review` SKILL.md files into `<root>/.agents/skills/` (shared with Codex), then calls `gemini skills link <abs-path>` for each so gemini registers them in its native skill system. Missing `gemini` binary, missing `skills` subcommand (needs gemini ≥ 0.35), or per-skill registration failures are warnings, not errors — on-disk install still succeeds.
+
 ## [0.7.3] - 2026-04-20
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -561,6 +561,58 @@ function installCodexSkills(root: string): void {
   installSkillsTo(path.join(root, ".agents", "skills"));
 }
 
+function installGeminiSkills(root: string): void {
+  installSkillsTo(path.join(root, ".agents", "skills"));
+}
+
+/**
+ * Register installed skills with Gemini CLI via `gemini skills link <abs-path>`.
+ *
+ * Requires gemini CLI >= 0.35 (the version that added `gemini skills`).
+ * Missing CLI, missing subcommand, and per-skill registration failures are
+ * non-fatal: we warn and continue so the on-disk install still succeeds.
+ */
+function registerGeminiSkills(skillsDir: string): void {
+  // Probe for the `gemini` binary. Absence is expected on CI / fresh machines.
+  try {
+    execSync("gemini --version", { stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
+  } catch {
+    console.log(fmt.warning(
+      "gemini CLI not found on PATH — skipping skill registration. " +
+      "Skills are installed to disk; re-run after installing gemini ≥ 0.35.",
+    ));
+    return;
+  }
+
+  // Probe `gemini skills` subcommand (added in 0.35).
+  try {
+    execSync("gemini skills --help", { stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
+  } catch {
+    console.log(fmt.warning(
+      "gemini CLI does not support `skills` subcommand (needs ≥ 0.35). " +
+      "Skipping registration — skills are still installed to disk.",
+    ));
+    return;
+  }
+
+  for (const skill of AGENT_SKILLS) {
+    const absPath = path.resolve(skillsDir, skill.name);
+    if (!fs.existsSync(absPath)) continue;
+    try {
+      execSync(`gemini skills link ${JSON.stringify(absPath)}`, {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 10000,
+      });
+      console.log(fmt.success(`Registered ${skill.name} with Gemini CLI`));
+    } catch (e: any) {
+      const msg = (e?.stderr?.toString?.() || e?.message || "").trim();
+      console.log(fmt.warning(
+        `Failed to register ${skill.name} with Gemini CLI: ${msg.split("\n")[0] || "unknown error"}`,
+      ));
+    }
+  }
+}
+
 async function askYesNo(question: string, defaultYes = true): Promise<boolean> {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
   const suffix = defaultYes ? "[Y/n]" : "[y/N]";
@@ -822,11 +874,13 @@ export function createInitCommand(): Command {
         }
       }
 
-      // Install Gemini CLI MCP + hooks if opted in
+      // Install Gemini CLI MCP + skills + hooks if opted in
       let geminiOk = false;
       if ((hasGemini || (opts.local && wantGemini)) && wantGemini) {
         try {
           geminiOk = installGeminiMcp(root);
+          installGeminiSkills(root);
+          registerGeminiSkills(path.join(root, ".agents", "skills"));
           installGeminiHooks(root);
           if (geminiOk && scope === "user") manager.set("agent.environments.gemini.enabled", true);
         } catch (e) {

--- a/node/tests/platform-integration.test.ts
+++ b/node/tests/platform-integration.test.ts
@@ -228,6 +228,65 @@ describe("Platform Integration — MCP Installs via CLI", () => {
     });
   });
 
+  // ── 2b-iii. Gemini skill install + registration ──────────────────
+
+  describe("Gemini skills install (--with-gemini)", () => {
+    it("installs rafter skills to <home>/.agents/skills/ (mirrors codex)", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".gemini"), { recursive: true });
+
+      const result = runCli("agent init --with-gemini", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      // All three AGENT_SKILLS must land on disk regardless of whether the
+      // gemini CLI is available for registration.
+      for (const name of ["rafter", "rafter-secure-design", "rafter-code-review"]) {
+        const skillPath = path.join(testHomeDir, ".agents", "skills", name, "SKILL.md");
+        expect(fs.existsSync(skillPath), `${name} SKILL.md should be installed`).toBe(true);
+      }
+    });
+
+    it("warns but succeeds when gemini CLI is not on PATH", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".gemini"), { recursive: true });
+
+      // Build a scrubbed PATH containing only a symlink to the node binary,
+      // so that `gemini` cannot be resolved even on dev machines where it's
+      // installed alongside node in the same nvm bin dir.
+      const isolatedBin = path.join(testHomeDir, "_bin");
+      fs.mkdirSync(isolatedBin, { recursive: true });
+      fs.symlinkSync(process.execPath, path.join(isolatedBin, "node"));
+
+      const result = spawnSync(process.execPath, [CLI_ENTRY, "agent", "init", "--with-gemini"], {
+        cwd: PROJECT_ROOT,
+        encoding: "utf-8",
+        timeout: 15_000,
+        env: {
+          HOME: testHomeDir,
+          XDG_CONFIG_HOME: path.join(testHomeDir, ".config"),
+          PATH: isolatedBin,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      expect(result.status ?? 1, `stderr: ${result.stderr}`).toBe(0);
+      // Skills still written to disk
+      const skillPath = path.join(testHomeDir, ".agents", "skills", "rafter", "SKILL.md");
+      expect(fs.existsSync(skillPath)).toBe(true);
+      // Warning surfaces
+      expect(result.stdout).toMatch(/gemini CLI not found on PATH/i);
+    });
+
+    it("shares skill dir with codex when both flags are passed", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".gemini"), { recursive: true });
+      fs.mkdirSync(path.join(testHomeDir, ".codex"), { recursive: true });
+
+      const result = runCli("agent init --with-gemini --with-codex", testHomeDir);
+      expect(result.exitCode).toBe(0);
+
+      const skillPath = path.join(testHomeDir, ".agents", "skills", "rafter", "SKILL.md");
+      expect(fs.existsSync(skillPath)).toBe(true);
+    });
+  });
+
   // ── 2c. Gemini environment detection ────────────────────────────
 
   describe("Gemini environment detection", () => {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.7.3"
+version = "0.7.4"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -304,6 +304,72 @@ def _install_codex_skills(root: Path) -> tuple[bool, str]:
         return False, str(e)
 
 
+def _install_gemini_skills(root: Path) -> tuple[bool, str]:
+    """Install all Rafter skills to <root>/.agents/skills/ for Gemini CLI.
+
+    Gemini shares the same skills dir as Codex — overwrite is harmless.
+    """
+    try:
+        _install_skills_to(root / ".agents" / "skills")
+        return True, ""
+    except Exception as e:
+        return False, str(e)
+
+
+def _register_gemini_skills(skills_dir: Path) -> None:
+    """Register installed skills with Gemini CLI via `gemini skills link <abs>`.
+
+    Requires gemini CLI >= 0.35. Missing CLI / subcommand / per-skill failures
+    are non-fatal: warn and continue so the on-disk install still succeeds.
+    """
+    gemini = shutil.which("gemini")
+    if not gemini:
+        rprint(fmt.warning(
+            "gemini CLI not found on PATH — skipping skill registration. "
+            "Skills are installed to disk; re-run after installing gemini ≥ 0.35."
+        ))
+        return
+
+    # Probe `gemini skills` subcommand (added in 0.35).
+    try:
+        subprocess.run(
+            [gemini, "skills", "--help"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        rprint(fmt.warning(
+            "gemini CLI does not support `skills` subcommand (needs ≥ 0.35). "
+            "Skipping registration — skills are still installed to disk."
+        ))
+        return
+
+    for skill in _AGENT_SKILLS:
+        abs_path = (skills_dir / skill["name"]).resolve()
+        if not abs_path.exists():
+            continue
+        try:
+            subprocess.run(
+                [gemini, "skills", "link", str(abs_path)],
+                check=True,
+                capture_output=True,
+                timeout=10,
+            )
+            rprint(fmt.success(f"Registered {skill['name']} with Gemini CLI"))
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
+            first_line = ""
+            stderr = getattr(e, "stderr", None)
+            if stderr:
+                try:
+                    first_line = stderr.decode("utf-8", errors="replace").strip().split("\n", 1)[0]
+                except Exception:
+                    first_line = ""
+            rprint(fmt.warning(
+                f"Failed to register {skill['name']} with Gemini CLI: {first_line or 'unknown error'}"
+            ))
+
+
 # ── MCP server entry (shared across MCP-native clients) ──────────────
 
 _RAFTER_MCP_ENTRY = {
@@ -630,11 +696,16 @@ def init(
         except Exception as e:
             rprint(fmt.error(f"Failed to install Codex CLI integration: {e}"))
 
-    # Install Gemini CLI MCP if opted in
+    # Install Gemini CLI MCP + skills if opted in
     gemini_ok = False
     if (has_gemini or (local and want_gemini)) and want_gemini:
         try:
             gemini_ok = _install_gemini_mcp(root)
+            skills_ok, skills_error = _install_gemini_skills(root)
+            if not skills_ok:
+                rprint(fmt.error(f"Failed to install Gemini CLI skills: {skills_error}"))
+            else:
+                _register_gemini_skills(root / ".agents" / "skills")
             if gemini_ok and scope == "user":
                 manager.set("agent.environments.gemini.enabled", True)
         except Exception as e:

--- a/python/tests/test_agent_init.py
+++ b/python/tests/test_agent_init.py
@@ -331,6 +331,85 @@ class TestInstallCodexSkills:
         assert content != "old content", "Skill should be updated on reinstall"
 
 
+# ── Gemini skill installation tests ──────────────────────────────────
+
+from rafter_cli.commands.agent import _install_gemini_skills, _register_gemini_skills
+
+
+class TestInstallGeminiSkills:
+    def test_creates_skills_from_scratch(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        ok, error = _install_gemini_skills(tmp_path)
+        assert ok, f"Expected success, got error: {error}"
+        assert error == ""
+
+        # Mirrors _AGENT_SKILLS — same list as codex.
+        for name in ("rafter", "rafter-secure-design", "rafter-code-review"):
+            skill_path = tmp_path / ".agents" / "skills" / name / "SKILL.md"
+            assert skill_path.exists(), f"{name} SKILL.md should be installed"
+            assert skill_path.read_text().strip(), f"{name} SKILL.md should not be empty"
+
+    def test_shares_dir_with_codex(self, tmp_path, monkeypatch):
+        """Gemini + Codex both write to <root>/.agents/skills/ — reinstall is idempotent."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from rafter_cli.commands.agent import _install_codex_skills
+
+        _install_codex_skills(tmp_path)
+        first = (tmp_path / ".agents" / "skills" / "rafter" / "SKILL.md").read_text()
+        _install_gemini_skills(tmp_path)
+        second = (tmp_path / ".agents" / "skills" / "rafter" / "SKILL.md").read_text()
+        assert first == second
+
+
+class TestRegisterGeminiSkills:
+    def test_skips_when_gemini_not_on_path(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr("rafter_cli.commands.agent.shutil.which", lambda name: None)
+        # Should not raise, should just warn
+        _register_gemini_skills(tmp_path / ".agents" / "skills")
+
+    def test_calls_gemini_skills_link_for_each_skill(self, tmp_path, monkeypatch):
+        # Install skill dirs
+        skills_dir = tmp_path / ".agents" / "skills"
+        for name in ("rafter", "rafter-secure-design", "rafter-code-review"):
+            (skills_dir / name).mkdir(parents=True)
+            (skills_dir / name / "SKILL.md").write_text("---\nname: x\n---\n")
+
+        monkeypatch.setattr("rafter_cli.commands.agent.shutil.which", lambda name: "/fake/gemini")
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, check=True, capture_output=True, timeout=None, **kw):
+            calls.append(list(cmd))
+            import subprocess as _sp
+            return _sp.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr("rafter_cli.commands.agent.subprocess.run", fake_run)
+
+        _register_gemini_skills(skills_dir)
+
+        # First call: `gemini skills --help` probe
+        assert calls[0][1:] == ["skills", "--help"]
+        # Following calls: one `skills link <abs>` per skill
+        link_calls = [c for c in calls if c[1:3] == ["skills", "link"]]
+        assert len(link_calls) == 3
+        linked_paths = {c[3] for c in link_calls}
+        for name in ("rafter", "rafter-secure-design", "rafter-code-review"):
+            assert str((skills_dir / name).resolve()) in linked_paths
+
+    def test_skips_when_skills_subcommand_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("rafter_cli.commands.agent.shutil.which", lambda name: "/fake/gemini")
+
+        import subprocess as _sp
+
+        def fake_run(cmd, check=True, capture_output=True, timeout=None, **kw):
+            raise _sp.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr("rafter_cli.commands.agent.subprocess.run", fake_run)
+
+        # Should not raise
+        _register_gemini_skills(tmp_path / ".agents" / "skills")
+
+
 # ── OpenClaw skill installation tests ────────────────────────────────
 
 from rafter_cli.commands.agent import _install_openclaw_skill
@@ -521,3 +600,52 @@ class TestGeminiInstructionFile:
         runner.invoke(app, ["agent", "init", "--with-claude-code"])
 
         assert not (tmp_path / ".gemini" / "GEMINI.md").exists()
+
+
+class TestGeminiWithSkillsEndToEnd:
+    """`rafter agent init --with-gemini` must install skills to .agents/skills/
+    AND attempt gemini CLI registration."""
+
+    def test_installs_skills_to_agents_dir(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+        from rafter_cli.__main__ import app
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".gemini").mkdir()
+        # gemini not on PATH — registration is a warning, install still runs
+        monkeypatch.setattr("rafter_cli.commands.agent.shutil.which", lambda name: None if name == "gemini" else "/usr/bin/" + name)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["agent", "init", "--with-gemini"])
+        assert result.exit_code == 0, result.output
+
+        for name in ("rafter", "rafter-secure-design", "rafter-code-review"):
+            skill = tmp_path / ".agents" / "skills" / name / "SKILL.md"
+            assert skill.exists(), f"{name} SKILL.md should be installed via --with-gemini"
+
+    def test_calls_gemini_skills_link_when_gemini_available(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+        from rafter_cli.__main__ import app
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".gemini").mkdir()
+
+        monkeypatch.setattr("rafter_cli.commands.agent.shutil.which", lambda name: "/fake/" + name if name == "gemini" else None)
+
+        link_calls: list[list[str]] = []
+
+        import subprocess as _sp
+
+        def fake_run(cmd, check=True, capture_output=True, timeout=None, **kw):
+            link_calls.append(list(cmd))
+            return _sp.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr("rafter_cli.commands.agent.subprocess.run", fake_run)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["agent", "init", "--with-gemini"])
+        assert result.exit_code == 0, result.output
+
+        # One probe + one link per skill (3 skills)
+        link_only = [c for c in link_calls if c[1:3] == ["skills", "link"]]
+        assert len(link_only) == 3


### PR DESCRIPTION
## Summary

- **rf-yit**: `rafter agent init --with-gemini` now installs rafter SKILL.md files to `<root>/.agents/skills/` (shared with Codex) AND calls `gemini skills link <abs-path>` for each skill so gemini registers them in its native skill system.
- Missing `gemini` binary, missing `skills` subcommand (needs gemini ≥ 0.35), or per-skill registration failures are warnings, not errors — on-disk install still succeeds.
- Version bump Node + Python to **0.7.4**.

## Why

v0.7.3 shipped the easy half: GEMINI.md injection. Empirical probe on baseline-rafter after 0.7.3 produced 41 tool calls but 0 rafter engagement (0 SKILL.md reads, 0 rafter CLI calls, 0 MCP calls). GEMINI.md alone is not enough pressure — gemini needs the skills registered in its native system.

## Test plan

- [x] Node: `platform-integration.test.ts` (64/64) + `codex-integration.test.ts` (16/16) pass, including 3 new Gemini-skills-install tests
- [x] Python: `test_agent_init.py` 39/39 pass, including 5 new `_install_gemini_skills` / `_register_gemini_skills` / end-to-end tests
- [x] `pnpm run build` green
- [x] Manual validation per bead:
  - `rm -rf /tmp/gem-chk && mkdir /tmp/gem-chk && cd /tmp/gem-chk && rafter agent init --local --with-gemini`
  - `GEMINI.md` created, `.agents/skills/rafter/SKILL.md` created
  - `gemini skills list` from /tmp/gem-chk reports the project-local rafter override

🤖 Generated with [Claude Code](https://claude.com/claude-code)