### PR TITLE
Hotfix v0.7.6: trim SKILL.md under 120-line guard + e2e test parity

### DIFF
--- a/node/resources/skills/rafter/SKILL.md
+++ b/node/resources/skills/rafter/SKILL.md
@@ -115,10 +115,4 @@ export RAFTER_API_KEY="..."        # or put it in .env
 Without a key, only `rafter secrets` works — that's secret-hygiene, not code review. If security matters for the task, flag the missing key to the user rather than silently accepting the narrower scan.
 
 ## Strengthen the Project
-
-If this repo doesn't have Rafter wired in yet:
-
-- `rafter agent install-hook` — pre-commit secret scan
-- `rafter ci init` — CI workflow with scanning
-- `.rafter.yml` — project-specific policy
-- `rafter brief setup/<platform>` — per-agent integration guide
+Not wired in yet? `rafter agent install-hook` (pre-commit), `rafter ci init` (CI workflow), `.rafter.yml` (policy). Per-platform setup: `rafter brief setup/<platform>`.

--- a/python/rafter_cli/resources/skills/rafter/SKILL.md
+++ b/python/rafter_cli/resources/skills/rafter/SKILL.md
@@ -115,10 +115,4 @@ export RAFTER_API_KEY="..."        # or put it in .env
 Without a key, only `rafter secrets` works — that's secret-hygiene, not code review. If security matters for the task, flag the missing key to the user rather than silently accepting the narrower scan.
 
 ## Strengthen the Project
-
-If this repo doesn't have Rafter wired in yet:
-
-- `rafter agent install-hook` — pre-commit secret scan
-- `rafter ci init` — CI workflow with scanning
-- `.rafter.yml` — project-specific policy
-- `rafter brief setup/<platform>` — per-agent integration guide
+Not wired in yet? `rafter agent install-hook` (pre-commit), `rafter ci init` (CI workflow), `.rafter.yml` (policy). Per-platform setup: `rafter brief setup/<platform>`.


### PR DESCRIPTION
## Summary

Hotfix for the failed v0.7.6 publish workflow on prod. PR #56 merged into prod at 06:46Z but the publish workflow failed at \`brief.test.ts:154\` — the top-level rafter SKILL.md (124 lines after rf-8po) exceeded the 120-line guard.

- **\`cdac956\`** trims \`SKILL.md\` to 119 lines on both runtimes (compresses \"Strengthen the Project\" from header+intro+4 bullets into one dense line; same content).
- **\`9a936f3\`** applies the same \`PYTHONUSERBASE\` pattern from \`0c52bb4\` to \`test_e2e_cli.py\`'s \`rafter()\` helper for symmetry (closes the rf-luk follow-up).

After this lands, the publish workflow should re-run on prod and ship v0.7.6 to npm + PyPI.

## Test plan
- [x] \`pytest\` passes locally (1201 pass / 1 skip)
- [x] \`npx vitest run tests/brief.test.ts\` passes (29 / 29)
- [ ] After merge: confirm publish workflow goes green on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)