### PR TITLE
Release v0.7.7

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.7.6"
+version = "0.7.7"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps version to v0.7.7. v0.7.6 partial-published (PyPI shipped from PR #56, npm from PR #58, GH Release never tagged) — moving forward with a clean release rather than reconciling.

No code changes from \`cdac956\` (v0.7.6 head) — pure version bump.

## Test plan
- [x] \`pytest\` passing locally as of cdac956
- [x] \`npx vitest run tests/brief.test.ts\` passing locally
- [ ] Publish workflow ships 0.7.7 to npm + PyPI
- [ ] GitHub Release v0.7.7 tag created

🤖 Generated with [Claude Code](https://claude.com/claude-code)