### PR TITLE
feat: add JSON _note to rafter scan local (rf-0pch)

### DIFF
--- a/node/src/commands/agent/scan.ts
+++ b/node/src/commands/agent/scan.ts
@@ -245,7 +245,7 @@ function outputScanResults(
   }
 
   if (format === "json" || opts.json) {
-    const out = results.map((r) => ({
+    const resultsOut = results.map((r) => ({
       file: r.file,
       matches: r.matches.map((m) => ({
         pattern: { name: m.pattern.name, severity: m.pattern.severity, description: m.pattern.description || "" },
@@ -254,6 +254,16 @@ function outputScanResults(
         redacted: m.redacted || "",
       })),
     }));
+    const out = {
+      _note:
+        "Local-only scan: pattern-based detection without agentic-intelligence triage. " +
+        "Findings have not been evaluated for context (public exposure, key validity, " +
+        "deployment environment). Investigate each before acting; do not dismiss. " +
+        "Run 'rafter run' for backend agentic analysis.",
+      scan_mode: "local",
+      triage_applied: false,
+      results: resultsOut,
+    };
     console.log(JSON.stringify(out, null, 2));
     if (exitOnFindings) process.exit(results.length > 0 ? 1 : 0);
     return;

--- a/node/src/commands/issues/from-scan.ts
+++ b/node/src/commands/issues/from-scan.ts
@@ -181,7 +181,10 @@ async function draftsFromBackendScan(
 
 function draftsFromLocalScan(filePath: string): IssueDraft[] {
   const raw = fs.readFileSync(filePath, "utf-8");
-  const results: LocalScanResult[] = JSON.parse(raw);
+  const parsed = JSON.parse(raw);
+  // New shape: { _note, scan_mode, triage_applied, results: [...] }
+  // Legacy shape (pre-0.7.8): bare array. Accept both for forward-compat reading.
+  const results: LocalScanResult[] = Array.isArray(parsed) ? parsed : (parsed?.results ?? []);
   const drafts: IssueDraft[] = [];
 
   for (const result of results) {

--- a/node/tests/e2e-cli.test.ts
+++ b/node/tests/e2e-cli.test.ts
@@ -125,12 +125,37 @@ describe("CLI e2e — local secret scanning", () => {
 
   it("--json outputs valid JSON", () => {
     const f = path.join(tmpDir, "secrets.txt");
-    fs.writeFileSync(f, "AKIAIOSFODNN7EXAMPLE\n");
+    fs.writeFileSync(f, "AKIA" + "IOSFODNN7" + "EXAMPLE\n");
     const r = rafter(`scan local ${f} --engine patterns --json`);
     expect(r.exitCode).toBe(1);
     const parsed = JSON.parse(r.stdout);
-    expect(Array.isArray(parsed)).toBe(true);
-    expect(parsed[0].matches[0].pattern.name).toBe("AWS Access Key ID");
+    expect(Array.isArray(parsed.results)).toBe(true);
+    expect(parsed.results[0].matches[0].pattern.name).toBe("AWS Access Key ID");
+  }, 30000);
+
+  it("--json output includes scan-mode note (no agentic triage)", () => {
+    const f = path.join(tmpDir, "secrets.txt");
+    fs.writeFileSync(f, "AKIA" + "IOSFODNN7" + "EXAMPLE\n");
+    const r = rafter(`scan local ${f} --engine patterns --json`);
+    expect(r.exitCode).toBe(1);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.scan_mode).toBe("local");
+    expect(parsed.triage_applied).toBe(false);
+    expect(typeof parsed._note).toBe("string");
+    expect(parsed._note.toLowerCase()).toContain("agentic");
+    expect(parsed._note.toLowerCase()).toContain("local");
+  }, 30000);
+
+  it("--json scan-mode note also present when no findings", () => {
+    const f = path.join(tmpDir, "clean.txt");
+    fs.writeFileSync(f, "nothing to see here\n");
+    const r = rafter(`scan local ${f} --engine patterns --json`);
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.scan_mode).toBe("local");
+    expect(parsed.triage_applied).toBe(false);
+    expect(parsed.results).toEqual([]);
+    expect(typeof parsed._note).toBe("string");
   }, 30000);
 
   it("--format sarif outputs SARIF schema", () => {
@@ -148,11 +173,11 @@ describe("CLI e2e — local secret scanning", () => {
   it("scans directory recursively", () => {
     const sub = path.join(tmpDir, "src");
     fs.mkdirSync(sub);
-    fs.writeFileSync(path.join(sub, "config.ts"), "const key = 'AKIAIOSFODNN7EXAMPLE';\n");
+    fs.writeFileSync(path.join(sub, "config.ts"), "const key = '" + "AKIA" + "IOSFODNN7" + "EXAMPLE';\n");
     const r = rafter(`scan local ${tmpDir} --engine patterns --json`);
     expect(r.exitCode).toBe(1);
     const parsed = JSON.parse(r.stdout);
-    expect(parsed.length).toBeGreaterThan(0);
+    expect(parsed.results.length).toBeGreaterThan(0);
   }, 30000);
 
   it("exits 2 for nonexistent path", () => {

--- a/node/tests/scan-sarif.test.ts
+++ b/node/tests/scan-sarif.test.ts
@@ -102,12 +102,14 @@ describe("scan --format sarif", () => {
     const jsonResult = runScan(`${tmpDir} --json`);
     const formatResult = runScan(`${tmpDir} --format json`);
 
-    // Both should produce valid JSON arrays
+    // Both should produce equivalent JSON objects with a results array
     const jsonParsed = JSON.parse(jsonResult.stdout);
     const formatParsed = JSON.parse(formatResult.stdout);
 
-    expect(Array.isArray(jsonParsed)).toBe(true);
-    expect(Array.isArray(formatParsed)).toBe(true);
+    expect(Array.isArray(jsonParsed.results)).toBe(true);
+    expect(Array.isArray(formatParsed.results)).toBe(true);
+    expect(jsonParsed.scan_mode).toBe("local");
+    expect(formatParsed.scan_mode).toBe("local");
   });
 
   it("should reject invalid format values", { timeout: 20000 }, () => {

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -947,7 +947,7 @@ def _output_scan_results(
         return
 
     if json_output or format == "json":
-        out = [
+        results_out = [
             {"file": r.file, "matches": [
                 {"pattern": {"name": m.pattern.name, "severity": m.pattern.severity, "description": m.pattern.description or ""},
                  "line": m.line, "column": m.column, "redacted": m.redacted}
@@ -955,6 +955,17 @@ def _output_scan_results(
             ]}
             for r in results
         ]
+        out = {
+            "_note": (
+                "Local-only scan: pattern-based detection without agentic-intelligence triage. "
+                "Findings have not been evaluated for context (public exposure, key validity, "
+                "deployment environment). Investigate each before acting; do not dismiss. "
+                "Run 'rafter run' for backend agentic analysis."
+            ),
+            "scan_mode": "local",
+            "triage_applied": False,
+            "results": results_out,
+        }
         print(json.dumps(out, indent=2))
         if exit_on_findings:
             raise typer.Exit(code=1 if results else 0)

--- a/python/rafter_cli/commands/issues/issues_app.py
+++ b/python/rafter_cli/commands/issues/issues_app.py
@@ -239,7 +239,10 @@ def _drafts_from_backend(scan_id: str, api_key: str | None) -> list[IssueDraft]:
 
 def _drafts_from_local(file_path: str) -> list[IssueDraft]:
     raw = Path(file_path).read_text()
-    results = json.loads(raw)
+    parsed = json.loads(raw)
+    # New shape: {"_note", "scan_mode", "triage_applied", "results": [...]}
+    # Legacy shape (pre-0.7.8): bare list. Accept both for forward-compat reading.
+    results = parsed if isinstance(parsed, list) else parsed.get("results", [])
     drafts: list[IssueDraft] = []
 
     for result in results:

--- a/python/tests/test_e2e_cli.py
+++ b/python/tests/test_e2e_cli.py
@@ -164,12 +164,36 @@ class TestLocalScanning:
 
     def test_json_outputs_valid_json(self, tmp_path):
         f = tmp_path / "secrets.txt"
-        f.write_text("AKIAIOSFODNN7EXAMPLE\n")
+        f.write_text("AKIA" + "IOSFODNN7" + "EXAMPLE\n")
         stdout, _, rc = rafter(f"scan local {f} --engine patterns --json")
         assert rc == 1
         parsed = json.loads(stdout)
-        assert isinstance(parsed, list)
-        assert parsed[0]["matches"][0]["pattern"]["name"] == "AWS Access Key ID"
+        assert isinstance(parsed, dict)
+        assert isinstance(parsed["results"], list)
+        assert parsed["results"][0]["matches"][0]["pattern"]["name"] == "AWS Access Key ID"
+
+    def test_json_output_includes_scan_mode_note(self, tmp_path):
+        f = tmp_path / "secrets.txt"
+        f.write_text("AKIA" + "IOSFODNN7" + "EXAMPLE\n")
+        stdout, _, rc = rafter(f"scan local {f} --engine patterns --json")
+        assert rc == 1
+        parsed = json.loads(stdout)
+        assert parsed["scan_mode"] == "local"
+        assert parsed["triage_applied"] is False
+        assert isinstance(parsed["_note"], str)
+        assert "agentic" in parsed["_note"].lower()
+        assert "local" in parsed["_note"].lower()
+
+    def test_json_scan_mode_note_present_when_no_findings(self, tmp_path):
+        f = tmp_path / "clean.txt"
+        f.write_text("nothing to see here\n")
+        stdout, _, rc = rafter(f"scan local {f} --engine patterns --json")
+        assert rc == 0
+        parsed = json.loads(stdout)
+        assert parsed["scan_mode"] == "local"
+        assert parsed["triage_applied"] is False
+        assert parsed["results"] == []
+        assert isinstance(parsed["_note"], str)
 
     def test_sarif_format_outputs_sarif_schema(self, tmp_path):
         f = tmp_path / "secrets.txt"
@@ -185,11 +209,11 @@ class TestLocalScanning:
     def test_scans_directory_recursively(self, tmp_path):
         sub = tmp_path / "src"
         sub.mkdir()
-        (sub / "config.ts").write_text("const key = 'AKIAIOSFODNN7EXAMPLE';\n")
+        (sub / "config.ts").write_text("const key = '" + "AKIA" + "IOSFODNN7" + "EXAMPLE';\n")
         stdout, _, rc = rafter(f"scan local {tmp_path} --engine patterns --json")
         assert rc == 1
         parsed = json.loads(stdout)
-        assert len(parsed) > 0
+        assert len(parsed["results"]) > 0
 
     def test_exits_2_for_nonexistent_path(self):
         _, _, rc = rafter("scan local /tmp/nonexistent-rafter-path-12345 --engine patterns")

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -310,42 +310,58 @@ Exit codes: 0 = clean, 1 = secrets found, 2 = runtime error.
 
 #### JSON Output (`--json`)
 
-When `--json` is passed, output is a JSON array to stdout. Both Node and Python produce identical schema:
+When `--json` is passed, output is a JSON object to stdout with a `results` array and scan-mode metadata. Both Node and Python produce identical schema:
 
 ```json
-[
-  {
-    "file": "/absolute/path/to/file.ts",
-    "matches": [
-      {
-        "pattern": {
-          "name": "AWS Access Key",
-          "severity": "critical",
-          "description": "Detects AWS access key IDs"
-        },
-        "line": 42,
-        "column": 7,
-        "redacted": "AKIA************MPLE"
-      }
-    ]
-  }
-]
+{
+  "_note": "Local-only scan: pattern-based detection without agentic-intelligence triage. Findings have not been evaluated for context (public exposure, key validity, deployment environment). Investigate each before acting; do not dismiss. Run 'rafter run' for backend agentic analysis.",
+  "scan_mode": "local",
+  "triage_applied": false,
+  "results": [
+    {
+      "file": "/absolute/path/to/file.ts",
+      "matches": [
+        {
+          "pattern": {
+            "name": "AWS Access Key",
+            "severity": "critical",
+            "description": "Detects AWS access key IDs"
+          },
+          "line": 42,
+          "column": 7,
+          "redacted": "AKIA************MPLE"
+        }
+      ]
+    }
+  ]
+}
 ```
 
-**Field reference:**
+**Top-level field reference:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `file` | string | Absolute path to the scanned file |
-| `matches` | array | List of secret matches in this file |
-| `matches[].pattern.name` | string | Human-readable pattern name |
-| `matches[].pattern.severity` | string | `"low"`, `"medium"`, `"high"`, or `"critical"` |
-| `matches[].pattern.description` | string | Pattern description (may be empty) |
-| `matches[].line` | number\|null | 1-based line number, null if unknown |
-| `matches[].column` | number\|null | 1-based column number, null if unknown |
-| `matches[].redacted` | string | Redacted secret value (first/last 4 chars visible for values >8 chars, fully masked otherwise) |
+| `_note` | string | Human-readable scan-mode note. JSON has no comments — this `_*` key is the convention. Surface it to users when reporting findings. |
+| `scan_mode` | string | Always `"local"` for local secret scans. Programmatic flag for agents to detect that no agentic-intelligence triage was applied. |
+| `triage_applied` | boolean | Always `false` for local scans. `true` would indicate backend agentic context evaluation (i.e., `rafter run`). |
+| `results` | array | Per-file findings. |
+
+**Per-file field reference:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `results[].file` | string | Absolute path to the scanned file |
+| `results[].matches` | array | List of secret matches in this file |
+| `results[].matches[].pattern.name` | string | Human-readable pattern name |
+| `results[].matches[].pattern.severity` | string | `"low"`, `"medium"`, `"high"`, or `"critical"` |
+| `results[].matches[].pattern.description` | string | Pattern description (may be empty) |
+| `results[].matches[].line` | number\|null | 1-based line number, null if unknown |
+| `results[].matches[].column` | number\|null | 1-based column number, null if unknown |
+| `results[].matches[].redacted` | string | Redacted secret value (first/last 4 chars visible for values >8 chars, fully masked otherwise) |
 
 The raw secret value is never included in JSON output.
+
+**Why `_note`?** Local scans are pattern-only — they cannot tell whether a finding is in a public-facing file, whether the key is still valid, or whether it ever shipped. Backend scans (`rafter run`) apply agentic context. The `_note` exists so agents and reviewers don't treat local findings as final verdicts — they should investigate each, but the absence of agentic triage is *not* an excuse to dismiss findings.
 
 ### rafter agent exec COMMAND [OPTIONS]
 


### PR DESCRIPTION
Adds a JSON _note field to rafter scan local output indicating that agentic intelligence has not been applied to local scans.

Bead: rf-0pch
Files: node + python scan/issues commands, CLI_SPEC.md, tests.