### PR TITLE
feat: suppress findings via .rafter.yml ignore + emit JSON _suppressed (rf-d8s)

### DIFF
--- a/node/src/commands/agent/scan.ts
+++ b/node/src/commands/agent/scan.ts
@@ -3,6 +3,14 @@ import { RegexScanner, ScanResult } from "../../scanners/regex-scanner.js";
 import { GitleaksScanner } from "../../scanners/gitleaks.js";
 import { ConfigManager } from "../../core/config-manager.js";
 import { AuditLogger } from "../../core/audit-logger.js";
+import {
+  Suppression,
+  SuppressedFinding,
+  applySuppressions,
+  loadSuppressions,
+  policyIgnoreToSuppressions,
+} from "../../core/custom-patterns.js";
+import type { ScanIgnoreRule } from "../../core/config-schema.js";
 import { execSync, execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -98,22 +106,23 @@ export function createScanCommand(): Command {
           "Warning: rafter agent scan is deprecated and will be removed in a future major version. Use rafter secrets instead.\n"
         );
       }
-      // Load policy-merged config for excludePaths/customPatterns
+      // Load policy-merged config for excludePaths/customPatterns/ignore
       const manager = new ConfigManager();
       const cfg = manager.loadWithPolicy();
       const scanCfg = cfg.agent?.scan;
+      const suppressions = collectSuppressions(scanCfg?.ignore);
 
       const baselineEntries = opts.baseline ? loadBaselineEntries() : [];
 
       // Handle --diff flag
       if (opts.diff) {
-        await scanDiffFiles(opts.diff, opts, scanCfg, baselineEntries, path.resolve(scanPath));
+        await scanDiffFiles(opts.diff, opts, scanCfg, baselineEntries, path.resolve(scanPath), suppressions);
         return;
       }
 
       // Handle --staged flag
       if (opts.staged) {
-        await scanStagedFiles(opts, scanCfg, baselineEntries, path.resolve(scanPath));
+        await scanStagedFiles(opts, scanCfg, baselineEntries, path.resolve(scanPath), suppressions);
         return;
       }
 
@@ -127,7 +136,7 @@ export function createScanCommand(): Command {
 
       // Handle --watch flag
       if (opts.watch) {
-        await watchAndScan(resolvedPath, opts, scanCfg);
+        await watchAndScan(resolvedPath, opts, scanCfg, suppressions);
         return;
       }
 
@@ -150,7 +159,7 @@ export function createScanCommand(): Command {
         results = await scanFile(resolvedPath, engine, scanCfg);
       }
 
-      outputScanResults(applyBaseline(results, baselineEntries), opts);
+      outputScanResults(applyBaseline(results, baselineEntries), opts, undefined, true, suppressions);
     });
 }
 
@@ -166,6 +175,15 @@ export function createSecretsCommand(): Command {
     "Scan files/directories for hardcoded secrets (regex + gitleaks). Secrets only — not a code analysis. For full SAST/SCA, use 'rafter run'.",
   );
   return cmd;
+}
+
+/**
+ * Combine .rafterignore + policy ignore rules into a single Suppression list.
+ * Order matters — first match wins, and policy rules are checked first so an
+ * explicit reason wins over a bare .rafterignore line covering the same finding.
+ */
+function collectSuppressions(policyIgnore?: ScanIgnoreRule[]): Suppression[] {
+  return [...policyIgnoreToSuppressions(policyIgnore), ...loadSuppressions()];
 }
 
 /**
@@ -231,6 +249,7 @@ function outputScanResults(
   opts: ScanOpts,
   context?: string,
   exitOnFindings: boolean = true,
+  suppressions: Suppression[] = [],
 ): void {
   const format = opts.format ?? (opts.json ? "json" : "text");
 
@@ -239,13 +258,17 @@ function outputScanResults(
     process.exit(2);
   }
 
+  // Split suppressed findings off the main result list. Both engines feed
+  // through here, so policy-driven suppression applies regardless of source.
+  const { results: keptResults, suppressed } = applySuppressions(results, suppressions);
+
   if (format === "sarif") {
-    outputSarif(results);
+    outputSarif(keptResults);
     return;
   }
 
   if (format === "json" || opts.json) {
-    const resultsOut = results.map((r) => ({
+    const filesOut = keptResults.map((r) => ({
       file: r.file,
       matches: r.matches.map((m) => ({
         pattern: { name: m.pattern.name, severity: m.pattern.severity, description: m.pattern.description || "" },
@@ -254,7 +277,7 @@ function outputScanResults(
         redacted: m.redacted || "",
       })),
     }));
-    const out = {
+    const out: { _note: string; scan_mode: string; triage_applied: boolean; results: typeof filesOut; _suppressed?: SuppressedFinding[] } = {
       _note:
         "Local-only scan: pattern-based detection without agentic-intelligence triage. " +
         "Findings have not been evaluated for context (public exposure, key validity, " +
@@ -262,14 +285,22 @@ function outputScanResults(
         "Run 'rafter run' for backend agentic analysis.",
       scan_mode: "local",
       triage_applied: false,
-      results: resultsOut,
+      results: filesOut,
     };
+    if (suppressed.length > 0) {
+      out._suppressed = suppressed;
+    }
     console.log(JSON.stringify(out, null, 2));
-    if (exitOnFindings) process.exit(results.length > 0 ? 1 : 0);
+    if (exitOnFindings) process.exit(keptResults.length > 0 ? 1 : 0);
     return;
   }
 
-  if (results.length === 0) {
+  // Text output — note suppression on stderr so stdout remains parseable.
+  if (suppressed.length > 0 && !opts.quiet) {
+    console.error(fmt.info(`(${suppressed.length} finding(s) hidden by .rafter.yml)`));
+  }
+
+  if (keptResults.length === 0) {
     if (!opts.quiet) {
       const msg = context ? `No secrets detected in ${context}` : "No secrets detected";
       console.log(`\n${fmt.success(msg)}\n`);
@@ -278,10 +309,10 @@ function outputScanResults(
     return;
   }
 
-  console.log(`\n${fmt.warning(`Found secrets in ${results.length} file(s):`)}\n`);
+  console.log(`\n${fmt.warning(`Found secrets in ${keptResults.length} file(s):`)}\n`);
 
   let totalMatches = 0;
-  for (const result of results) {
+  for (const result of keptResults) {
     console.log(`\n${fmt.info(result.file)}`);
 
     for (const match of result.matches) {
@@ -297,7 +328,7 @@ function outputScanResults(
     }
   }
 
-  console.log(`\n${fmt.warning(`Total: ${totalMatches} secret(s) detected in ${results.length} file(s)`)}\n`);
+  console.log(`\n${fmt.warning(`Total: ${totalMatches} secret(s) detected in ${keptResults.length} file(s)`)}\n`);
 
   if (context === "staged files") {
     console.log(`${fmt.error("Commit blocked. Remove secrets before committing.")}\n`);
@@ -314,9 +345,10 @@ function outputScanResults(
 async function scanDiffFiles(
   ref: string,
   opts: ScanOpts,
-  scanCfg?: { excludePaths?: string[]; customPatterns?: Array<{ name: string; regex: string; severity: string }> },
+  scanCfg?: { excludePaths?: string[]; customPatterns?: Array<{ name: string; regex: string; severity: string }>; ignore?: ScanIgnoreRule[] },
   baselineEntries: BaselineEntry[] = [],
   scanPath?: string,
+  suppressions: Suppression[] = [],
 ): Promise<void> {
   const cwd = scanPath && fs.existsSync(scanPath) && fs.statSync(scanPath).isDirectory() ? scanPath : undefined;
   try {
@@ -327,7 +359,7 @@ async function scanDiffFiles(
     }).trim();
 
     if (!diffOutput) {
-      outputScanResults([], opts, `files changed since ${ref}`);
+      outputScanResults([], opts, `files changed since ${ref}`, true, suppressions);
       return;
     }
 
@@ -356,7 +388,7 @@ async function scanDiffFiles(
       allResults.push(...results);
     }
 
-    outputScanResults(applyBaseline(allResults, baselineEntries), opts, `files changed since ${ref}`);
+    outputScanResults(applyBaseline(allResults, baselineEntries), opts, `files changed since ${ref}`, true, suppressions);
   } catch (error: any) {
     if (error.status === 128) {
       console.error("Error: Not in a git repository or invalid ref");
@@ -371,9 +403,10 @@ async function scanDiffFiles(
  */
 async function scanStagedFiles(
   opts: ScanOpts,
-  scanCfg?: { excludePaths?: string[]; customPatterns?: Array<{ name: string; regex: string; severity: string }> },
+  scanCfg?: { excludePaths?: string[]; customPatterns?: Array<{ name: string; regex: string; severity: string }>; ignore?: ScanIgnoreRule[] },
   baselineEntries: BaselineEntry[] = [],
   scanPath?: string,
+  suppressions: Suppression[] = [],
 ): Promise<void> {
   const cwd = scanPath && fs.existsSync(scanPath) && fs.statSync(scanPath).isDirectory() ? scanPath : undefined;
   try {
@@ -384,7 +417,7 @@ async function scanStagedFiles(
     }).trim();
 
     if (!stagedFilesOutput) {
-      outputScanResults([], opts, "staged files");
+      outputScanResults([], opts, "staged files", true, suppressions);
       return;
     }
 
@@ -413,7 +446,7 @@ async function scanStagedFiles(
       allResults.push(...results);
     }
 
-    outputScanResults(applyBaseline(allResults, baselineEntries), opts, "staged files");
+    outputScanResults(applyBaseline(allResults, baselineEntries), opts, "staged files", true, suppressions);
   } catch (error: any) {
     if (error.status === 128) {
       console.error("Error: Not in a git repository");
@@ -511,7 +544,8 @@ async function scanDirectory(
 async function watchAndScan(
   watchPath: string,
   opts: ScanOpts,
-  scanCfg?: { excludePaths?: string[]; customPatterns?: Array<{ name: string; regex: string; severity: string }> },
+  scanCfg?: { excludePaths?: string[]; customPatterns?: Array<{ name: string; regex: string; severity: string }>; ignore?: ScanIgnoreRule[] },
+  suppressions: Suppression[] = [],
 ): Promise<void> {
   const { watch } = await import("chokidar");
   const logger = new AuditLogger();
@@ -530,7 +564,7 @@ async function watchAndScan(
 
   if (initialResults.length > 0) {
     console.log(fmt.warning(`\n[Initial scan] Found secrets:`));
-    outputScanResults(initialResults, { ...opts, quiet: false }, undefined, /* exitOnFindings= */ false);
+    outputScanResults(initialResults, { ...opts, quiet: false }, undefined, /* exitOnFindings= */ false, suppressions);
     logWatchFindings(logger, initialResults);
   } else if (!opts.quiet) {
     console.log(fmt.success(`[Initial scan] No secrets detected`));
@@ -555,7 +589,7 @@ async function watchAndScan(
 
     const results = await scanFile(filePath, engine, scanCfg);
     if (results.length > 0) {
-      outputScanResults(results, { ...opts, quiet: false }, undefined, /* exitOnFindings= */ false);
+      outputScanResults(results, { ...opts, quiet: false }, undefined, /* exitOnFindings= */ false, suppressions);
       logWatchFindings(logger, results);
     } else if (!opts.quiet) {
       console.log(fmt.success(`  No secrets detected`));
@@ -573,7 +607,7 @@ async function watchAndScan(
 
     const results = await scanFile(filePath, engine, scanCfg);
     if (results.length > 0) {
-      outputScanResults(results, { ...opts, quiet: false }, undefined, /* exitOnFindings= */ false);
+      outputScanResults(results, { ...opts, quiet: false }, undefined, /* exitOnFindings= */ false, suppressions);
       logWatchFindings(logger, results);
     } else if (!opts.quiet) {
       console.log(fmt.success(`  No secrets detected`));

--- a/node/src/core/config-manager.ts
+++ b/node/src/core/config-manager.ts
@@ -289,6 +289,12 @@ export class ConfigManager {
       }
     }
 
+    // Ignore rules — top-level policy key, applied per finding at scan time
+    if (policy.ignore && config.agent) {
+      if (!config.agent.scan) config.agent.scan = {};
+      config.agent.scan.ignore = policy.ignore;
+    }
+
     // Audit settings
     if (policy.audit && config.agent) {
       if (policy.audit.retentionDays != null) {

--- a/node/src/core/config-schema.ts
+++ b/node/src/core/config-schema.ts
@@ -8,6 +8,12 @@ export interface ScanCustomPattern {
   severity: 'low' | 'medium' | 'high' | 'critical';
 }
 
+export interface ScanIgnoreRule {
+  paths: string[];
+  rules?: string[];
+  reason?: string;
+}
+
 export interface RafterConfig {
   version: string;
   initialized: string;
@@ -84,6 +90,7 @@ export interface RafterConfig {
     scan?: {
       excludePaths?: string[];
       customPatterns?: ScanCustomPattern[];
+      ignore?: ScanIgnoreRule[];
     };
     /**
      * Fine-grained per-component install state. Keys are component IDs like

--- a/node/src/core/custom-patterns.ts
+++ b/node/src/core/custom-patterns.ts
@@ -1,13 +1,14 @@
 /**
  * Load custom secret patterns from ~/.rafter/patterns/
- * and suppression rules from .rafterignore.
+ * and suppression rules from .rafterignore + .rafter.yml ignore section.
  */
 
 import fs from "fs";
 import path from "path";
 import { minimatch } from "minimatch";
-import { Pattern } from "./pattern-engine.js";
+import { Pattern, PatternMatch } from "./pattern-engine.js";
 import { getRafterDir } from "./config-defaults.js";
+import type { ScanIgnoreRule } from "./config-schema.js";
 
 // ---------------------------------------------------------------------------
 // Custom pattern loading
@@ -108,6 +109,20 @@ export interface Suppression {
   pathGlob: string;
   /** Optional pattern name to suppress, e.g. "generic-api-key". Empty = suppress all patterns for matching files. */
   patternName?: string;
+  /** Human-readable rationale (from .rafter.yml `reason`). */
+  reason?: string;
+  /** Where the suppression was defined — surfaced in JSON output. */
+  source?: ".rafterignore" | ".rafter.yml";
+}
+
+export interface SuppressedFinding {
+  file: string;
+  line: number | null;
+  column: number | null;
+  rule: string;
+  severity: string;
+  reason: string | null;
+  source: string;
 }
 
 /**
@@ -131,11 +146,12 @@ export function loadSuppressions(projectRoot: string = process.cwd()): Suppressi
       if (!line || line.startsWith("#")) continue;
       const colonIdx = line.indexOf(":");
       if (colonIdx === -1) {
-        suppressions.push({ pathGlob: line });
+        suppressions.push({ pathGlob: line, source: ".rafterignore" });
       } else {
         suppressions.push({
           pathGlob: line.slice(0, colonIdx).trim(),
           patternName: line.slice(colonIdx + 1).trim() || undefined,
+          source: ".rafterignore",
         });
       }
     }
@@ -143,6 +159,85 @@ export function loadSuppressions(projectRoot: string = process.cwd()): Suppressi
     // ignore unreadable .rafterignore
   }
   return suppressions;
+}
+
+/**
+ * Convert .rafter.yml ignore rules into the flat Suppression list used at scan time.
+ * Each entry's path globs cross-product with its rule names.
+ */
+export function policyIgnoreToSuppressions(rules: ScanIgnoreRule[] | undefined): Suppression[] {
+  if (!rules || rules.length === 0) return [];
+  const out: Suppression[] = [];
+  for (const rule of rules) {
+    if (!Array.isArray(rule.paths) || rule.paths.length === 0) continue;
+    const ruleNames = Array.isArray(rule.rules) && rule.rules.length > 0 ? rule.rules : [undefined];
+    for (const pathGlob of rule.paths) {
+      for (const ruleName of ruleNames) {
+        out.push({
+          pathGlob,
+          patternName: ruleName,
+          reason: rule.reason,
+          source: ".rafter.yml",
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Find the first matching suppression for a finding, or null. First-match wins so
+ * users can put more specific entries earlier and rely on stable precedence.
+ */
+export function findSuppression(
+  filePath: string,
+  patternName: string,
+  suppressions: Suppression[]
+): Suppression | null {
+  for (const s of suppressions) {
+    if (matchGlob(s.pathGlob, filePath)) {
+      if (!s.patternName || s.patternName.toLowerCase() === patternName.toLowerCase()) {
+        return s;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Split scan results into kept matches and structured suppressed findings.
+ * Used by the scan command for engine-agnostic suppression.
+ */
+export function applySuppressions<R extends { file: string; matches: PatternMatch[] }>(
+  results: R[],
+  suppressions: Suppression[],
+): { results: R[]; suppressed: SuppressedFinding[] } {
+  if (suppressions.length === 0) return { results, suppressed: [] };
+  const suppressed: SuppressedFinding[] = [];
+  const filtered: R[] = [];
+  for (const r of results) {
+    const kept: PatternMatch[] = [];
+    for (const m of r.matches) {
+      const hit = findSuppression(r.file, m.pattern.name, suppressions);
+      if (hit) {
+        suppressed.push({
+          file: r.file,
+          line: m.line ?? null,
+          column: m.column ?? null,
+          rule: m.pattern.name,
+          severity: m.pattern.severity,
+          reason: hit.reason ?? null,
+          source: hit.source ?? ".rafterignore",
+        });
+      } else {
+        kept.push(m);
+      }
+    }
+    if (kept.length > 0) {
+      filtered.push({ ...r, matches: kept });
+    }
+  }
+  return { results: filtered, suppressed };
 }
 
 /**
@@ -167,10 +262,16 @@ export function isSuppressed(
  * Match a file path against a glob pattern using minimatch.
  *
  * Uses `matchBase` so bare patterns like "*.env" match against the basename
- * (e.g. "config/.env"), and `dot` so dotfiles are included.
+ * (e.g. "config/.env"), and `dot` so dotfiles are included. Also tries
+ * matching the glob against any suffix of the path so that relative globs
+ * like `tests/fixtures/**` match absolute paths under any project root.
  */
 function matchGlob(glob: string, filePath: string): boolean {
   const g = glob.replace(/\\/g, "/");
   const f = filePath.replace(/\\/g, "/");
-  return minimatch(f, g, { dot: true, matchBase: true });
+  if (minimatch(f, g, { dot: true, matchBase: true })) return true;
+  // Auto-anchor relative globs to "anywhere in the path" so that `tests/**`
+  // matches `/abs/project/tests/foo`. Skip if the user already anchored.
+  if (g.startsWith("/") || g.startsWith("**/") || g.startsWith("**")) return false;
+  return minimatch(f, "**/" + g, { dot: true });
 }

--- a/node/src/core/policy-loader.ts
+++ b/node/src/core/policy-loader.ts
@@ -20,6 +20,15 @@ export interface PolicyDocEntry {
   };
 }
 
+export interface PolicyIgnoreRule {
+  /** Glob patterns matching files where findings should be suppressed. Required. */
+  paths: string[];
+  /** Pattern names to suppress (case-insensitive). Omitted = suppress all rules. */
+  rules?: string[];
+  /** Human-readable rationale, surfaced in the JSON `_suppressed` output. */
+  reason?: string;
+}
+
 export interface PolicyFile {
   version?: string;
   riskLevel?: string;
@@ -32,6 +41,7 @@ export interface PolicyFile {
     excludePaths?: string[];
     customPatterns?: PolicyCustomPattern[];
   };
+  ignore?: PolicyIgnoreRule[];
   audit?: {
     retentionDays?: number;
     logLevel?: string;
@@ -118,6 +128,32 @@ function mapPolicy(raw: Record<string, any>): PolicyFile {
     }
   }
 
+  if (Array.isArray(raw.ignore)) {
+    const rules: PolicyIgnoreRule[] = [];
+    for (const entry of raw.ignore) {
+      if (!entry || typeof entry !== "object") {
+        console.error(`Warning: skipping malformed ignore entry — must be an object with paths.`);
+        continue;
+      }
+      const paths = entry.paths;
+      if (!Array.isArray(paths) || paths.length === 0) {
+        console.error(`Warning: skipping ignore entry — "paths" must be a non-empty array of strings.`);
+        continue;
+      }
+      const rule: PolicyIgnoreRule = { paths: paths.map((p: any) => String(p)) };
+      if (Array.isArray(entry.rules)) {
+        rule.rules = entry.rules.map((r: any) => String(r));
+      }
+      if (typeof entry.reason === "string" && entry.reason) {
+        rule.reason = entry.reason;
+      }
+      rules.push(rule);
+    }
+    if (rules.length > 0) {
+      policy.ignore = rules;
+    }
+  }
+
   if (raw.audit && typeof raw.audit === "object") {
     policy.audit = {};
     if (raw.audit.retention_days != null) {
@@ -192,7 +228,7 @@ function deriveDocId(source: string, kind: "path" | "url"): string {
   return crypto.createHash("sha256").update(source).digest("hex").slice(0, 8);
 }
 
-const VALID_TOP_LEVEL_KEYS = new Set(["version", "risk_level", "command_policy", "scan", "audit", "docs"]);
+const VALID_TOP_LEVEL_KEYS = new Set(["version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs"]);
 const VALID_RISK_LEVELS = new Set(["minimal", "moderate", "aggressive"]);
 const VALID_COMMAND_MODES = new Set(["allow-all", "approve-dangerous", "deny-list"]);
 const VALID_LOG_LEVELS = new Set(["debug", "info", "warn", "error"]);
@@ -270,6 +306,39 @@ function validatePolicy(policy: PolicyFile, raw: Record<string, any>): PolicyFil
         } else {
           delete policy.scan.customPatterns;
         }
+      }
+    }
+  }
+
+  if (policy.ignore !== undefined) {
+    if (!Array.isArray(policy.ignore)) {
+      console.error(`Warning: "ignore" must be an array — ignoring.`);
+      delete policy.ignore;
+    } else {
+      const valid: PolicyIgnoreRule[] = [];
+      for (const entry of policy.ignore) {
+        if (!entry || typeof entry !== "object") {
+          console.error(`Warning: skipping malformed ignore entry — must be an object with paths.`);
+          continue;
+        }
+        if (!Array.isArray(entry.paths) || entry.paths.length === 0 || !entry.paths.every((p) => typeof p === "string" && p)) {
+          console.error(`Warning: skipping ignore entry — "paths" must be a non-empty array of strings.`);
+          continue;
+        }
+        if (entry.rules !== undefined && (!Array.isArray(entry.rules) || !entry.rules.every((r) => typeof r === "string"))) {
+          console.error(`Warning: skipping ignore entry — "rules" must be an array of strings.`);
+          continue;
+        }
+        if (entry.reason !== undefined && typeof entry.reason !== "string") {
+          console.error(`Warning: ignore entry "reason" must be a string — dropping reason.`);
+          delete entry.reason;
+        }
+        valid.push(entry);
+      }
+      if (valid.length > 0) {
+        policy.ignore = valid;
+      } else {
+        delete policy.ignore;
       }
     }
   }

--- a/node/src/scanners/regex-scanner.ts
+++ b/node/src/scanners/regex-scanner.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { PatternEngine, PatternMatch, Pattern } from "../core/pattern-engine.js";
 import { DEFAULT_SECRET_PATTERNS } from "./secret-patterns.js";
-import { loadCustomPatterns, loadSuppressions, isSuppressed, Suppression } from "../core/custom-patterns.js";
+import { loadCustomPatterns } from "../core/custom-patterns.js";
 
 export interface ScanResult {
   file: string;
@@ -11,7 +11,6 @@ export interface ScanResult {
 
 export class RegexScanner {
   private engine: PatternEngine;
-  private suppressions: Suppression[];
 
   constructor(customPatterns?: Array<{ name: string; regex: string; severity: string }>) {
     const patterns: Pattern[] = [...DEFAULT_SECRET_PATTERNS, ...loadCustomPatterns()];
@@ -25,19 +24,16 @@ export class RegexScanner {
       }
     }
     this.engine = new PatternEngine(patterns);
-    this.suppressions = loadSuppressions();
   }
 
   /**
-   * Scan a single file for secrets
+   * Scan a single file for secrets. Suppression is applied at the scan
+   * command boundary (engine-agnostic), not here.
    */
   scanFile(filePath: string): ScanResult {
     try {
       const content = fs.readFileSync(filePath, "utf-8");
-      const raw = this.engine.scanWithPosition(content);
-      const matches = raw.filter(
-        (m) => !isSuppressed(filePath, m.pattern.name, this.suppressions)
-      );
+      const matches = this.engine.scanWithPosition(content);
       return { file: filePath, matches };
     } catch (e) {
       return { file: filePath, matches: [] };

--- a/node/tests/policy-loader.test.ts
+++ b/node/tests/policy-loader.test.ts
@@ -164,6 +164,52 @@ scan:
     expect(stderrSpy.mock.calls.some((c) => String(c[0]).includes("invalid regex"))).toBe(true);
   });
 
+  it("parses ignore rules with paths, rules, and reason", async () => {
+    const yml = `
+ignore:
+  - paths: ["tests/fixtures/**", "*.example.env"]
+    rules: ["AWS Access Key", "Generic API Key"]
+    reason: "test fixtures"
+  - paths: ["docs/**"]
+    reason: "documentation examples"
+`;
+    fs.writeFileSync(path.join(tmpDir, ".rafter.yml"), yml);
+    const policy = await loadPolicyFresh();
+
+    expect(policy!.ignore).toBeDefined();
+    expect(policy!.ignore!.length).toBe(2);
+    expect(policy!.ignore![0].paths).toEqual(["tests/fixtures/**", "*.example.env"]);
+    expect(policy!.ignore![0].rules).toEqual(["AWS Access Key", "Generic API Key"]);
+    expect(policy!.ignore![0].reason).toBe("test fixtures");
+    expect(policy!.ignore![1].rules).toBeUndefined();
+    expect(policy!.ignore![1].reason).toBe("documentation examples");
+  });
+
+  it("ignore: rules without paths are skipped with a warning", async () => {
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const yml = `
+ignore:
+  - rules: ["AWS Access Key"]
+  - paths: ["valid/**"]
+    reason: "kept"
+`;
+    fs.writeFileSync(path.join(tmpDir, ".rafter.yml"), yml);
+    const policy = await loadPolicyFresh();
+
+    expect(policy!.ignore!.length).toBe(1);
+    expect(policy!.ignore![0].paths).toEqual(["valid/**"]);
+    expect(stderrSpy.mock.calls.some((c) => String(c[0]).includes("paths"))).toBe(true);
+  });
+
+  it("ignore: empty array results in no ignore section", async () => {
+    const yml = `
+ignore: []
+`;
+    fs.writeFileSync(path.join(tmpDir, ".rafter.yml"), yml);
+    const policy = await loadPolicyFresh();
+    expect(policy!.ignore).toBeUndefined();
+  });
+
   it("warns and strips invalid audit.retention_days (non-number)", async () => {
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const yml = `

--- a/node/tests/suppression.test.ts
+++ b/node/tests/suppression.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { applySuppressions, policyIgnoreToSuppressions, findSuppression, Suppression } from "../src/core/custom-patterns.js";
+import { PatternMatch } from "../src/core/pattern-engine.js";
+
+function mkMatch(name: string, severity = "high", line = 1): PatternMatch {
+  return {
+    pattern: { name, regex: ".*", severity: severity as any },
+    match: "secret",
+    line,
+    column: 1,
+    redacted: "***",
+  };
+}
+
+describe("policyIgnoreToSuppressions", () => {
+  it("flattens paths × rules, attaches reason and source", () => {
+    const out = policyIgnoreToSuppressions([
+      { paths: ["tests/**", "fixtures/**"], rules: ["AWS Access Key"], reason: "fixtures" },
+    ]);
+    expect(out.length).toBe(2);
+    expect(out[0]).toMatchObject({ pathGlob: "tests/**", patternName: "AWS Access Key", reason: "fixtures", source: ".rafter.yml" });
+    expect(out[1].pathGlob).toBe("fixtures/**");
+  });
+
+  it("omitting rules yields a single suppression covering all rule names", () => {
+    const out = policyIgnoreToSuppressions([
+      { paths: ["docs/**"], reason: "docs" },
+    ]);
+    expect(out.length).toBe(1);
+    expect(out[0].patternName).toBeUndefined();
+  });
+
+  it("returns [] for empty/undefined input", () => {
+    expect(policyIgnoreToSuppressions(undefined)).toEqual([]);
+    expect(policyIgnoreToSuppressions([])).toEqual([]);
+  });
+});
+
+describe("findSuppression", () => {
+  it("returns first matching suppression — ordering matters", () => {
+    const sups: Suppression[] = [
+      { pathGlob: "tests/**", patternName: "AWS Access Key", reason: "first", source: ".rafter.yml" },
+      { pathGlob: "tests/**", reason: "fallback", source: ".rafter.yml" },
+    ];
+    const hit = findSuppression("tests/foo.env", "AWS Access Key", sups);
+    expect(hit?.reason).toBe("first");
+  });
+
+  it("rule-name match is case-insensitive", () => {
+    const sups: Suppression[] = [
+      { pathGlob: "**/*.env", patternName: "aws access key", source: ".rafter.yml" },
+    ];
+    expect(findSuppression("foo.env", "AWS Access Key", sups)).not.toBeNull();
+  });
+
+  it("non-existent rule name causes no match (harmless)", () => {
+    const sups: Suppression[] = [
+      { pathGlob: "tests/**", patternName: "Nonexistent Rule", source: ".rafter.yml" },
+    ];
+    expect(findSuppression("tests/foo.env", "AWS Access Key", sups)).toBeNull();
+  });
+
+  it("returns null when no rule matches", () => {
+    const sups: Suppression[] = [
+      { pathGlob: "src/**", source: ".rafter.yml" },
+    ];
+    expect(findSuppression("docs/foo.md", "AWS Access Key", sups)).toBeNull();
+  });
+});
+
+describe("applySuppressions", () => {
+  it("returns input unchanged when suppressions are empty", () => {
+    const results = [{ file: "a.ts", matches: [mkMatch("AWS Access Key")] }];
+    const out = applySuppressions(results, []);
+    expect(out.results).toBe(results);
+    expect(out.suppressed).toEqual([]);
+  });
+
+  it("splits matches into kept + suppressed structures", () => {
+    const sups: Suppression[] = [
+      { pathGlob: "tests/**", patternName: "AWS Access Key", reason: "fixtures", source: ".rafter.yml" },
+    ];
+    const results = [
+      {
+        file: "tests/foo.env",
+        matches: [
+          mkMatch("AWS Access Key", "critical", 5),
+          mkMatch("Generic API Key", "high", 7),
+        ],
+      },
+      {
+        file: "src/api.ts",
+        matches: [mkMatch("AWS Access Key", "critical", 12)],
+      },
+    ];
+    const out = applySuppressions(results, sups);
+
+    // tests/foo.env keeps Generic API Key, src/api.ts unchanged
+    expect(out.results.length).toBe(2);
+    expect(out.results[0].matches.length).toBe(1);
+    expect(out.results[0].matches[0].pattern.name).toBe("Generic API Key");
+    expect(out.results[1].matches[0].pattern.name).toBe("AWS Access Key");
+
+    // One finding suppressed with structured detail
+    expect(out.suppressed.length).toBe(1);
+    expect(out.suppressed[0]).toMatchObject({
+      file: "tests/foo.env",
+      line: 5,
+      rule: "AWS Access Key",
+      severity: "critical",
+      reason: "fixtures",
+      source: ".rafter.yml",
+    });
+  });
+
+  it("drops files with all matches suppressed", () => {
+    const sups: Suppression[] = [
+      { pathGlob: "fixtures/**", reason: "all fixtures", source: ".rafter.yml" },
+    ];
+    const results = [
+      { file: "fixtures/a.env", matches: [mkMatch("AWS Access Key")] },
+      { file: "src/x.ts", matches: [mkMatch("Generic API Key")] },
+    ];
+    const out = applySuppressions(results, sups);
+    expect(out.results.map((r) => r.file)).toEqual(["src/x.ts"]);
+    expect(out.suppressed.length).toBe(1);
+    expect(out.suppressed[0].reason).toBe("all fixtures");
+  });
+
+  it("reason is null when source is .rafterignore (no rationale provided)", () => {
+    const sups: Suppression[] = [
+      { pathGlob: "vendor/**", source: ".rafterignore" },
+    ];
+    const results = [{ file: "vendor/lib.js", matches: [mkMatch("AWS Access Key")] }];
+    const out = applySuppressions(results, sups);
+    expect(out.suppressed[0].reason).toBeNull();
+    expect(out.suppressed[0].source).toBe(".rafterignore");
+  });
+});

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -941,21 +941,26 @@ def _output_scan_results(
     context: str | None = None,
     format: str = "text",
     exit_on_findings: bool = True,
+    suppressions: list | None = None,
 ) -> None:
+    from ..core.custom_patterns import apply_suppressions
+    suppressions = suppressions or []
+    kept_results, suppressed = apply_suppressions(results, suppressions)
+
     if format == "sarif":
-        _output_sarif(results)
+        _output_sarif(kept_results)
         return
 
     if json_output or format == "json":
-        results_out = [
+        files_out = [
             {"file": r.file, "matches": [
                 {"pattern": {"name": m.pattern.name, "severity": m.pattern.severity, "description": m.pattern.description or ""},
                  "line": m.line, "column": m.column, "redacted": m.redacted}
                 for m in r.matches
             ]}
-            for r in results
+            for r in kept_results
         ]
-        out = {
+        out: dict = {
             "_note": (
                 "Local-only scan: pattern-based detection without agentic-intelligence triage. "
                 "Findings have not been evaluated for context (public exposure, key validity, "
@@ -964,14 +969,20 @@ def _output_scan_results(
             ),
             "scan_mode": "local",
             "triage_applied": False,
-            "results": results_out,
+            "results": files_out,
         }
+        if suppressed:
+            from dataclasses import asdict
+            out["_suppressed"] = [asdict(s) for s in suppressed]
         print(json.dumps(out, indent=2))
         if exit_on_findings:
-            raise typer.Exit(code=1 if results else 0)
+            raise typer.Exit(code=1 if kept_results else 0)
         return
 
-    if not results:
+    if suppressed and not quiet:
+        print(f"({len(suppressed)} finding(s) hidden by .rafter.yml)", file=sys.stderr)
+
+    if not kept_results:
         if not quiet:
             msg = f"No secrets detected in {context}" if context else "No secrets detected"
             rprint(f"\n{fmt.success(msg)}\n")
@@ -979,10 +990,10 @@ def _output_scan_results(
             raise typer.Exit(code=0)
         return
 
-    rprint(f"\n{fmt.warning(f'Found secrets in {len(results)} file(s):')}\n")
+    rprint(f"\n{fmt.warning(f'Found secrets in {len(kept_results)} file(s):')}\n")
 
     total = 0
-    for r in results:
+    for r in kept_results:
         rprint(f"\n{fmt.info(r.file)}")
         for m in r.matches:
             total += 1
@@ -993,7 +1004,7 @@ def _output_scan_results(
             rprint(f"     Redacted: {m.redacted}")
             rprint()
 
-    rprint(f"\n{fmt.warning(f'Total: {total} secret(s) detected in {len(results)} file(s)')}\n")
+    rprint(f"\n{fmt.warning(f'Total: {total} secret(s) detected in {len(kept_results)} file(s)')}\n")
 
     if context == "staged files":
         rprint(f"{fmt.error('Commit blocked. Remove secrets before committing.')}\n")
@@ -1012,6 +1023,7 @@ def _watch_and_scan(
     format: str,
     custom_patterns,
     scan_cfg,
+    suppressions: list | None = None,
 ) -> None:
     """Watch a path for changes and re-scan on each change. Ctrl+C exits."""
     try:
@@ -1035,7 +1047,7 @@ def _watch_and_scan(
 
     if initial_results:
         rprint(fmt.warning("\n[Initial scan] Found secrets:"))
-        _output_scan_results(initial_results, json_output, False, format=format, exit_on_findings=False)
+        _output_scan_results(initial_results, json_output, False, format=format, exit_on_findings=False, suppressions=suppressions)
         _log_watch_findings(logger, initial_results)
     elif not quiet:
         rprint(fmt.success("[Initial scan] No secrets detected"))
@@ -1058,7 +1070,7 @@ def _watch_and_scan(
                 print(f"\n[{ts}] Changed: {file_path}", file=sys.stderr)
             results = _scan_file(file_path, eng, custom_patterns)
             if results:
-                _output_scan_results(results, json_output, False, format=format, exit_on_findings=False)
+                _output_scan_results(results, json_output, False, format=format, exit_on_findings=False, suppressions=suppressions)
                 _log_watch_findings(logger, results)
             elif not quiet:
                 rprint(fmt.success("  No secrets detected"))
@@ -1168,6 +1180,9 @@ def scan(
         if scan_cfg.custom_patterns else None
     )
 
+    from ..core.custom_patterns import load_suppressions, policy_ignore_to_suppressions
+    suppressions = policy_ignore_to_suppressions(scan_cfg.ignore) + load_suppressions()
+
     baseline_entries = _load_baseline_entries() if baseline else []
 
     # --diff
@@ -1197,7 +1212,7 @@ def scan(
             if os.path.isfile(resolved):
                 all_results.extend(_scan_file(resolved, eng, custom_patterns))
         filtered = _apply_baseline(all_results, baseline_entries)
-        _output_scan_results(filtered, json_output, quiet, f"files changed since {diff}", format=format)
+        _output_scan_results(filtered, json_output, quiet, f"files changed since {diff}", format=format, suppressions=suppressions)
         return
 
     # --staged
@@ -1227,7 +1242,7 @@ def scan(
             if os.path.isfile(resolved):
                 all_results.extend(_scan_file(resolved, eng, custom_patterns))
         filtered = _apply_baseline(all_results, baseline_entries)
-        _output_scan_results(filtered, json_output, quiet, "staged files", format=format)
+        _output_scan_results(filtered, json_output, quiet, "staged files", format=format, suppressions=suppressions)
         return
 
     # Default: scan path
@@ -1238,7 +1253,7 @@ def scan(
 
     # --watch
     if watch:
-        _watch_and_scan(resolved_path, engine, quiet, json_output, format, custom_patterns, scan_cfg)
+        _watch_and_scan(resolved_path, engine, quiet, json_output, format, custom_patterns, scan_cfg, suppressions)
         return
 
     eng = _select_engine(engine, quiet)
@@ -1253,7 +1268,7 @@ def scan(
         results = _scan_file(resolved_path, eng, custom_patterns)
 
     filtered = _apply_baseline(results, baseline_entries)
-    _output_scan_results(filtered, json_output, quiet, format=format)
+    _output_scan_results(filtered, json_output, quiet, format=format, suppressions=suppressions)
 
 
 # ── audit ────────────────────────────────────────────────────────────

--- a/python/rafter_cli/commands/scan.py
+++ b/python/rafter_cli/commands/scan.py
@@ -109,6 +109,7 @@ def scan_local(
         _load_baseline_entries,
     )
     from ..core.config_manager import ConfigManager
+    from ..core.custom_patterns import load_suppressions, policy_ignore_to_suppressions
 
     manager = ConfigManager()
     cfg = manager.load_with_policy()
@@ -118,6 +119,10 @@ def scan_local(
         [{"name": p.name, "regex": p.regex, "severity": p.severity} for p in scan_cfg.custom_patterns]
         if scan_cfg.custom_patterns else None
     )
+
+    # Combine policy-derived ignore rules with .rafterignore. Policy first so
+    # an explicit reason wins over a bare .rafterignore line.
+    suppressions = policy_ignore_to_suppressions(scan_cfg.ignore) + load_suppressions()
 
     baseline_entries = _load_baseline_entries() if baseline else []
 
@@ -159,7 +164,7 @@ def scan_local(
             if os.path.isfile(resolved):
                 all_results.extend(_scan_file(resolved, eng, custom_patterns))
         filtered = _apply_baseline(all_results, baseline_entries)
-        _output_scan_results(filtered, json_output, quiet, f"files changed since {diff}", format=format)
+        _output_scan_results(filtered, json_output, quiet, f"files changed since {diff}", format=format, suppressions=suppressions)
         return
 
     # --staged
@@ -196,7 +201,7 @@ def scan_local(
             if os.path.isfile(resolved):
                 all_results.extend(_scan_file(resolved, eng, custom_patterns))
         filtered = _apply_baseline(all_results, baseline_entries)
-        _output_scan_results(filtered, json_output, quiet, "staged files", format=format)
+        _output_scan_results(filtered, json_output, quiet, "staged files", format=format, suppressions=suppressions)
         return
 
     # Default: scan path
@@ -207,7 +212,7 @@ def scan_local(
 
     # --watch
     if watch:
-        _watch_and_scan(resolved_path, engine, quiet, json_output, format, custom_patterns, scan_cfg)
+        _watch_and_scan(resolved_path, engine, quiet, json_output, format, custom_patterns, scan_cfg, suppressions)
         return
 
     eng = _select_engine(engine, quiet)
@@ -222,7 +227,7 @@ def scan_local(
         results = _scan_file(resolved_path, eng, custom_patterns)
 
     filtered = _apply_baseline(results, baseline_entries)
-    _output_scan_results(filtered, json_output, quiet, format=format)
+    _output_scan_results(filtered, json_output, quiet, format=format, suppressions=suppressions)
 
 
 # ── rafter secrets — top-level alias for local secret scanning ────────

--- a/python/rafter_cli/core/config_manager.py
+++ b/python/rafter_cli/core/config_manager.py
@@ -238,6 +238,18 @@ class ConfigManager:
                     ScanCustomPattern(**p) for p in scan["custom_patterns"]
                 ]
 
+        if policy.get("ignore"):
+            from .config_schema import ScanIgnoreRule
+
+            config.agent.scan.ignore = [
+                ScanIgnoreRule(
+                    paths=list(r.get("paths", [])),
+                    rules=list(r["rules"]) if r.get("rules") is not None else None,
+                    reason=r.get("reason"),
+                )
+                for r in policy["ignore"]
+            ]
+
         audit = policy.get("audit")
         if audit:
             if audit.get("retention_days") is not None:
@@ -309,6 +321,7 @@ class ConfigManager:
                     ScanCustomPattern(**cls._pick_fields(ScanCustomPattern, p))
                     for p in (agent_raw.get("scan") or {}).get("custom_patterns", (agent_raw.get("scan") or {}).get("customPatterns", []))
                 ],
+                ignore=cls._parse_ignore_rules((agent_raw.get("scan") or {}).get("ignore", [])),
             ),
             components=agent_raw.get("components") or {},
         )
@@ -319,6 +332,27 @@ class ConfigManager:
             backend=backend,
             agent=agent,
         )
+
+    @staticmethod
+    def _parse_ignore_rules(raw_rules) -> list:
+        from .config_schema import ScanIgnoreRule
+
+        if not isinstance(raw_rules, list):
+            return []
+        out = []
+        for r in raw_rules:
+            if not isinstance(r, dict):
+                continue
+            paths = r.get("paths")
+            if not isinstance(paths, list) or not paths:
+                continue
+            rules_list = r.get("rules") if isinstance(r.get("rules"), list) else None
+            out.append(ScanIgnoreRule(
+                paths=[str(p) for p in paths],
+                rules=[str(x) for x in rules_list] if rules_list is not None else None,
+                reason=r.get("reason") if isinstance(r.get("reason"), str) else None,
+            ))
+        return out
 
     @staticmethod
     def _deep_merge(target: dict, source: dict) -> dict:

--- a/python/rafter_cli/core/config_schema.py
+++ b/python/rafter_cli/core/config_schema.py
@@ -34,6 +34,13 @@ class ScanCustomPattern:
 
 
 @dataclass
+class ScanIgnoreRule:
+    paths: list[str] = field(default_factory=list)
+    rules: list[str] | None = None
+    reason: str | None = None
+
+
+@dataclass
 class CommandPolicyConfig:
     mode: CommandPolicyMode = "approve-dangerous"
     blocked_patterns: list[str] = field(
@@ -62,6 +69,7 @@ class NotificationsConfig:
 class ScanConfig:
     exclude_paths: list[str] = field(default_factory=list)
     custom_patterns: list[ScanCustomPattern] = field(default_factory=list)
+    ignore: list[ScanIgnoreRule] = field(default_factory=list)
 
 
 @dataclass

--- a/python/rafter_cli/core/custom_patterns.py
+++ b/python/rafter_cli/core/custom_patterns.py
@@ -96,6 +96,19 @@ def _load_json(path: Path) -> list[Pattern]:
 class Suppression:
     path_glob: str
     pattern_name: Optional[str] = None
+    reason: Optional[str] = None
+    source: str = ".rafterignore"
+
+
+@dataclass
+class SuppressedFinding:
+    file: str
+    line: Optional[int]
+    column: Optional[int]
+    rule: str
+    severity: str
+    reason: Optional[str]
+    source: str
 
 
 def load_suppressions(project_root: str | Path | None = None) -> list[Suppression]:
@@ -120,39 +133,147 @@ def load_suppressions(project_root: str | Path | None = None) -> list[Suppressio
                 continue
             colon = line.find(":")
             if colon == -1:
-                suppressions.append(Suppression(path_glob=line))
+                suppressions.append(Suppression(path_glob=line, source=".rafterignore"))
             else:
                 suppressions.append(Suppression(
                     path_glob=line[:colon].strip(),
                     pattern_name=line[colon + 1:].strip() or None,
+                    source=".rafterignore",
                 ))
     except OSError:
         pass
     return suppressions
 
 
-def is_suppressed(file_path: str, pattern_name: str, suppressions: list[Suppression]) -> bool:
-    """Return True if this finding should be suppressed."""
+def policy_ignore_to_suppressions(rules) -> list[Suppression]:
+    """Flatten ScanIgnoreRule[] into Suppression[] (cross-product paths × rules)."""
+    if not rules:
+        return []
+    out: list[Suppression] = []
+    for rule in rules:
+        paths = getattr(rule, "paths", None) or (rule.get("paths") if isinstance(rule, dict) else None)
+        if not paths:
+            continue
+        rule_names = getattr(rule, "rules", None) if not isinstance(rule, dict) else rule.get("rules")
+        reason = getattr(rule, "reason", None) if not isinstance(rule, dict) else rule.get("reason")
+        names_iter = list(rule_names) if rule_names else [None]
+        for path_glob in paths:
+            for name in names_iter:
+                out.append(Suppression(
+                    path_glob=path_glob,
+                    pattern_name=name,
+                    reason=reason,
+                    source=".rafter.yml",
+                ))
+    return out
+
+
+def find_suppression(file_path: str, pattern_name: str, suppressions: list[Suppression]) -> Optional[Suppression]:
+    """Return the first matching suppression, or None. First-match wins."""
     for s in suppressions:
         if _match_glob(s.path_glob, file_path):
             if s.pattern_name is None or s.pattern_name.lower() == pattern_name.lower():
-                return True
-    return False
+                return s
+    return None
+
+
+def is_suppressed(file_path: str, pattern_name: str, suppressions: list[Suppression]) -> bool:
+    """Return True if this finding should be suppressed."""
+    return find_suppression(file_path, pattern_name, suppressions) is not None
+
+
+def apply_suppressions(results, suppressions: list[Suppression]):
+    """Split a list of ScanResult-like records into kept + suppressed findings.
+
+    Each result must have `.file` and `.matches` (list of PatternMatch).
+    Returns (filtered_results, suppressed_list).
+    """
+    if not suppressions:
+        return results, []
+    suppressed: list[SuppressedFinding] = []
+    filtered = []
+    for r in results:
+        kept = []
+        for m in r.matches:
+            hit = find_suppression(r.file, m.pattern.name, suppressions)
+            if hit is not None:
+                suppressed.append(SuppressedFinding(
+                    file=r.file,
+                    line=m.line,
+                    column=m.column,
+                    rule=m.pattern.name,
+                    severity=m.pattern.severity,
+                    reason=hit.reason,
+                    source=hit.source,
+                ))
+            else:
+                kept.append(m)
+        if kept:
+            # Preserve original type by mutating a copy
+            r_copy = type(r)(file=r.file, matches=kept)
+            filtered.append(r_copy)
+    return filtered, suppressed
 
 
 def _match_glob(glob_pattern: str, file_path: str) -> bool:
-    """Match a file path against a glob pattern using fnmatch.
+    """Match a file path against a glob pattern.
 
     Uses fnmatch.fnmatch for well-tested glob semantics. Patterns without
-    a path separator are matched against the basename so that e.g. "*.env"
-    matches "config/.env".
+    a path separator are matched against the basename so e.g. "*.env"
+    matches "config/.env". Relative path-globs like "tests/fixtures/**"
+    are auto-anchored to match anywhere in the path so they line up with
+    absolute scan paths.
     """
     g = glob_pattern.replace("\\", "/")
     f = file_path.replace("\\", "/")
 
-    # If the pattern has no path separator, match against the basename
-    # (similar to minimatch's matchBase behaviour).
+    # Bare basename pattern — match against the file basename.
     if "/" not in g:
-        f = f.rsplit("/", 1)[-1]
+        return fnmatch.fnmatch(f.rsplit("/", 1)[-1], g)
 
-    return fnmatch.fnmatch(f, g)
+    # Translate `**` (recursive) for fnmatch — fnmatch only supports `*`/`?`.
+    # Rewrite "tests/fixtures/**" → check via `tests/fixtures/*` over each path
+    # prefix. Cheaper: try "in path" check.
+    if _glob_in_path(g, f):
+        return True
+
+    # Auto-anchor to "anywhere in the path" if user didn't already anchor.
+    if g.startswith("/") or g.startswith("**/") or g.startswith("**"):
+        return False
+    return _glob_in_path(g, f, anchored_anywhere=True)
+
+
+def _glob_in_path(pattern: str, path: str, anchored_anywhere: bool = False) -> bool:
+    """Translate `**` to `.*` and use a regex match on the path.
+
+    This is a small subset of glob with `**` recursion that fnmatch lacks.
+    """
+    pat = pattern
+    if anchored_anywhere:
+        pat = "**/" + pat
+    # Convert glob to regex piece-by-piece. Keep it deliberately simple — we
+    # only need `**`, `*`, and `?` semantics for path matching.
+    regex = []
+    i = 0
+    while i < len(pat):
+        c = pat[i]
+        if c == "*" and i + 1 < len(pat) and pat[i + 1] == "*":
+            # `**` — match across path segments
+            regex.append(".*")
+            i += 2
+            # Consume optional trailing slash to allow "**/foo" patterns
+            if i < len(pat) and pat[i] == "/":
+                i += 1
+        elif c == "*":
+            regex.append("[^/]*")
+            i += 1
+        elif c == "?":
+            regex.append("[^/]")
+            i += 1
+        elif c in ".+()|^$":
+            regex.append(re.escape(c))
+            i += 1
+        else:
+            regex.append(c)
+            i += 1
+    return re.fullmatch("".join(regex), path) is not None

--- a/python/rafter_cli/core/policy_loader.py
+++ b/python/rafter_cli/core/policy_loader.py
@@ -85,6 +85,26 @@ def _map_policy(raw: dict) -> dict:
                 for p in scan["custom_patterns"]
             ]
 
+    ignore = raw.get("ignore")
+    if isinstance(ignore, list):
+        rules: list[dict] = []
+        for entry in ignore:
+            if not isinstance(entry, dict):
+                print('Warning: skipping malformed ignore entry — must be an object with paths.', file=sys.stderr)
+                continue
+            paths = entry.get("paths")
+            if not isinstance(paths, list) or not paths:
+                print('Warning: skipping ignore entry — "paths" must be a non-empty array of strings.', file=sys.stderr)
+                continue
+            rule: dict = {"paths": [str(p) for p in paths]}
+            if isinstance(entry.get("rules"), list):
+                rule["rules"] = [str(r) for r in entry["rules"]]
+            if isinstance(entry.get("reason"), str) and entry["reason"]:
+                rule["reason"] = entry["reason"]
+            rules.append(rule)
+        if rules:
+            policy["ignore"] = rules
+
     audit = raw.get("audit")
     if isinstance(audit, dict):
         policy["audit"] = {}
@@ -159,7 +179,7 @@ def _derive_doc_id(source: str, kind: str) -> str:
     return hashlib.sha256(source.encode("utf-8")).hexdigest()[:8]
 
 
-_VALID_TOP_LEVEL_KEYS = {"version", "risk_level", "command_policy", "scan", "audit", "docs"}
+_VALID_TOP_LEVEL_KEYS = {"version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs"}
 _VALID_RISK_LEVELS = {"minimal", "moderate", "aggressive"}
 _VALID_COMMAND_MODES = {"allow-all", "approve-dangerous", "deny-list"}
 _VALID_LOG_LEVELS = {"debug", "info", "warn", "error"}
@@ -218,6 +238,33 @@ def _validate_policy(policy: dict, raw: dict) -> dict:
                 scan["custom_patterns"] = valid_patterns
             else:
                 del scan["custom_patterns"]
+
+    ignore = policy.get("ignore")
+    if ignore is not None:
+        if not isinstance(ignore, list):
+            print('Warning: "ignore" must be an array — ignoring.', file=sys.stderr)
+            del policy["ignore"]
+        else:
+            valid_rules: list[dict] = []
+            for entry in ignore:
+                if not isinstance(entry, dict):
+                    print('Warning: skipping malformed ignore entry — must be an object with paths.', file=sys.stderr)
+                    continue
+                paths = entry.get("paths")
+                if not isinstance(paths, list) or not paths or not all(isinstance(p, str) and p for p in paths):
+                    print('Warning: skipping ignore entry — "paths" must be a non-empty array of strings.', file=sys.stderr)
+                    continue
+                if "rules" in entry and (not isinstance(entry["rules"], list) or not all(isinstance(r, str) for r in entry["rules"])):
+                    print('Warning: skipping ignore entry — "rules" must be an array of strings.', file=sys.stderr)
+                    continue
+                if "reason" in entry and not isinstance(entry["reason"], str):
+                    print('Warning: ignore entry "reason" must be a string — dropping reason.', file=sys.stderr)
+                    del entry["reason"]
+                valid_rules.append(entry)
+            if valid_rules:
+                policy["ignore"] = valid_rules
+            else:
+                del policy["ignore"]
 
     audit = policy.get("audit")
     if isinstance(audit, dict):

--- a/python/rafter_cli/scanners/regex_scanner.py
+++ b/python/rafter_cli/scanners/regex_scanner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from ..core.pattern_engine import Pattern, PatternEngine, PatternMatch
 from .secret_patterns import DEFAULT_SECRET_PATTERNS
-from ..core.custom_patterns import load_custom_patterns, load_suppressions, is_suppressed
+from ..core.custom_patterns import load_custom_patterns
 
 
 @dataclass
@@ -44,15 +44,14 @@ class RegexScanner:
                     severity=cp.get("severity", "high"),
                 ))
         self._engine = PatternEngine(patterns)
-        self._suppressions = load_suppressions()
 
     def scan_file(self, file_path: str) -> ScanResult:
+        # Suppression is applied at the scan command boundary (engine-agnostic).
         try:
             content = Path(file_path).read_text(errors="ignore")
         except (OSError, UnicodeDecodeError):
             return ScanResult(file=file_path)
-        raw = self._engine.scan_with_position(content)
-        matches = [m for m in raw if not is_suppressed(file_path, m.pattern.name, self._suppressions)]
+        matches = self._engine.scan_with_position(content)
         return ScanResult(file=file_path, matches=matches)
 
     def scan_files(self, file_paths: list[str]) -> list[ScanResult]:

--- a/python/tests/test_policy.py
+++ b/python/tests/test_policy.py
@@ -173,3 +173,48 @@ class TestValidateLogLevel:
             err = capsys.readouterr().err
             assert err == "", f"Unexpected warning for log_level={level}"
             assert result["audit"]["log_level"] == level
+
+
+class TestIgnoreRules:
+    """`.rafter.yml` ignore section parsing + validation."""
+
+    def test_parses_paths_rules_reason(self):
+        raw = {"ignore": [
+            {"paths": ["tests/fixtures/**", "*.example.env"],
+             "rules": ["AWS Access Key", "Generic API Key"],
+             "reason": "test fixtures"},
+            {"paths": ["docs/**"], "reason": "docs examples"},
+        ]}
+        result = _validate_policy(_map_policy(raw), raw)
+        assert len(result["ignore"]) == 2
+        assert result["ignore"][0]["paths"] == ["tests/fixtures/**", "*.example.env"]
+        assert result["ignore"][0]["rules"] == ["AWS Access Key", "Generic API Key"]
+        assert result["ignore"][0]["reason"] == "test fixtures"
+        assert "rules" not in result["ignore"][1]
+
+    def test_skips_entries_without_paths(self, capsys):
+        raw = {"ignore": [
+            {"rules": ["AWS Access Key"]},
+            {"paths": ["valid/**"], "reason": "kept"},
+        ]}
+        # _map_policy already drops the malformed entry; validate sees only the valid one.
+        # We exercise validate directly with an unfiltered policy to assert the warning path.
+        result = _validate_policy(
+            {"ignore": [{"rules": ["AWS Access Key"]}, {"paths": ["valid/**"], "reason": "kept"}]},
+            raw,
+        )
+        err = capsys.readouterr().err
+        assert "paths" in err
+        assert len(result["ignore"]) == 1
+        assert result["ignore"][0]["paths"] == ["valid/**"]
+
+    def test_empty_ignore_array_dropped(self):
+        raw = {"ignore": []}
+        result = _validate_policy(_map_policy(raw), raw)
+        assert "ignore" not in result
+
+    def test_non_array_ignore_warned_and_dropped(self, capsys):
+        result = _validate_policy({"ignore": "not-a-list"}, {"ignore": "not-a-list"})
+        err = capsys.readouterr().err
+        assert "ignore" in err
+        assert "ignore" not in result

--- a/python/tests/test_suppression.py
+++ b/python/tests/test_suppression.py
@@ -1,0 +1,115 @@
+"""Unit tests for the suppression engine — policy-driven and .rafterignore."""
+from __future__ import annotations
+
+from rafter_cli.core.custom_patterns import (
+    Suppression,
+    apply_suppressions,
+    find_suppression,
+    policy_ignore_to_suppressions,
+)
+from rafter_cli.core.config_schema import ScanIgnoreRule
+from rafter_cli.core.pattern_engine import Pattern, PatternMatch
+from rafter_cli.scanners.regex_scanner import ScanResult
+
+
+def _mk_match(name: str, severity: str = "high", line: int = 1) -> PatternMatch:
+    return PatternMatch(
+        pattern=Pattern(name=name, regex=".*", severity=severity),
+        match="secret",
+        line=line,
+        column=1,
+        redacted="***",
+    )
+
+
+class TestPolicyIgnoreToSuppressions:
+    def test_flattens_paths_x_rules(self):
+        rules = [ScanIgnoreRule(
+            paths=["tests/**", "fixtures/**"],
+            rules=["AWS Access Key"],
+            reason="fixtures",
+        )]
+        out = policy_ignore_to_suppressions(rules)
+        assert len(out) == 2
+        assert out[0].path_glob == "tests/**"
+        assert out[0].pattern_name == "AWS Access Key"
+        assert out[0].reason == "fixtures"
+        assert out[0].source == ".rafter.yml"
+
+    def test_no_rules_means_all_rules_suppressed(self):
+        rules = [ScanIgnoreRule(paths=["docs/**"], rules=None, reason="docs")]
+        out = policy_ignore_to_suppressions(rules)
+        assert len(out) == 1
+        assert out[0].pattern_name is None
+
+    def test_empty_input(self):
+        assert policy_ignore_to_suppressions(None) == []
+        assert policy_ignore_to_suppressions([]) == []
+
+
+class TestFindSuppression:
+    def test_first_match_wins(self):
+        sups = [
+            Suppression(path_glob="tests/**", pattern_name="AWS Access Key", reason="first", source=".rafter.yml"),
+            Suppression(path_glob="tests/**", pattern_name=None, reason="fallback", source=".rafter.yml"),
+        ]
+        hit = find_suppression("tests/foo.env", "AWS Access Key", sups)
+        assert hit is not None
+        assert hit.reason == "first"
+
+    def test_case_insensitive_rule_match(self):
+        sups = [Suppression(path_glob="*.env", pattern_name="aws access key", source=".rafter.yml")]
+        assert find_suppression("foo.env", "AWS Access Key", sups) is not None
+
+    def test_non_existent_rule_does_not_match(self):
+        sups = [Suppression(path_glob="tests/**", pattern_name="Made-Up Rule", source=".rafter.yml")]
+        assert find_suppression("tests/foo.env", "AWS Access Key", sups) is None
+
+
+class TestApplySuppressions:
+    def test_returns_input_when_no_suppressions(self):
+        results = [ScanResult(file="a.ts", matches=[_mk_match("AWS Access Key")])]
+        kept, suppressed = apply_suppressions(results, [])
+        assert kept is results
+        assert suppressed == []
+
+    def test_splits_kept_and_suppressed(self):
+        sups = [Suppression(path_glob="tests/**", pattern_name="AWS Access Key", reason="fixtures", source=".rafter.yml")]
+        results = [
+            ScanResult(file="tests/foo.env", matches=[
+                _mk_match("AWS Access Key", "critical", 5),
+                _mk_match("Generic API Key", "high", 7),
+            ]),
+            ScanResult(file="src/api.ts", matches=[_mk_match("AWS Access Key", "critical", 12)]),
+        ]
+        kept, suppressed = apply_suppressions(results, sups)
+        # tests/foo.env keeps Generic API Key only; src/api.ts unchanged
+        assert len(kept) == 2
+        kept_names = {r.file: [m.pattern.name for m in r.matches] for r in kept}
+        assert kept_names["tests/foo.env"] == ["Generic API Key"]
+        assert kept_names["src/api.ts"] == ["AWS Access Key"]
+        # Suppressed entry has structured detail
+        assert len(suppressed) == 1
+        assert suppressed[0].file == "tests/foo.env"
+        assert suppressed[0].rule == "AWS Access Key"
+        assert suppressed[0].severity == "critical"
+        assert suppressed[0].reason == "fixtures"
+        assert suppressed[0].source == ".rafter.yml"
+        assert suppressed[0].line == 5
+
+    def test_drops_files_with_all_matches_suppressed(self):
+        sups = [Suppression(path_glob="fixtures/**", reason="all fixtures", source=".rafter.yml")]
+        results = [
+            ScanResult(file="fixtures/a.env", matches=[_mk_match("AWS Access Key")]),
+            ScanResult(file="src/x.ts", matches=[_mk_match("Generic API Key")]),
+        ]
+        kept, suppressed = apply_suppressions(results, sups)
+        assert [r.file for r in kept] == ["src/x.ts"]
+        assert len(suppressed) == 1
+
+    def test_rafterignore_source_has_no_reason(self):
+        sups = [Suppression(path_glob="vendor/**", source=".rafterignore")]
+        results = [ScanResult(file="vendor/lib.js", matches=[_mk_match("AWS Access Key")])]
+        _, suppressed = apply_suppressions(results, sups)
+        assert suppressed[0].reason is None
+        assert suppressed[0].source == ".rafterignore"

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -363,6 +363,38 @@ The raw secret value is never included in JSON output.
 
 **Why `_note`?** Local scans are pattern-only — they cannot tell whether a finding is in a public-facing file, whether the key is still valid, or whether it ever shipped. Backend scans (`rafter run`) apply agentic context. The `_note` exists so agents and reviewers don't treat local findings as final verdicts — they should investigate each, but the absence of agentic triage is *not* an excuse to dismiss findings.
 
+##### Suppression-aware output shape
+
+When `.rafter.yml` `ignore:` rules (or `.rafterignore`) hide one or more findings, an `_suppressed` field is added to the wrapper so the consumer can see what was suppressed and why. The field is omitted when no findings are hidden.
+
+```json
+{
+  "_note": "Local-only scan: pattern-based detection without agentic-intelligence triage. ...",
+  "scan_mode": "local",
+  "triage_applied": false,
+  "results": [ /* same shape as without suppression */ ],
+  "_suppressed": [
+    {
+      "file": "/abs/path/tests/fixtures/fake.env",
+      "line": 3,
+      "column": 7,
+      "rule": "AWS Access Key",
+      "severity": "critical",
+      "reason": "test fixtures with fake AWS keys",
+      "source": ".rafter.yml"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_suppressed` | array (optional) | Each hidden finding, with file/line/column, rule name, severity, reason, and source. Absent when no suppression occurred. |
+| `_suppressed[].source` | string | `".rafter.yml"` for policy ignore rules, `".rafterignore"` for the legacy file |
+| `_suppressed[].reason` | string\|null | The `reason:` from the matching ignore rule, or `null` for `.rafterignore` lines |
+
+Exit code is unaffected by suppression — exit `1` is returned only when at least one *non-suppressed* finding remains.
+
 ### rafter agent exec COMMAND [OPTIONS]
 
 Execute shell command with risk assessment and approval workflow.
@@ -973,6 +1005,12 @@ scan:
     - name: "Internal API Key"
       regex: "INTERNAL_[A-Z0-9]{32}"
       severity: critical
+ignore:
+  - paths: ["tests/fixtures/**", "*.example.env"]
+    rules: ["AWS Access Key", "Generic API Key"]
+    reason: "test fixtures with fake credentials"
+  - paths: ["docs/**"]
+    reason: "documentation examples"
 audit:
   retention_days: 90
   log_level: info
@@ -999,6 +1037,8 @@ Precedence: policy file overrides `~/.rafter/config.json`. Arrays replace, not a
 - Unknown keys per-entry are ignored with a warning.
 
 **URL caching:** URL-backed docs are cached at `~/.rafter/docs-cache/` keyed by `sha256(url)[:32]`. Default TTL is 86400 seconds. On network failure, a stale cached copy is served and a warning is printed. `docs list` never fetches; `docs show` fetches on miss/expired or when `--refresh` is set.
+
+**Ignore rules (`ignore:`):** suppress findings without removing them from the audit trail. Each entry needs `paths:` (a non-empty list of globs); `rules:` is optional (omitting it suppresses every rule on the matched paths) and `reason:` is surfaced verbatim in the JSON `_suppressed` output. Path globs are matched anywhere along absolute scan paths — `tests/fixtures/**` matches `/abs/project/tests/fixtures/foo`. Rule-name matching is case-insensitive; non-existent rule names are harmless (they just never match). First entry that matches wins, so put more specific entries earlier.
 
 ---
 


### PR DESCRIPTION
Adds finding suppression via .rafter.yml ignore rules and surfaces suppressed entries through a JSON _suppressed field. Includes config schema + policy loader updates and tests across node and python.

Bead: rf-d8s
Includes a follow-on auto-save commit from gt-pvx safety net.
Files: scan command, config-manager, custom-patterns, policy-loader, regex-scanner, CLI_SPEC.md, plus suppression tests (node + python).