### PR TITLE
fix(github-action): surface HTTP error body on scan API failures (rf-zfhj)

### DIFF
--- a/github-action/action.yml
+++ b/github-action/action.yml
@@ -69,7 +69,11 @@ runs:
         RAFTER_URL: ${{ inputs.rafter-url }}
         SCAN_MODE: ${{ inputs.scan-mode }}
       run: |
-        RESPONSE=$(curl -fsS -X POST \
+        # --fail-with-body: non-2xx → body printed to stdout AND exit nonzero.
+        # We capture body+status separately so future failures self-explain
+        # (instead of just "curl exit 22"). API key never echoed.
+        BODY_FILE="$(mktemp)"
+        HTTP_CODE=$(curl -sS -o "$BODY_FILE" -w "%{http_code}" -X POST \
           -H "Content-Type: application/json" \
           -H "x-api-key: ${RAFTER_API_KEY}" \
           -d "{
@@ -77,12 +81,31 @@ runs:
             \"branch_name\": \"${{ github.head_ref || github.ref_name }}\",
             \"scan_mode\": \"${SCAN_MODE}\"
           }" \
-          "${RAFTER_URL}/api/static/scan" 2>&1)
+          "${RAFTER_URL}/api/static/scan") || {
+            echo "::error::curl transport error contacting ${RAFTER_URL}/api/static/scan"
+            cat "$BODY_FILE" || true
+            rm -f "$BODY_FILE"
+            exit 1
+          }
+
+        RESPONSE=$(cat "$BODY_FILE")
+        rm -f "$BODY_FILE"
+
+        if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+          ERROR=$(echo "$RESPONSE" | jq -r '.error // empty' 2>/dev/null || true)
+          echo "::error::Rafter scan trigger failed: HTTP ${HTTP_CODE}"
+          if [ -n "$ERROR" ]; then
+            echo "::error::Server: ${ERROR}"
+          else
+            echo "Server response: ${RESPONSE}"
+          fi
+          exit 1
+        fi
 
         SCAN_ID=$(echo "$RESPONSE" | jq -r '.scan_id // empty')
         if [ -z "$SCAN_ID" ]; then
           ERROR=$(echo "$RESPONSE" | jq -r '.error // "Unknown error triggering scan"')
-          echo "::error::Failed to trigger scan: ${ERROR}"
+          echo "::error::Failed to trigger scan (HTTP ${HTTP_CODE}): ${ERROR}"
           exit 1
         fi
 
@@ -103,9 +126,25 @@ runs:
         STATUS="pending"
 
         while [ $POLL_COUNT -lt $MAX_POLLS ]; do
-          RESPONSE=$(curl -fsS \
+          BODY_FILE="$(mktemp)"
+          HTTP_CODE=$(curl -sS -o "$BODY_FILE" -w "%{http_code}" \
             -H "x-api-key: ${RAFTER_API_KEY}" \
-            "${RAFTER_URL}/api/static/scan?scan_id=${SCAN_ID}" 2>&1)
+            "${RAFTER_URL}/api/static/scan?scan_id=${SCAN_ID}") || {
+              echo "::warning::curl transport error during poll (will retry)"
+              cat "$BODY_FILE" || true
+              rm -f "$BODY_FILE"
+              sleep 10
+              POLL_COUNT=$((POLL_COUNT+1))
+              continue
+            }
+          RESPONSE=$(cat "$BODY_FILE")
+          rm -f "$BODY_FILE"
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            ERROR=$(echo "$RESPONSE" | jq -r '.error // empty' 2>/dev/null || true)
+            echo "::error::Rafter scan poll failed: HTTP ${HTTP_CODE}${ERROR:+ — $ERROR}"
+            exit 1
+          fi
 
           STATUS=$(echo "$RESPONSE" | jq -r '.status // "unknown"')
 
@@ -139,20 +178,30 @@ runs:
         RAFTER_URL: ${{ inputs.rafter-url }}
         SCAN_ID: ${{ steps.scan.outputs.scan_id }}
       run: |
-        # Fetch JSON results
-        curl -fsS -H "x-api-key: ${RAFTER_API_KEY}" \
-          "${RAFTER_URL}/api/static/scan?scan_id=${SCAN_ID}" \
-          > "${{ runner.temp }}/rafter-results.json"
+        # fetch_results <output-path> <url>: HTTP-status aware GET that surfaces
+        # server error body on non-2xx (avoids silent curl exit 22 failures).
+        fetch_results() {
+          local out="$1"
+          local url="$2"
+          local code
+          code=$(curl -sS -o "$out" -w "%{http_code}" \
+            -H "x-api-key: ${RAFTER_API_KEY}" "$url") || {
+              echo "::error::curl transport error fetching ${url}"
+              cat "$out" || true
+              return 1
+            }
+          if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
+            local body err
+            body=$(cat "$out" || true)
+            err=$(echo "$body" | jq -r '.error // empty' 2>/dev/null || true)
+            echo "::error::Rafter results fetch failed: HTTP ${code}${err:+ — $err}"
+            return 1
+          fi
+        }
 
-        # Fetch Markdown results
-        curl -fsS -H "x-api-key: ${RAFTER_API_KEY}" \
-          "${RAFTER_URL}/api/static/scan?scan_id=${SCAN_ID}&format=md" \
-          > "${{ runner.temp }}/rafter-results.md"
-
-        # Fetch SARIF results
-        curl -fsS -H "x-api-key: ${RAFTER_API_KEY}" \
-          "${RAFTER_URL}/api/static/scan?scan_id=${SCAN_ID}&format=sarif" \
-          > "${{ runner.temp }}/rafter-results.sarif"
+        fetch_results "${{ runner.temp }}/rafter-results.json"  "${RAFTER_URL}/api/static/scan?scan_id=${SCAN_ID}"
+        fetch_results "${{ runner.temp }}/rafter-results.md"    "${RAFTER_URL}/api/static/scan?scan_id=${SCAN_ID}&format=md"
+        fetch_results "${{ runner.temp }}/rafter-results.sarif" "${RAFTER_URL}/api/static/scan?scan_id=${SCAN_ID}&format=sarif"
 
         # Extract counts
         RESULTS="${{ runner.temp }}/rafter-results.json"


### PR DESCRIPTION
## Summary

The scan-trigger step in `github-action/action.yml` uses `curl -fsS`, which on HTTP >= 400 exits 22 and **suppresses the response body**. The result is opaque CI failures like:

```
Run RESPONSE=$(curl -fsS -X POST ...
Error: Process completed with exit code 22.
```

…with zero diagnostic info. The same pattern is repeated in the polling step and the three results-fetching curls (JSON / Markdown / SARIF). Right now this is breaking secbolt CI scans (and any other consumer of `@v1`), and it's undebuggable from the action logs.

This PR replaces `-fsS` with explicit HTTP-status capture (`curl -sS -o file -w %{http_code}`) in all four scan API calls. On non-2xx, the action emits `::error::` with the HTTP code and the server's `.error` field (e.g. `"Invalid or inactive API key."` for 401). On curl transport failure, it logs and exits/retries.

## Why this matters

Without this fix, the next time the rafter API rejects a request (expired key, schema change, 5xx, rate limit, anything), every consumer of `Raftersecurity/rafter-cli/github-action@v1` gets the same useless `exit code 22` and has to attach a debugger to the GitHub runner to figure out what went wrong.

## Root cause of the original failure

For secbolt specifically, the most likely cause is an invalid/expired `RAFTER_API_KEY` secret on the secbolt repo — `https://rafter.so/api/static/scan` is reachable and returns `401 {"error":"Invalid or inactive API key."}` for bad keys. With this PR, that exact message will appear in the next CI run, so Rome can fix the secret. (Confirming this directly required the secret, which the agent doesn't have in env.)

## Security review

- API key is never echoed. Only used as `-H "x-api-key: ${RAFTER_API_KEY}"`.
- Server response body cannot contain the API key — verified against the `/api/static/scan` route handler in `Rome-1-securable-bolt/app/api/static/scan/route.ts`. All error paths return `{error: <message>}` with no key reflection.
- GitHub Actions auto-masks `${{ secrets.RAFTER_API_KEY }}` in logs as defense in depth.
- Walked CWE-532 (sensitive logging), CWE-78 (command injection — no new injection surface; same `${{ }}` interpolation as before), and CWE-918 (SSRF — `RAFTER_URL` is pre-existing input, unchanged).

## Test plan

- [ ] Merge to a topic branch on a test repo with a known-bad API key; confirm action prints `Rafter scan trigger failed: HTTP 401 — Invalid or inactive API key.` instead of `exit 22`.
- [ ] Verify happy path: known-good key triggers scan, polling proceeds, results fetched, no regression in success path.
- [ ] Verify timeout / poll-error paths still terminate cleanly.
- [ ] Re-tag `v1` after merge so secbolt's `@v1` reference picks up the fix.

Bead: `rf-zfhj` (P0 - blocking secbolt CI)

Generated with Claude Code