### PR TITLE
docs: fix broken repo URL in README badges (rf-6epe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rafter CLI
 
-[![npm version](https://img.shields.io/npm/v/@rafter-security/cli)](https://www.npmjs.com/package/@rafter-security/cli) [![PyPI version](https://img.shields.io/pypi/v/rafter-cli)](https://pypi.org/project/rafter-cli/) [![Scanned by Rafter](https://img.shields.io/badge/scanned_by-Rafter-2ea44f)](https://github.com/raftercli/rafter) [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![npm version](https://img.shields.io/npm/v/@rafter-security/cli)](https://www.npmjs.com/package/@rafter-security/cli) [![PyPI version](https://img.shields.io/pypi/v/rafter-cli)](https://pypi.org/project/rafter-cli/) [![Scanned by Rafter](https://img.shields.io/badge/scanned_by-Rafter-2ea44f)](https://github.com/Raftersecurity/rafter-cli) [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 <p>
   <a href="#supported-platforms"><img alt="Claude Code supported" src="https://img.shields.io/badge/Claude%20Code-supported-d97757?style=flat&labelColor=141413&logo=claude&logoColor=faf9f5"></a>
@@ -553,16 +553,16 @@ Python package is in `python/` — see [`python/README.md`](python/README.md) fo
 
 Show that your project is protected by Rafter. Add one of these badges to your README:
 
-[![Scanned by Rafter](https://img.shields.io/badge/scanned_by-Rafter-2ea44f)](https://github.com/raftercli/rafter) [![Rafter policy: enforced](https://img.shields.io/badge/rafter_policy-enforced-2ea44f)](https://github.com/raftercli/rafter)
+[![Scanned by Rafter](https://img.shields.io/badge/scanned_by-Rafter-2ea44f)](https://github.com/Raftersecurity/rafter-cli) [![Rafter policy: enforced](https://img.shields.io/badge/rafter_policy-enforced-2ea44f)](https://github.com/Raftersecurity/rafter-cli)
 
 **Markdown (copy-paste):**
 
 ```markdown
-[![Scanned by Rafter](https://img.shields.io/badge/scanned_by-Rafter-2ea44f)](https://github.com/raftercli/rafter)
+[![Scanned by Rafter](https://img.shields.io/badge/scanned_by-Rafter-2ea44f)](https://github.com/Raftersecurity/rafter-cli)
 ```
 
 ```markdown
-[![Rafter policy: enforced](https://img.shields.io/badge/rafter_policy-enforced-2ea44f)](https://github.com/raftercli/rafter)
+[![Rafter policy: enforced](https://img.shields.io/badge/rafter_policy-enforced-2ea44f)](https://github.com/Raftersecurity/rafter-cli)
 ```
 
 More badge variants (HTML, reStructuredText) available in [`badges/`](badges/).

--- a/badges/README.md
+++ b/badges/README.md
@@ -29,13 +29,13 @@ Pick a badge and copy the snippet for your preferred format.
 **Markdown:**
 
 ```markdown
-[![Scanned by Rafter](https://img.shields.io/badge/scanned_by-Rafter-2ea44f)](https://github.com/raftercli/rafter)
+[![Scanned by Rafter](https://img.shields.io/badge/scanned_by-Rafter-2ea44f)](https://github.com/Raftersecurity/rafter-cli)
 ```
 
 **HTML:**
 
 ```html
-<a href="https://github.com/raftercli/rafter">
+<a href="https://github.com/Raftersecurity/rafter-cli">
   <img src="https://img.shields.io/badge/scanned_by-Rafter-2ea44f" alt="Scanned by Rafter">
 </a>
 ```
@@ -44,7 +44,7 @@ Pick a badge and copy the snippet for your preferred format.
 
 ```rst
 .. image:: https://img.shields.io/badge/scanned_by-Rafter-2ea44f
-   :target: https://github.com/raftercli/rafter
+   :target: https://github.com/Raftersecurity/rafter-cli
    :alt: Scanned by Rafter
 ```
 
@@ -53,13 +53,13 @@ Pick a badge and copy the snippet for your preferred format.
 **Markdown:**
 
 ```markdown
-[![Rafter policy: enforced](https://img.shields.io/badge/rafter_policy-enforced-2ea44f)](https://github.com/raftercli/rafter)
+[![Rafter policy: enforced](https://img.shields.io/badge/rafter_policy-enforced-2ea44f)](https://github.com/Raftersecurity/rafter-cli)
 ```
 
 **HTML:**
 
 ```html
-<a href="https://github.com/raftercli/rafter">
+<a href="https://github.com/Raftersecurity/rafter-cli">
   <img src="https://img.shields.io/badge/rafter_policy-enforced-2ea44f" alt="Rafter policy: enforced">
 </a>
 ```
@@ -68,7 +68,7 @@ Pick a badge and copy the snippet for your preferred format.
 
 ```rst
 .. image:: https://img.shields.io/badge/rafter_policy-enforced-2ea44f
-   :target: https://github.com/raftercli/rafter
+   :target: https://github.com/Raftersecurity/rafter-cli
    :alt: Rafter policy: enforced
 ```
 
@@ -77,13 +77,13 @@ Pick a badge and copy the snippet for your preferred format.
 **Markdown:**
 
 ```markdown
-[![Rafter policy: moderate](https://img.shields.io/badge/rafter_policy-moderate-blue)](https://github.com/raftercli/rafter)
+[![Rafter policy: moderate](https://img.shields.io/badge/rafter_policy-moderate-blue)](https://github.com/Raftersecurity/rafter-cli)
 ```
 
 **HTML:**
 
 ```html
-<a href="https://github.com/raftercli/rafter">
+<a href="https://github.com/Raftersecurity/rafter-cli">
   <img src="https://img.shields.io/badge/rafter_policy-moderate-blue" alt="Rafter policy: moderate">
 </a>
 ```
@@ -92,7 +92,7 @@ Pick a badge and copy the snippet for your preferred format.
 
 ```rst
 .. image:: https://img.shields.io/badge/rafter_policy-moderate-blue
-   :target: https://github.com/raftercli/rafter
+   :target: https://github.com/Raftersecurity/rafter-cli
    :alt: Rafter policy: moderate
 ```
 
@@ -101,13 +101,13 @@ Pick a badge and copy the snippet for your preferred format.
 **Markdown:**
 
 ```markdown
-[![Secrets: clean](https://img.shields.io/badge/secrets-clean-2ea44f)](https://github.com/raftercli/rafter)
+[![Secrets: clean](https://img.shields.io/badge/secrets-clean-2ea44f)](https://github.com/Raftersecurity/rafter-cli)
 ```
 
 **HTML:**
 
 ```html
-<a href="https://github.com/raftercli/rafter">
+<a href="https://github.com/Raftersecurity/rafter-cli">
   <img src="https://img.shields.io/badge/secrets-clean-2ea44f" alt="Secrets: clean">
 </a>
 ```
@@ -116,7 +116,7 @@ Pick a badge and copy the snippet for your preferred format.
 
 ```rst
 .. image:: https://img.shields.io/badge/secrets-clean-2ea44f
-   :target: https://github.com/raftercli/rafter
+   :target: https://github.com/Raftersecurity/rafter-cli
    :alt: Secrets: clean
 ```
 

--- a/outreach-drafts.md
+++ b/outreach-drafts.md
@@ -51,7 +51,7 @@ something I noticed while scanning for exposed credentials on GitHub.
   catches secrets before they're pushed
 - [trufflehog](https://github.com/trufflesecurity/trufflehog) — scans Git
   history for high-entropy strings and known key patterns
-- [rafter](https://github.com/raftercli/rafter) — security CLI that
+- [rafter](https://github.com/Raftersecurity/rafter-cli) — security CLI that
   integrates with AI coding agents to catch secrets, risky commands, and
   policy violations in real time
 
@@ -106,7 +106,7 @@ contains what appear to be live database credentials:
   scanning
 - [trufflehog](https://github.com/trufflesecurity/trufflehog) — Git history
   scanner
-- [rafter](https://github.com/raftercli/rafter) — security CLI for AI coding
+- [rafter](https://github.com/Raftersecurity/rafter-cli) — security CLI for AI coding
   agents with built-in secret scanning and policy enforcement
 
 This is super common — especially when `.env` variants like `.env.txt` bypass
@@ -159,7 +159,7 @@ infrastructure.
 - [gitleaks](https://github.com/gitleaks/gitleaks) — pre-commit secret detection
 - [trufflehog](https://github.com/trufflesecurity/trufflehog) — deep Git
   history scanning
-- [rafter](https://github.com/raftercli/rafter) — security toolkit for
+- [rafter](https://github.com/Raftersecurity/rafter-cli) — security toolkit for
   developers using AI coding agents
 
 Hope this helps — just trying to make sure exposed keys get rotated. 🛡️
@@ -209,7 +209,7 @@ is high-severity.
   secret detection
 - [trufflehog](https://github.com/trufflesecurity/trufflehog) — scans Git
   history
-- [rafter](https://github.com/raftercli/rafter) — security CLI with
+- [rafter](https://github.com/Raftersecurity/rafter-cli) — security CLI with
   built-in secret scanning and AI agent policy enforcement
 
 This is a common issue with `.env` file variants — `.env-` bypasses the
@@ -263,7 +263,7 @@ reused elsewhere.
   pre-commit hooks
 - [trufflehog](https://github.com/trufflesecurity/trufflehog) — scans full
   Git history
-- [rafter](https://github.com/raftercli/rafter) — security CLI for
+- [rafter](https://github.com/Raftersecurity/rafter-cli) — security CLI for
   developers and AI coding agents
 
 Hope this helps — just flagging it so you can rotate the credentials. 🛡️


### PR DESCRIPTION
## Summary

- Fixes broken `github.com/raftercli/rafter` (404) → `github.com/Raftersecurity/rafter-cli` in README badges, badge gallery, and outreach disclosure drafts.
- First-click trust signal for security adopters evaluating Rafter.

## Context

Closed PR #70 (`rf-v85b`) was a consumer-perspective OS code review document. The review document itself was correctly closed (not landing in-repo), but the findings inside are valid. Mayor task `rf-b00i` extracted each finding into its own bead; this PR addresses the simplest of them — `rf-6epe`.

The other 20 findings are filed as separate beads (rf-z6sv, rf-jpqn, rf-hrtd, rf-p28d, rf-qrku, rf-wusc, rf-u98l, rf-gq4x, rf-shf2, rf-qzh9, rf-72sd, rf-896b, rf-9g4v, rf-ib9y, rf-mjbz, rf-bf85, rf-q1be, rf-ijcg, rf-y3xf, rf-53yl) and can be slung individually.

## Files

- `README.md` — 4 badge URL fixes (lines 3, 556, 561, 565)
- `badges/README.md` — 12 fixes (Markdown / HTML / reST snippets for 4 badge variants)
- `outreach-drafts.md` — 5 fixes in disclosure email templates

## Test plan

- [x] `git remote -v` confirms canonical URL is `Raftersecurity/rafter-cli`
- [x] No remaining `github.com/raftercli/rafter` references in any tracked file
- [x] Doc-only diff — no source / test / build changes