### PR TITLE
feat(rf-svn3): Cursor deep support — per-skill rules, sub-agent, full pre/post-tool hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Cursor deep support: per-skill rules + sub-agent + full pre/post-tool hooks** (Node + Python, rf-svn3 / rf-cia phase c). `rafter agent init --with-cursor` now ships Cursor to Claude-Code parity:
+  - Hooks at `~/.cursor/hooks.json` cover `preToolUse` + `postToolUse` + `beforeShellExecution` (was `beforeShellExecution` only). Idempotent across all three events; non-rafter entries preserved.
+  - Replaces the single consolidated `.cursor/rules/rafter-security.mdc` with **four per-skill rules** (`rafter.mdc`, `rafter-secure-design.mdc`, `rafter-code-review.mdc`, `rafter-skill-review.mdc`). Each rule's frontmatter description is reused verbatim from the skill's `SKILL.md` (trigger-first), `alwaysApply: false`. The legacy file is auto-removed on reinstall.
+  - Drops the rafter sub-agent at `.cursor/agents/rafter.md`, reusing the rf-q7j Claude-Code sub-agent body with the `tools:` line stripped (Cursor's frontmatter doesn't have it; tools inherit from parent).
+  - Backed by 13 new Node tests and 12 new Python tests. The `cursor.instructions` component now manages rules + sub-agent together for `rafter agent enable/disable`.
+
 ### Removed
 - **`rafter agent init --with-continue` no longer writes `~/.continue/settings.json`** (Node + Python, rf-cia): Continue.dev does not read `settings.json` and has no `hooks.PreToolUse`/`PostToolUse` field in its config schema (current versions use `config.yaml`, legacy uses `config.json`). The hook install was a silent no-op at runtime — files written, never consumed. Removed `installContinueDevHooks` from the Node init flow, `_continue_hooks` ComponentSpec from both Node and Python `rafter agent enable/disable` registries, and the matching test expectations. MCP install (`.continue/config.json` mcpServers entry) is unchanged. Continue.dev integration is now MCP-only — matches what `recipes/continue-dev.md` always claimed.
 

--- a/node/resources/agents/rafter.md
+++ b/node/resources/agents/rafter.md
@@ -1,0 +1,66 @@
+---
+name: rafter
+description: Use proactively to answer "is this safe / secure / production worthy?" Delegate when about to commit, push, open a PR, or mark a security-relevant task done; when a diff touches auth, credentials, secrets, user input, SQL, shell, file paths, deserialization, or crypto; when evaluating a destructive shell command before running it; or when reviewing a third-party skill, MCP server, or agent config before installing. Returns a structured finding list with severity, location, and a one-sentence fix.
+tools: Bash, Read, Grep
+---
+
+# Rafter — Security Sub-Agent
+
+You are Rafter, a security-focused sub-agent. The calling agent has handed you a security question and is waiting for a tight, structured verdict. You do not write code. You do not commit. You do not run scanners other than `rafter`.
+
+## Pick the right tier — do not stop at "local"
+
+Rafter ships three CLI tiers **and** four in-repo skills. They are NOT interchangeable. The local tier is the narrowest of all of them — secrets-only — and stopping there is the #1 way agents under-use rafter.
+
+### CLI tiers (run code through the scanner)
+
+1. **`rafter run`** (default mode) — remote SAST + SCA + secrets via the Rafter API. Real code analysis: dataflow, taint, vulnerable deps, crypto misuse, injection sinks. Needs `RAFTER_API_KEY`. **This is the default for "is this safe / secure / production worthy?".**
+2. **`rafter run --mode plus`** — agentic deep-dive on suspicious patterns. Slower, higher signal. Use when fast mode flags something worth investigating, or when stakes are high (auth, payments, ingress, crypto, anything user-data-shaped).
+3. **`rafter secrets [path]`** — local secrets only (regex + gitleaks for hardcoded API keys, tokens, private keys). Fast, offline, no key. **NOT a code security scan.** Will not find SQL injection, SSRF, auth bugs, deserialization, or logic flaws. Use only when no API key is available, or as a fast pre-check alongside `rafter run`.
+
+If `RAFTER_API_KEY` is unset, run `rafter secrets` and **say so explicitly in your verdict** — "secrets-only pass; full code analysis was skipped (no API key)." Do not claim the code was "scanned" without that qualification. Never silently downgrade.
+
+### Rafter skills (the questions the scanner can't ask)
+
+When the answer needs *judgment* — design choices, code-review questions, vetting an external asset — reach for a skill rather than (or in addition to) the CLI. Skills ship next to this sub-agent at `.claude/skills/<name>/SKILL.md`. `Read` only the one you need.
+
+- **`rafter`** — the tier router. The skill version of this guidance: same three CLI tiers plus a Choose-Your-Adventure for "scan code", "evaluate a command", "audit a plugin", "understand a finding". Start here when the right move isn't obvious. → `.claude/skills/rafter/SKILL.md`
+- **`rafter-secure-design`** — shift-left, design-phase questions *before the code exists*. Auth, data storage, API surface, ingestion, deployment, dependencies. Use at feature kickoff, architecture review, or when picking between primitives. → `.claude/skills/rafter-secure-design/SKILL.md`
+- **`rafter-code-review`** — structured review (OWASP / MITRE / ASVS) as questions, not audits. Pairs with `rafter run`: the scanner finds known-bad patterns, this skill asks the questions patterns miss. Use during PR review, refactoring risky modules, or pre-release hardening. → `.claude/skills/rafter-code-review/SKILL.md`
+- **`rafter-skill-review`** — REQUIRED before installing any third-party `SKILL.md`, MCP manifest, Cursor rule, or agent config. Installing a skill grants Read/Bash/network under your identity — `curl | sh` in a different costume. Wraps `rafter skill review`. → `.claude/skills/rafter-skill-review/SKILL.md`
+
+### Routing rule
+
+| Question shape | Reach for |
+|---|---|
+| "Is this code / diff / repo safe?" (existing code) | `rafter run` (CLI tier 1), pair with `rafter-code-review` skill for the judgment layer |
+| "Is this design / primitive / API shape safe?" (no code yet) | `rafter-secure-design` skill |
+| "Is this command safe to run?" | `rafter agent exec --dry-run -- <cmd>` |
+| "Is this skill / MCP / agent config safe to install?" | `rafter-skill-review` skill (do NOT install first) |
+| "Which rafter thing should I even use?" | `rafter` skill (tier router) |
+
+## Other rafter commands you can use
+
+- `rafter agent exec --dry-run -- <command>` — classify a shell command's risk tier before running it.
+- `rafter agent exec -- <command>` — wrap execution; blocks on critical, prompts on high.
+- `cat ~/.rafter/audit.jsonl` — recent security-relevant events on this machine (read-only inspection).
+
+## Protocol
+
+1. **Infer scope** from the caller's prompt: a path, a diff, a commit range, a shell command, a third-party config to install, a design sketch. If scope is ambiguous, default to scanning the current working directory.
+2. **Pick the right tool** using the routing table above. When unsure, `Read` `.claude/skills/rafter/SKILL.md` first — that's the tier router.
+3. **Run it.** Capture stdout/stderr. For skill-driven judgment work, walk the skill's checklist and capture findings the same way you would CLI output.
+4. **Report.** One short paragraph of verdict, then findings as a list:
+   - `severity` (critical / high / medium / low / info)
+   - `location` (`file:line` or command/snippet)
+   - `rule` or category (e.g. `hardcoded-secret`, `sql-injection`, `dangerous-shell`, `design:auth-primitive`, `skill:prompt-injection`)
+   - `fix` (one sentence — what the caller should change)
+   - If there are no findings: say so in one line and stop.
+
+## Hard rules
+
+- **Never** modify code, write files, run `git commit`, or open PRs. You are read-only.
+- **Never** invoke non-rafter scanners (no `npm audit`, no `safety`, no `trivy`). The caller can do that — your job is the rafter signal.
+- **Never** silently fall back to a weaker tier. If you couldn't run the tier the question called for, name the tier you ran and why.
+- **Never** install or load a third-party skill / MCP / agent asset on the caller's behalf. Vet via `rafter-skill-review` and return the verdict; the caller decides.
+- Be terse. The calling agent wants a verdict, not an essay.

--- a/node/resources/cursor-rules/rafter-code-review.mdc
+++ b/node/resources/cursor-rules/rafter-code-review.mdc
@@ -1,0 +1,14 @@
+---
+description: "REQUIRED before declaring a task done when the diff touches user input, SQL, shell, auth, credentials, file paths, serialization, or dependency surface. Walks OWASP/ASVS/MITRE questions the compiler and the test suite won't catch. Pair with `rafter run` on the same diff. A security-relevant task marked complete without both has been under-delivered — do not claim done."
+alwaysApply: false
+---
+
+# rafter-code-review — structured pre-merge review
+
+Pointer rule. Use the `rafter-code-review` skill at `.claude/skills/rafter-code-review/SKILL.md` BEFORE declaring done on any diff touching the surface listed above.
+
+- Read the matching sub-doc (web-app / api / llm / cli-library-iac).
+- Walk the OWASP / ASVS / MITRE questions the scanner can't ask.
+- Pair with `rafter run` on the same diff — the scanner finds known-bad patterns, this skill asks the questions patterns miss.
+
+A security-relevant task marked complete without BOTH the skill walkthrough and a `rafter run` pass has been under-delivered. Do not claim done until both are recorded.

--- a/node/resources/cursor-rules/rafter-secure-design.mdc
+++ b/node/resources/cursor-rules/rafter-secure-design.mdc
@@ -1,0 +1,14 @@
+---
+description: "REQUIRED before writing code for any feature touching auth, payments, credentials, tokens, sessions, file upload, user data, or data deletion. Invoke it, record answers inline in the design doc or PR description, then write the code. Skipping this is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. If the feature touches any of those surfaces and this hasn't run, the design is incomplete — do not proceed to implementation."
+alwaysApply: false
+---
+
+# rafter-secure-design — shift-left design review
+
+Pointer rule. Use the `rafter-secure-design` skill at `.claude/skills/rafter-secure-design/SKILL.md` BEFORE writing code for any feature on the surface listed above.
+
+- Read the matching sub-doc (auth / data-storage / api-design / ingestion / deployment / dependencies).
+- Each sub-doc is a set of questions a security engineer would ask at kickoff — answer them inline in the design or PR description.
+- Pair with `rafter-code-review` (mid-lifecycle) and `rafter run` (detection) once code exists.
+
+Skipping this skill on the listed surfaces is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. Do not proceed to implementation until it has run.

--- a/node/resources/cursor-rules/rafter-skill-review.mdc
+++ b/node/resources/cursor-rules/rafter-skill-review.mdc
@@ -1,0 +1,14 @@
+---
+description: "REQUIRED before copying any third-party SKILL.md, MCP manifest, Cursor rule, or agent config into this machine or forwarding one to a user. Installing a skill grants Read/Bash/network under your identity — this is `curl | sh` in a different costume. Do not install, load, recommend, or forward any third-party agent asset until this skill has vetted it. Bypassing this turns the agent into a delivery vector."
+alwaysApply: false
+---
+
+# rafter-skill-review — vet before you install
+
+Pointer rule. Use the `rafter-skill-review` skill at `.claude/skills/rafter-skill-review/SKILL.md` BEFORE installing or forwarding any third-party agent asset.
+
+- Run `rafter skill review <path-or-url>` against the SKILL.md / MCP manifest / Cursor rule / agent config.
+- Read the skill's sub-docs for the deeper review questions (telemetry, allowed-tools, network egress).
+- Do NOT install, load, recommend, or forward the asset until the skill has produced a verdict.
+
+Installing a skill grants Read/Bash/network under your identity — `curl | sh` in a different costume. Bypassing this turns the agent into a delivery vector.

--- a/node/resources/cursor-rules/rafter.mdc
+++ b/node/resources/cursor-rules/rafter.mdc
@@ -1,0 +1,15 @@
+---
+description: "Entry point for rafter. Invoke when a sub-skill is unclear, or when the task needs `rafter run` (remote SAST+SCA), `rafter secrets` (local secrets-only), `rafter audit`, policy checks, or command-risk evaluation. If a task is security-relevant and no rafter skill or CLI call has been made, invoke this before handing the task off — an un-evaluated \"done\" on security-relevant work is not done."
+alwaysApply: false
+---
+
+# rafter — security toolkit router
+
+Pointer rule. Use the `rafter` skill (full guidance at `.claude/skills/rafter/SKILL.md`, also installed as a Cursor sub-agent at `.cursor/agents/rafter.md`).
+
+- Run `rafter run` for the default tier — remote SAST + SCA + secrets. Needs `RAFTER_API_KEY`.
+- Run `rafter run --mode plus` for agentic deep-dive on suspicious patterns.
+- Run `rafter secrets <path>` for offline secrets-only (NOT a code security scan).
+- Run `rafter agent exec --dry-run -- <cmd>` to classify a shell command's risk before running it.
+
+If unsure which tier to pick, Read `.claude/skills/rafter/SKILL.md` and follow the routing table.

--- a/node/src/commands/agent/components.ts
+++ b/node/src/commands/agent/components.ts
@@ -410,6 +410,13 @@ function claudeCodeMcp(): ComponentSpec {
   };
 }
 
+/** Cursor hook events covered by rafter (rf-svn3). */
+const CURSOR_HOOK_EVENTS: { event: string; command: string }[] = [
+  { event: "preToolUse", command: "rafter hook pretool --format cursor" },
+  { event: "postToolUse", command: "rafter hook posttool --format cursor" },
+  { event: "beforeShellExecution", command: "rafter hook pretool --format cursor" },
+];
+
 function cursorHooks(): ComponentSpec {
   const home = os.homedir();
   const hooksPath = path.join(home, ".cursor", "hooks.json");
@@ -417,14 +424,16 @@ function cursorHooks(): ComponentSpec {
     id: "cursor.hooks",
     platform: "cursor",
     kind: "hooks",
-    description: "Cursor hooks (~/.cursor/hooks.json)",
+    description: "Cursor hooks: preToolUse + postToolUse + beforeShellExecution (~/.cursor/hooks.json)",
     detectDir: path.join(home, ".cursor"),
     path: hooksPath,
     isInstalled: () => {
       if (!fs.existsSync(hooksPath)) return false;
       const cfg = readJson(hooksPath);
-      for (const entry of cfg.hooks?.beforeShellExecution ?? []) {
-        if (String(entry?.command ?? "").includes("rafter hook pretool")) return true;
+      for (const { event } of CURSOR_HOOK_EVENTS) {
+        for (const entry of cfg.hooks?.[event] ?? []) {
+          if (String(entry?.command ?? "").includes("rafter hook")) return true;
+        }
       }
       return false;
     },
@@ -434,50 +443,127 @@ function cursorHooks(): ComponentSpec {
       const cfg: Record<string, any> = fs.existsSync(hooksPath) ? readJson(hooksPath) : {};
       cfg.version ??= 1;
       cfg.hooks ??= {};
-      cfg.hooks.beforeShellExecution ??= [];
-      cfg.hooks.beforeShellExecution = filterOutRafter(
-        cfg.hooks.beforeShellExecution,
-        (e) => String(e?.command ?? "").includes("rafter hook pretool"),
-      );
-      cfg.hooks.beforeShellExecution.push({
-        command: "rafter hook pretool --format cursor",
-        type: "command",
-        timeout: 5000,
-      });
+      for (const { event, command } of CURSOR_HOOK_EVENTS) {
+        cfg.hooks[event] ??= [];
+        cfg.hooks[event] = filterOutRafter(
+          cfg.hooks[event],
+          (e) => String(e?.command ?? "").includes("rafter hook"),
+        );
+        cfg.hooks[event].push({ command, type: "command", timeout: 5000 });
+      }
       writeJson(hooksPath, cfg);
     },
     uninstall: () => {
       if (!fs.existsSync(hooksPath)) return;
       const cfg = readJson(hooksPath);
-      if (cfg.hooks?.beforeShellExecution) {
-        cfg.hooks.beforeShellExecution = filterOutRafter(
-          cfg.hooks.beforeShellExecution,
-          (e) => String(e?.command ?? "").includes("rafter hook pretool"),
-        );
+      for (const { event } of CURSOR_HOOK_EVENTS) {
+        if (cfg.hooks?.[event]) {
+          cfg.hooks[event] = filterOutRafter(
+            cfg.hooks[event],
+            (e) => String(e?.command ?? "").includes("rafter hook"),
+          );
+        }
       }
       writeJson(hooksPath, cfg);
     },
   };
 }
 
+const CURSOR_RULE_SKILLS = [
+  "rafter",
+  "rafter-secure-design",
+  "rafter-code-review",
+  "rafter-skill-review",
+] as const;
+
+function cursorRuleSourceDir(): string | null {
+  // After build: dist/commands/agent/components.js -> ../../../resources/cursor-rules
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "..", "resources", "cursor-rules"),
+    path.resolve(__dirname, "..", "..", "resources", "cursor-rules"),
+  ];
+  return candidates.find((p) => fs.existsSync(p)) ?? null;
+}
+
+function cursorAgentSourceFile(): string | null {
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "..", "resources", "agents", "rafter.md"),
+    path.resolve(__dirname, "..", "..", "resources", "agents", "rafter.md"),
+  ];
+  return candidates.find((p) => fs.existsSync(p)) ?? null;
+}
+
+/**
+ * Cursor instructions = per-skill rules under .cursor/rules/ + the rafter
+ * sub-agent at .cursor/agents/rafter.md (rf-svn3). The legacy consolidated
+ * rafter-security.mdc was retired.
+ *
+ * `path` reports the rules dir for diagnostics; install/uninstall manage
+ * both rules and the sub-agent file together.
+ */
 function cursorInstructions(): ComponentSpec {
   const home = os.homedir();
-  const filePath = path.join(home, ".cursor", "rules", "rafter-security.mdc");
+  const rulesDir = path.join(home, ".cursor", "rules");
+  const agentPath = path.join(home, ".cursor", "agents", "rafter.md");
+  const legacyPath = path.join(rulesDir, "rafter-security.mdc");
   return {
     id: "cursor.instructions",
     platform: "cursor",
     kind: "instructions",
-    description: "Cursor global rule block (~/.cursor/rules/rafter-security.mdc)",
+    description: "Cursor per-skill rules + rafter sub-agent (~/.cursor/rules/, ~/.cursor/agents/rafter.md)",
     detectDir: path.join(home, ".cursor"),
-    path: filePath,
-    isInstalled: () => hasMarkerBlock(filePath),
-    install: () => injectInstructionFile(filePath),
+    path: rulesDir,
+    isInstalled: () => {
+      const rulesPresent = CURSOR_RULE_SKILLS.every((n) =>
+        fs.existsSync(path.join(rulesDir, `${n}.mdc`)),
+      );
+      return rulesPresent && fs.existsSync(agentPath);
+    },
+    install: () => {
+      fs.mkdirSync(rulesDir, { recursive: true });
+      const ruleSrc = cursorRuleSourceDir();
+      if (ruleSrc) {
+        for (const name of CURSOR_RULE_SKILLS) {
+          const src = path.join(ruleSrc, `${name}.mdc`);
+          if (fs.existsSync(src)) {
+            fs.copyFileSync(src, path.join(rulesDir, `${name}.mdc`));
+          }
+        }
+      }
+      // Migrate away from the legacy consolidated rule.
+      if (fs.existsSync(legacyPath)) {
+        try { fs.unlinkSync(legacyPath); } catch { /* best-effort */ }
+      }
+
+      const agentSrc = cursorAgentSourceFile();
+      if (agentSrc) {
+        fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+        const raw = fs.readFileSync(agentSrc, "utf-8");
+        const cursored = stripFrontmatterField(raw, "tools");
+        fs.writeFileSync(agentPath, cursored, "utf-8");
+      }
+    },
     uninstall: () => {
-      if (!fs.existsSync(filePath)) return;
-      // This file is ours — delete it rather than editing around the block.
-      fs.rmSync(filePath, { force: true });
+      for (const name of CURSOR_RULE_SKILLS) {
+        const p = path.join(rulesDir, `${name}.mdc`);
+        if (fs.existsSync(p)) fs.rmSync(p, { force: true });
+      }
+      if (fs.existsSync(legacyPath)) fs.rmSync(legacyPath, { force: true });
+      if (fs.existsSync(agentPath)) fs.rmSync(agentPath, { force: true });
     },
   };
+}
+
+/** Strip a single-line frontmatter field from a markdown file's frontmatter. */
+function stripFrontmatterField(content: string, field: string): string {
+  if (!content.startsWith("---\n")) return content;
+  const fmEnd = content.indexOf("\n---", 4);
+  if (fmEnd === -1) return content;
+  const frontmatter = content.slice(4, fmEnd);
+  const body = content.slice(fmEnd);
+  const re = new RegExp(`^${field}:\\s.*$`, "m");
+  const cleaned = frontmatter.replace(re, "").replace(/\n\n+/g, "\n").replace(/^\n/, "");
+  return `---\n${cleaned}${body}`;
 }
 
 function cursorMcp(): ComponentSpec {

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -51,7 +51,6 @@ function installGlobalInstructions(
     claudeCode?: boolean;
     codex?: boolean;
     gemini?: boolean;
-    cursor?: boolean;
   },
   root: string,
   scope: "user" | "project",
@@ -93,16 +92,10 @@ function installGlobalInstructions(
     }
   }
 
-  // Cursor — <root>/.cursor/rules/rafter-security.mdc
-  if (platforms.cursor) {
-    try {
-      const filePath = path.join(root, ".cursor", "rules", "rafter-security.mdc");
-      injectInstructionFile(filePath);
-      console.log(fmt.success(`Installed Rafter instructions to ${filePath}`));
-    } catch (e) {
-      console.log(fmt.warning(`Failed to write Cursor instructions: ${e}`));
-    }
-  }
+  // Cursor uses per-skill rules at <root>/.cursor/rules/<skill>.mdc and the
+  // rafter sub-agent at <root>/.cursor/agents/rafter.md (installed in the
+  // Cursor branch above). The consolidated rafter-security.mdc was retired
+  // in rf-svn3 in favor of per-skill rules with trigger-first descriptions.
 }
 
 function installClaudeCodeHooks(root: string): void {
@@ -215,6 +208,18 @@ function installCodexHooks(root: string): void {
   console.log(fmt.success(`Installed hooks to ${hooksPath}`));
 }
 
+/**
+ * Install Cursor hooks at <root>/.cursor/hooks.json.
+ *
+ * Covers the full pre/post-tool lifecycle plus shell-specific gating:
+ *   - preToolUse           — rafter classifies every tool call
+ *   - postToolUse          — rafter post-hook (audit, telemetry)
+ *   - beforeShellExecution — narrower complement; some Cursor versions
+ *                            fire this without firing preToolUse for shell.
+ *
+ * Idempotent — repeated installs do not duplicate rafter entries.
+ * Non-rafter entries (other tools' hooks, unrelated events) are preserved.
+ */
 function installCursorHooks(root: string): void {
   const cursorDir = path.join(root, ".cursor");
 
@@ -235,21 +240,126 @@ function installCursorHooks(root: string): void {
 
   if (!config.version) config.version = 1;
   if (!config.hooks) config.hooks = {};
-  if (!config.hooks.beforeShellExecution) config.hooks.beforeShellExecution = [];
 
-  // Remove existing rafter hooks
-  config.hooks.beforeShellExecution = config.hooks.beforeShellExecution.filter(
-    (entry: any) => !entry.command?.includes("rafter hook pretool")
-  );
+  const events: { event: string; command: string }[] = [
+    { event: "preToolUse", command: "rafter hook pretool --format cursor" },
+    { event: "postToolUse", command: "rafter hook posttool --format cursor" },
+    { event: "beforeShellExecution", command: "rafter hook pretool --format cursor" },
+  ];
 
-  config.hooks.beforeShellExecution.push({
-    command: "rafter hook pretool --format cursor",
-    type: "command",
-    timeout: 5000,
-  });
+  for (const { event, command } of events) {
+    if (!Array.isArray(config.hooks[event])) config.hooks[event] = [];
+    config.hooks[event] = config.hooks[event].filter(
+      (entry: any) => !entry?.command?.includes("rafter hook"),
+    );
+    config.hooks[event].push({ command, type: "command", timeout: 5000 });
+  }
 
   fs.writeFileSync(hooksPath, JSON.stringify(config, null, 2), "utf-8");
   console.log(fmt.success(`Installed hooks to ${hooksPath}`));
+}
+
+/** Skills shipped as both Cursor rules and (Claude Code / Codex / Gemini) skills. */
+const CURSOR_RULE_SKILLS = [
+  "rafter",
+  "rafter-secure-design",
+  "rafter-code-review",
+  "rafter-skill-review",
+] as const;
+
+/**
+ * Install per-skill Cursor rules at <root>/.cursor/rules/<skill>.mdc.
+ *
+ * One file per shipped skill. Each rule's frontmatter description is reused
+ * verbatim from the skill's SKILL.md frontmatter (trigger-first phrasing per
+ * rf-4ei / rf-8po) so Cursor surfaces it on the same triggers as Claude Code.
+ *
+ * Replaces the legacy consolidated `.cursor/rules/rafter-security.mdc` — that
+ * single file is no longer written by the Cursor install path.
+ */
+function installCursorRules(root: string): void {
+  const rulesDir = path.join(root, ".cursor", "rules");
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  // Resolve resources/cursor-rules relative to this module.
+  // After build: dist/commands/agent/init.js -> ../../../resources/cursor-rules
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "..", "resources", "cursor-rules"),
+    path.resolve(__dirname, "..", "..", "resources", "cursor-rules"),
+  ];
+  const sourceDir = candidates.find((p) => fs.existsSync(p));
+  if (!sourceDir) {
+    console.log(fmt.warning(`Cursor rule templates not found in resources/cursor-rules`));
+    return;
+  }
+
+  for (const name of CURSOR_RULE_SKILLS) {
+    const src = path.join(sourceDir, `${name}.mdc`);
+    const dest = path.join(rulesDir, `${name}.mdc`);
+    if (!fs.existsSync(src)) {
+      console.log(fmt.warning(`Cursor rule template missing: ${src}`));
+      continue;
+    }
+    fs.copyFileSync(src, dest);
+    console.log(fmt.success(`Installed Cursor rule to ${dest}`));
+  }
+
+  // Remove the legacy consolidated rule if present, so reinstall on top of
+  // an old layout migrates cleanly.
+  const legacy = path.join(rulesDir, "rafter-security.mdc");
+  if (fs.existsSync(legacy)) {
+    try {
+      fs.unlinkSync(legacy);
+      console.log(fmt.info(`Removed legacy ${legacy} (superseded by per-skill rules)`));
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/**
+ * Install Cursor sub-agent at <root>/.cursor/agents/rafter.md.
+ *
+ * Reuses the Claude-Code sub-agent body (rf-q7j) with one shape difference:
+ * Cursor's frontmatter has no `tools:` field — tools inherit from the parent
+ * agent. The hard rules in the body (no code modification, no commits) still
+ * apply, since Cursor relies on prompt-level constraints rather than
+ * structural restriction.
+ */
+function installCursorSubAgents(root: string): void {
+  const agentsDir = path.join(root, ".cursor", "agents");
+  fs.mkdirSync(agentsDir, { recursive: true });
+
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "..", "resources", "agents", "rafter.md"),
+    path.resolve(__dirname, "..", "..", "resources", "agents", "rafter.md"),
+  ];
+  const src = candidates.find((p) => fs.existsSync(p));
+  if (!src) {
+    console.log(fmt.warning(`Rafter sub-agent template not found in resources/agents`));
+    return;
+  }
+
+  const raw = fs.readFileSync(src, "utf-8");
+  const cursored = stripToolsFromFrontmatter(raw);
+
+  const dest = path.join(agentsDir, "rafter.md");
+  fs.writeFileSync(dest, cursored, "utf-8");
+  console.log(fmt.success(`Installed Cursor sub-agent to ${dest}`));
+}
+
+/** Strip the Claude-Code `tools:` line from sub-agent frontmatter — Cursor doesn't have it. */
+function stripToolsFromFrontmatter(content: string): string {
+  if (!content.startsWith("---\n")) return content;
+  const fmEnd = content.indexOf("\n---", 4);
+  if (fmEnd === -1) return content;
+  const frontmatter = content.slice(4, fmEnd);
+  const body = content.slice(fmEnd);
+  const cleaned = frontmatter
+    .split("\n")
+    .filter((line) => !/^tools:\s/.test(line))
+    .join("\n");
+  return `---\n${cleaned}${body}`;
 }
 
 function installGeminiHooks(root: string): void {
@@ -888,12 +998,14 @@ export function createInitCommand(): Command {
         }
       }
 
-      // Install Cursor MCP + hooks if opted in
+      // Install Cursor MCP + hooks + per-skill rules + sub-agent if opted in
       let cursorOk = false;
       if ((hasCursor || (opts.local && wantCursor)) && wantCursor) {
         try {
           cursorOk = installCursorMcp(root);
           installCursorHooks(root);
+          installCursorRules(root);
+          installCursorSubAgents(root);
           if (cursorOk && scope === "user") manager.set("agent.environments.cursor.enabled", true);
         } catch (e) {
           console.error(fmt.error(`Failed to install Cursor integration: ${e}`));
@@ -940,12 +1052,13 @@ export function createInitCommand(): Command {
         localUnsupported("Aider");
       }
 
-      // Install global instruction files for platforms that support them
+      // Install global instruction files for platforms that support them.
+      // Cursor is intentionally absent — Cursor uses per-skill rules + the
+      // rafter sub-agent installed in the Cursor branch above (rf-svn3).
       installGlobalInstructions({
         claudeCode: claudeCodeOk,
         codex: codexOk,
         gemini: geminiOk,
-        cursor: cursorOk,
       }, root, scope);
 
       console.log();

--- a/node/tests/cursor-deep-support.test.ts
+++ b/node/tests/cursor-deep-support.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { randomBytes } from "crypto";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
+
+const SHIPPED_SKILLS = [
+  "rafter",
+  "rafter-secure-design",
+  "rafter-code-review",
+  "rafter-skill-review",
+];
+
+function createTempDir(prefix: string): string {
+  const tmpDir = path.join(
+    os.tmpdir(),
+    `${prefix}-${Date.now()}-${randomBytes(6).toString("hex")}`,
+  );
+  fs.mkdirSync(tmpDir, { recursive: true });
+  return tmpDir;
+}
+
+function cleanupDir(dir: string) {
+  if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function runCli(args: string, homeDir: string) {
+  return spawnSync(`node ${CLI_ENTRY} ${args}`, {
+    cwd: PROJECT_ROOT,
+    encoding: "utf-8",
+    timeout: 15_000,
+    shell: true,
+    env: { ...process.env, HOME: homeDir, XDG_CONFIG_HOME: path.join(homeDir, ".config") },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+describe("Cursor deep support — rf-cia (rf-svn3)", () => {
+  let testHomeDir: string;
+
+  beforeEach(() => {
+    testHomeDir = createTempDir("rafter-cursor-deep");
+    fs.mkdirSync(path.join(testHomeDir, ".cursor"), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanupDir(testHomeDir);
+  });
+
+  // ── A. Hooks: extend coverage to preToolUse + postToolUse ───────────
+
+  describe("Cursor hooks — preToolUse + postToolUse", () => {
+    it("writes preToolUse, postToolUse, and beforeShellExecution entries", () => {
+      const result = runCli("agent init --with-cursor", testHomeDir);
+      expect(result.status).toBe(0);
+
+      const hooksPath = path.join(testHomeDir, ".cursor", "hooks.json");
+      const config = JSON.parse(fs.readFileSync(hooksPath, "utf-8"));
+      expect(config.version).toBe(1);
+      expect(Array.isArray(config.hooks.preToolUse)).toBe(true);
+      expect(Array.isArray(config.hooks.postToolUse)).toBe(true);
+      expect(Array.isArray(config.hooks.beforeShellExecution)).toBe(true);
+
+      const pre = config.hooks.preToolUse.find((e: any) => e.command?.includes("rafter"));
+      expect(pre).toBeDefined();
+      expect(pre.command).toBe("rafter hook pretool --format cursor");
+      expect(pre.type).toBe("command");
+
+      const post = config.hooks.postToolUse.find((e: any) => e.command?.includes("rafter"));
+      expect(post).toBeDefined();
+      expect(post.command).toBe("rafter hook posttool --format cursor");
+      expect(post.type).toBe("command");
+
+      const shell = config.hooks.beforeShellExecution.find((e: any) =>
+        e.command?.includes("rafter"),
+      );
+      expect(shell).toBeDefined();
+      expect(shell.command).toBe("rafter hook pretool --format cursor");
+    });
+
+    it("is idempotent — repeated install yields exactly one rafter entry per event", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      runCli("agent init --with-cursor", testHomeDir);
+      runCli("agent init --with-cursor", testHomeDir);
+
+      const config = JSON.parse(
+        fs.readFileSync(path.join(testHomeDir, ".cursor", "hooks.json"), "utf-8"),
+      );
+      for (const ev of ["preToolUse", "postToolUse", "beforeShellExecution"]) {
+        const rafterHooks = config.hooks[ev].filter((e: any) =>
+          e.command?.includes("rafter"),
+        );
+        expect(rafterHooks, `event ${ev}`).toHaveLength(1);
+      }
+    });
+
+    it("preserves pre-existing non-rafter hook entries across all events", () => {
+      const cursorDir = path.join(testHomeDir, ".cursor");
+      const hooksPath = path.join(cursorDir, "hooks.json");
+      fs.writeFileSync(
+        hooksPath,
+        JSON.stringify(
+          {
+            version: 1,
+            hooks: {
+              preToolUse: [{ command: "other pre", type: "command" }],
+              postToolUse: [{ command: "other post", type: "command" }],
+              beforeShellExecution: [{ command: "other shell", type: "command" }],
+              afterFileEdit: [{ command: "other edit", type: "command" }],
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      runCli("agent init --with-cursor", testHomeDir);
+
+      const config = JSON.parse(fs.readFileSync(hooksPath, "utf-8"));
+      const flatten = (event: string) =>
+        (config.hooks[event] || []).map((e: any) => e.command).filter(Boolean);
+      expect(flatten("preToolUse")).toContain("other pre");
+      expect(flatten("postToolUse")).toContain("other post");
+      expect(flatten("beforeShellExecution")).toContain("other shell");
+      // Untouched event stays.
+      expect(flatten("afterFileEdit")).toEqual(["other edit"]);
+    });
+  });
+
+  // ── B. Per-skill rules ──────────────────────────────────────────────
+
+  describe("Cursor rules — per-skill .mdc files", () => {
+    it("writes one .mdc per shipped skill under .cursor/rules/", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const rulesDir = path.join(testHomeDir, ".cursor", "rules");
+      for (const name of SHIPPED_SKILLS) {
+        const p = path.join(rulesDir, `${name}.mdc`);
+        expect(fs.existsSync(p), `missing ${p}`).toBe(true);
+      }
+    });
+
+    it("each rule has frontmatter with description + alwaysApply: false", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const rulesDir = path.join(testHomeDir, ".cursor", "rules");
+      for (const name of SHIPPED_SKILLS) {
+        const content = fs.readFileSync(path.join(rulesDir, `${name}.mdc`), "utf-8");
+        expect(content.startsWith("---\n"), `${name}: must start with frontmatter`).toBe(true);
+        const fmEnd = content.indexOf("\n---", 4);
+        expect(fmEnd, `${name}: no closing frontmatter`).toBeGreaterThan(0);
+        const frontmatter = content.slice(4, fmEnd);
+        expect(frontmatter, `${name}: alwaysApply must be false`).toMatch(
+          /alwaysApply:\s*false/,
+        );
+        expect(frontmatter, `${name}: description must be present`).toMatch(/description:\s*"/);
+      }
+    });
+
+    it("each rule description is action-forcing (REQUIRED/Use/Invoke/Entry/etc.)", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const rulesDir = path.join(testHomeDir, ".cursor", "rules");
+      for (const name of SHIPPED_SKILLS) {
+        const content = fs.readFileSync(path.join(rulesDir, `${name}.mdc`), "utf-8");
+        const m = content.match(/description:\s*"([^"]+)"/);
+        expect(m, `${name}: description regex match`).toBeTruthy();
+        const desc = (m && m[1]) || "";
+        expect(desc.length, `${name}: description nonempty`).toBeGreaterThan(20);
+        // Trigger-first phrasing as per rf-4ei/rf-8po: starts with an
+        // imperative or action-forcing token.
+        expect(
+          /^(REQUIRED|Use|Invoke|Entry|Run|Read|Stop)/.test(desc),
+          `${name}: description must be action-forcing, got: ${desc.slice(0, 40)}`,
+        ).toBe(true);
+      }
+    });
+
+    it("does not write the legacy consolidated rafter-security.mdc", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const legacy = path.join(testHomeDir, ".cursor", "rules", "rafter-security.mdc");
+      expect(fs.existsSync(legacy)).toBe(false);
+    });
+
+    it("idempotent — repeated install does not duplicate or corrupt rules", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const before: Record<string, string> = {};
+      const rulesDir = path.join(testHomeDir, ".cursor", "rules");
+      for (const name of SHIPPED_SKILLS) {
+        before[name] = fs.readFileSync(path.join(rulesDir, `${name}.mdc`), "utf-8");
+      }
+      runCli("agent init --with-cursor", testHomeDir);
+      for (const name of SHIPPED_SKILLS) {
+        const after = fs.readFileSync(path.join(rulesDir, `${name}.mdc`), "utf-8");
+        expect(after).toBe(before[name]);
+      }
+    });
+
+    it("--local writes rules under <cwd>/.cursor/rules/", () => {
+      // Use testHomeDir as the cwd for --local install.
+      const result = spawnSync(`node ${CLI_ENTRY} agent init --local --with-cursor`, {
+        cwd: testHomeDir,
+        encoding: "utf-8",
+        timeout: 15_000,
+        shell: true,
+        env: { ...process.env, HOME: testHomeDir },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      expect(result.status).toBe(0);
+      for (const name of SHIPPED_SKILLS) {
+        const p = path.join(testHomeDir, ".cursor", "rules", `${name}.mdc`);
+        expect(fs.existsSync(p), `local: missing ${p}`).toBe(true);
+      }
+    });
+  });
+
+  // ── C. Sub-agent: .cursor/agents/rafter.md ──────────────────────────
+
+  describe("Cursor sub-agent — .cursor/agents/rafter.md", () => {
+    it("writes the rafter sub-agent to .cursor/agents/rafter.md", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const agentPath = path.join(testHomeDir, ".cursor", "agents", "rafter.md");
+      expect(fs.existsSync(agentPath)).toBe(true);
+    });
+
+    it("frontmatter has name + description but no `tools:` field", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const agentPath = path.join(testHomeDir, ".cursor", "agents", "rafter.md");
+      const content = fs.readFileSync(agentPath, "utf-8");
+      expect(content.startsWith("---\n")).toBe(true);
+      const fmEnd = content.indexOf("\n---", 4);
+      const frontmatter = content.slice(4, fmEnd);
+      expect(frontmatter).toMatch(/name:\s*rafter/);
+      expect(frontmatter).toMatch(/description:\s*\S/);
+      // Cursor frontmatter has no tools: field — strip it from the source if present.
+      expect(frontmatter).not.toMatch(/^tools:/m);
+    });
+
+    it("body references rafter run / rafter run --mode plus / rafter secrets", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const content = fs.readFileSync(
+        path.join(testHomeDir, ".cursor", "agents", "rafter.md"),
+        "utf-8",
+      );
+      expect(content).toContain("rafter run");
+      expect(content).toContain("--mode plus");
+      expect(content).toContain("rafter secrets");
+    });
+
+    it("idempotent — repeated install yields identical file", () => {
+      runCli("agent init --with-cursor", testHomeDir);
+      const agentPath = path.join(testHomeDir, ".cursor", "agents", "rafter.md");
+      const before = fs.readFileSync(agentPath, "utf-8");
+      runCli("agent init --with-cursor", testHomeDir);
+      const after = fs.readFileSync(agentPath, "utf-8");
+      expect(after).toBe(before);
+    });
+  });
+});

--- a/node/tests/platform-integration.test.ts
+++ b/node/tests/platform-integration.test.ts
@@ -1382,21 +1382,20 @@ describe("Platform Integration — MCP Installs via CLI", () => {
       expect(hook.timeout).toBe(5000);
     });
 
-    it("should install global instruction file to ~/.cursor/rules/rafter-security.mdc", () => {
+    it("should install per-skill rule files under ~/.cursor/rules/ (rf-svn3)", () => {
       fs.mkdirSync(path.join(testHomeDir, ".cursor"), { recursive: true });
 
       runCli("agent init --with-cursor", testHomeDir);
 
-      const instructionPath = path.join(
-        testHomeDir, ".cursor", "rules", "rafter-security.mdc"
-      );
-      expect(fs.existsSync(instructionPath)).toBe(true);
+      // The legacy consolidated rafter-security.mdc was retired in rf-svn3 in
+      // favor of per-skill rules with trigger-first descriptions.
+      const legacy = path.join(testHomeDir, ".cursor", "rules", "rafter-security.mdc");
+      expect(fs.existsSync(legacy)).toBe(false);
 
-      const content = fs.readFileSync(instructionPath, "utf-8");
-      expect(content).toContain("<!-- rafter:start -->");
-      expect(content).toContain("<!-- rafter:end -->");
-      expect(content).toContain("rafter-secure-design");
-      expect(content).toContain("rafter-code-review");
+      for (const name of ["rafter", "rafter-secure-design", "rafter-code-review", "rafter-skill-review"]) {
+        const p = path.join(testHomeDir, ".cursor", "rules", `${name}.mdc`);
+        expect(fs.existsSync(p), `missing ${p}`).toBe(true);
+      }
     });
 
     it("should deduplicate hooks on repeated installs", () => {
@@ -1532,17 +1531,21 @@ describe("Platform Integration — MCP Installs via CLI", () => {
       expect(starts).toBe(1);
     });
 
-    it("should not duplicate rafter block in Cursor rules on repeated installs", () => {
+    it("should not duplicate per-skill rule files in Cursor rules on repeated installs (rf-svn3)", () => {
       fs.mkdirSync(path.join(testHomeDir, ".cursor"), { recursive: true });
 
       runCli("agent init --with-cursor", testHomeDir);
       runCli("agent init --with-cursor", testHomeDir);
 
-      const content = fs.readFileSync(
-        path.join(testHomeDir, ".cursor", "rules", "rafter-security.mdc"), "utf-8"
-      );
-      const starts = (content.match(/<!-- rafter:start -->/g) || []).length;
-      expect(starts).toBe(1);
+      const rulesDir = path.join(testHomeDir, ".cursor", "rules");
+      const files = fs.readdirSync(rulesDir).sort();
+      // Exactly the four shipped per-skill rules — no duplicates, no legacy.
+      expect(files).toEqual([
+        "rafter-code-review.mdc",
+        "rafter-secure-design.mdc",
+        "rafter-skill-review.mdc",
+        "rafter.mdc",
+      ]);
     });
   });
 
@@ -1593,11 +1596,18 @@ describe("Platform Integration — MCP Installs via CLI", () => {
       expect(geminiSettings.hooks.BeforeTool).toBeDefined();
       expect(geminiSettings.hooks.AfterTool).toBeDefined();
 
-      // ── Cursor: MCP + hooks + instructions ──
+      // ── Cursor: MCP + hooks + per-skill rules + sub-agent (rf-svn3) ──
       expect(fs.existsSync(path.join(testHomeDir, ".cursor", "mcp.json"))).toBe(true);
       expect(fs.existsSync(path.join(testHomeDir, ".cursor", "hooks.json"))).toBe(true);
-      const cursorInstructions = path.join(testHomeDir, ".cursor", "rules", "rafter-security.mdc");
-      expect(fs.existsSync(cursorInstructions)).toBe(true);
+      for (const name of ["rafter", "rafter-secure-design", "rafter-code-review", "rafter-skill-review"]) {
+        expect(
+          fs.existsSync(path.join(testHomeDir, ".cursor", "rules", `${name}.mdc`)),
+          `cursor rule missing: ${name}`,
+        ).toBe(true);
+      }
+      expect(
+        fs.existsSync(path.join(testHomeDir, ".cursor", "agents", "rafter.md")),
+      ).toBe(true);
 
       // ── Windsurf: MCP + hooks ──
       expect(fs.existsSync(path.join(testHomeDir, ".codeium", "windsurf", "mcp_config.json"))).toBe(true);

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -265,13 +265,12 @@ def _install_global_instructions(
         except Exception as e:
             rprint(fmt.warning(f"Failed to write Gemini instructions: {e}"))
 
-    if cursor:
-        try:
-            file_path = root / ".cursor" / "rules" / "rafter-security.mdc"
-            _inject_instruction_file(file_path)
-            rprint(fmt.success(f"Installed Rafter instructions to {file_path}"))
-        except Exception as e:
-            rprint(fmt.warning(f"Failed to write Cursor instructions: {e}"))
+    # Cursor uses per-skill rules at <root>/.cursor/rules/<skill>.mdc plus
+    # the rafter sub-agent at <root>/.cursor/agents/rafter.md. Both are
+    # installed in the Cursor branch of init() — see _install_cursor_rules
+    # and _install_cursor_subagents (rf-svn3). The legacy consolidated
+    # rafter-security.mdc was retired.
+    _ = cursor  # parameter kept for call-site compatibility
 
 
 def _install_openclaw_skill() -> tuple[bool, str, str, str]:
@@ -433,6 +432,125 @@ def _install_gemini_mcp(root: Path) -> bool:
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
     rprint(fmt.success(f"Installed Rafter MCP server to {settings_path}"))
     return True
+
+
+# Cursor hook events covered by rafter (rf-svn3).
+_CURSOR_HOOK_EVENTS: tuple[tuple[str, str], ...] = (
+    ("preToolUse", "rafter hook pretool --format cursor"),
+    ("postToolUse", "rafter hook posttool --format cursor"),
+    ("beforeShellExecution", "rafter hook pretool --format cursor"),
+)
+
+# Skills shipped as both Cursor rules and Claude Code / Codex / Gemini skills.
+_CURSOR_RULE_SKILLS: tuple[str, ...] = (
+    "rafter",
+    "rafter-secure-design",
+    "rafter-code-review",
+    "rafter-skill-review",
+)
+
+
+def _install_cursor_hooks(root: Path) -> None:
+    """Install Cursor hooks at <root>/.cursor/hooks.json.
+
+    Covers preToolUse + postToolUse + beforeShellExecution. Idempotent —
+    repeated installs do not duplicate rafter entries. Non-rafter hook
+    entries are preserved.
+    """
+    cursor_dir = root / ".cursor"
+    cursor_dir.mkdir(parents=True, exist_ok=True)
+    hooks_path = cursor_dir / "hooks.json"
+
+    config: dict[str, Any] = {}
+    if hooks_path.exists():
+        try:
+            config = json.loads(hooks_path.read_text())
+        except (json.JSONDecodeError, ValueError):
+            rprint(fmt.warning("Existing Cursor hooks.json was unreadable, creating new one"))
+
+    config.setdefault("version", 1)
+    config.setdefault("hooks", {})
+
+    for event, command in _CURSOR_HOOK_EVENTS:
+        entries = config["hooks"].get(event)
+        if not isinstance(entries, list):
+            entries = []
+        entries = [
+            e for e in entries
+            if "rafter hook" not in (e or {}).get("command", "")
+        ]
+        entries.append({"command": command, "type": "command", "timeout": 5000})
+        config["hooks"][event] = entries
+
+    hooks_path.write_text(json.dumps(config, indent=2) + "\n")
+    rprint(fmt.success(f"Installed hooks to {hooks_path}"))
+
+
+def _install_cursor_rules(root: Path) -> None:
+    """Install per-skill Cursor rule files at <root>/.cursor/rules/<skill>.mdc.
+
+    Replaces the legacy consolidated `.cursor/rules/rafter-security.mdc`.
+    Each rule is a static template shipped under
+    `rafter_cli/resources/cursor-rules/`.
+    """
+    rules_dir = root / ".cursor" / "rules"
+    rules_dir.mkdir(parents=True, exist_ok=True)
+
+    res = importlib.resources.files("rafter_cli.resources")
+    for name in _CURSOR_RULE_SKILLS:
+        try:
+            content = res.joinpath("cursor-rules", f"{name}.mdc").read_text(encoding="utf-8")
+        except Exception:
+            rprint(fmt.warning(f"Cursor rule template missing: {name}.mdc"))
+            continue
+        dest = rules_dir / f"{name}.mdc"
+        dest.write_text(content, encoding="utf-8")
+        rprint(fmt.success(f"Installed Cursor rule to {dest}"))
+
+    # Migrate away from the legacy consolidated rule on reinstall.
+    legacy = rules_dir / "rafter-security.mdc"
+    if legacy.exists():
+        try:
+            legacy.unlink()
+            rprint(fmt.info(f"Removed legacy {legacy} (superseded by per-skill rules)"))
+        except OSError:
+            pass
+
+
+def _install_cursor_subagents(root: Path) -> None:
+    """Install the Cursor sub-agent at <root>/.cursor/agents/rafter.md.
+
+    Reuses the rf-q7j Claude-Code sub-agent body, with Cursor-shape
+    frontmatter (no `tools:` field — tools inherit from parent agent).
+    """
+    agents_dir = root / ".cursor" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+
+    res = importlib.resources.files("rafter_cli.resources")
+    try:
+        raw = res.joinpath("agents", "rafter.md").read_text(encoding="utf-8")
+    except Exception:
+        rprint(fmt.warning("Rafter sub-agent template not found in resources/agents/"))
+        return
+
+    cursored = _strip_frontmatter_field(raw, "tools")
+    dest = agents_dir / "rafter.md"
+    dest.write_text(cursored, encoding="utf-8")
+    rprint(fmt.success(f"Installed Cursor sub-agent to {dest}"))
+
+
+def _strip_frontmatter_field(content: str, field: str) -> str:
+    """Strip a single-line frontmatter field from a markdown file's frontmatter."""
+    if not content.startswith("---\n"):
+        return content
+    fm_end = content.find("\n---", 4)
+    if fm_end == -1:
+        return content
+    frontmatter = content[4:fm_end]
+    body = content[fm_end:]
+    pattern = re.compile(rf"^{re.escape(field)}:\s.*$\n?", re.MULTILINE)
+    cleaned = pattern.sub("", frontmatter)
+    return f"---\n{cleaned}{body}"
 
 
 def _install_cursor_mcp(root: Path) -> bool:
@@ -757,11 +875,14 @@ def init(
         except Exception as e:
             rprint(fmt.error(f"Failed to install Gemini CLI integration: {e}"))
 
-    # Install Cursor MCP if opted in
+    # Install Cursor MCP + hooks + per-skill rules + sub-agent if opted in
     cursor_ok = False
     if (has_cursor or (local and want_cursor)) and want_cursor:
         try:
             cursor_ok = _install_cursor_mcp(root)
+            _install_cursor_hooks(root)
+            _install_cursor_rules(root)
+            _install_cursor_subagents(root)
             if cursor_ok and scope == "user":
                 manager.set("agent.environments.cursor.enabled", True)
         except Exception as e:

--- a/python/rafter_cli/resources/agents/rafter.md
+++ b/python/rafter_cli/resources/agents/rafter.md
@@ -1,0 +1,66 @@
+---
+name: rafter
+description: Use proactively to answer "is this safe / secure / production worthy?" Delegate when about to commit, push, open a PR, or mark a security-relevant task done; when a diff touches auth, credentials, secrets, user input, SQL, shell, file paths, deserialization, or crypto; when evaluating a destructive shell command before running it; or when reviewing a third-party skill, MCP server, or agent config before installing. Returns a structured finding list with severity, location, and a one-sentence fix.
+tools: Bash, Read, Grep
+---
+
+# Rafter — Security Sub-Agent
+
+You are Rafter, a security-focused sub-agent. The calling agent has handed you a security question and is waiting for a tight, structured verdict. You do not write code. You do not commit. You do not run scanners other than `rafter`.
+
+## Pick the right tier — do not stop at "local"
+
+Rafter ships three CLI tiers **and** four in-repo skills. They are NOT interchangeable. The local tier is the narrowest of all of them — secrets-only — and stopping there is the #1 way agents under-use rafter.
+
+### CLI tiers (run code through the scanner)
+
+1. **`rafter run`** (default mode) — remote SAST + SCA + secrets via the Rafter API. Real code analysis: dataflow, taint, vulnerable deps, crypto misuse, injection sinks. Needs `RAFTER_API_KEY`. **This is the default for "is this safe / secure / production worthy?".**
+2. **`rafter run --mode plus`** — agentic deep-dive on suspicious patterns. Slower, higher signal. Use when fast mode flags something worth investigating, or when stakes are high (auth, payments, ingress, crypto, anything user-data-shaped).
+3. **`rafter secrets [path]`** — local secrets only (regex + gitleaks for hardcoded API keys, tokens, private keys). Fast, offline, no key. **NOT a code security scan.** Will not find SQL injection, SSRF, auth bugs, deserialization, or logic flaws. Use only when no API key is available, or as a fast pre-check alongside `rafter run`.
+
+If `RAFTER_API_KEY` is unset, run `rafter secrets` and **say so explicitly in your verdict** — "secrets-only pass; full code analysis was skipped (no API key)." Do not claim the code was "scanned" without that qualification. Never silently downgrade.
+
+### Rafter skills (the questions the scanner can't ask)
+
+When the answer needs *judgment* — design choices, code-review questions, vetting an external asset — reach for a skill rather than (or in addition to) the CLI. Skills ship next to this sub-agent at `.claude/skills/<name>/SKILL.md`. `Read` only the one you need.
+
+- **`rafter`** — the tier router. The skill version of this guidance: same three CLI tiers plus a Choose-Your-Adventure for "scan code", "evaluate a command", "audit a plugin", "understand a finding". Start here when the right move isn't obvious. → `.claude/skills/rafter/SKILL.md`
+- **`rafter-secure-design`** — shift-left, design-phase questions *before the code exists*. Auth, data storage, API surface, ingestion, deployment, dependencies. Use at feature kickoff, architecture review, or when picking between primitives. → `.claude/skills/rafter-secure-design/SKILL.md`
+- **`rafter-code-review`** — structured review (OWASP / MITRE / ASVS) as questions, not audits. Pairs with `rafter run`: the scanner finds known-bad patterns, this skill asks the questions patterns miss. Use during PR review, refactoring risky modules, or pre-release hardening. → `.claude/skills/rafter-code-review/SKILL.md`
+- **`rafter-skill-review`** — REQUIRED before installing any third-party `SKILL.md`, MCP manifest, Cursor rule, or agent config. Installing a skill grants Read/Bash/network under your identity — `curl | sh` in a different costume. Wraps `rafter skill review`. → `.claude/skills/rafter-skill-review/SKILL.md`
+
+### Routing rule
+
+| Question shape | Reach for |
+|---|---|
+| "Is this code / diff / repo safe?" (existing code) | `rafter run` (CLI tier 1), pair with `rafter-code-review` skill for the judgment layer |
+| "Is this design / primitive / API shape safe?" (no code yet) | `rafter-secure-design` skill |
+| "Is this command safe to run?" | `rafter agent exec --dry-run -- <cmd>` |
+| "Is this skill / MCP / agent config safe to install?" | `rafter-skill-review` skill (do NOT install first) |
+| "Which rafter thing should I even use?" | `rafter` skill (tier router) |
+
+## Other rafter commands you can use
+
+- `rafter agent exec --dry-run -- <command>` — classify a shell command's risk tier before running it.
+- `rafter agent exec -- <command>` — wrap execution; blocks on critical, prompts on high.
+- `cat ~/.rafter/audit.jsonl` — recent security-relevant events on this machine (read-only inspection).
+
+## Protocol
+
+1. **Infer scope** from the caller's prompt: a path, a diff, a commit range, a shell command, a third-party config to install, a design sketch. If scope is ambiguous, default to scanning the current working directory.
+2. **Pick the right tool** using the routing table above. When unsure, `Read` `.claude/skills/rafter/SKILL.md` first — that's the tier router.
+3. **Run it.** Capture stdout/stderr. For skill-driven judgment work, walk the skill's checklist and capture findings the same way you would CLI output.
+4. **Report.** One short paragraph of verdict, then findings as a list:
+   - `severity` (critical / high / medium / low / info)
+   - `location` (`file:line` or command/snippet)
+   - `rule` or category (e.g. `hardcoded-secret`, `sql-injection`, `dangerous-shell`, `design:auth-primitive`, `skill:prompt-injection`)
+   - `fix` (one sentence — what the caller should change)
+   - If there are no findings: say so in one line and stop.
+
+## Hard rules
+
+- **Never** modify code, write files, run `git commit`, or open PRs. You are read-only.
+- **Never** invoke non-rafter scanners (no `npm audit`, no `safety`, no `trivy`). The caller can do that — your job is the rafter signal.
+- **Never** silently fall back to a weaker tier. If you couldn't run the tier the question called for, name the tier you ran and why.
+- **Never** install or load a third-party skill / MCP / agent asset on the caller's behalf. Vet via `rafter-skill-review` and return the verdict; the caller decides.
+- Be terse. The calling agent wants a verdict, not an essay.

--- a/python/rafter_cli/resources/cursor-rules/rafter-code-review.mdc
+++ b/python/rafter_cli/resources/cursor-rules/rafter-code-review.mdc
@@ -1,0 +1,14 @@
+---
+description: "REQUIRED before declaring a task done when the diff touches user input, SQL, shell, auth, credentials, file paths, serialization, or dependency surface. Walks OWASP/ASVS/MITRE questions the compiler and the test suite won't catch. Pair with `rafter run` on the same diff. A security-relevant task marked complete without both has been under-delivered — do not claim done."
+alwaysApply: false
+---
+
+# rafter-code-review — structured pre-merge review
+
+Pointer rule. Use the `rafter-code-review` skill at `.claude/skills/rafter-code-review/SKILL.md` BEFORE declaring done on any diff touching the surface listed above.
+
+- Read the matching sub-doc (web-app / api / llm / cli-library-iac).
+- Walk the OWASP / ASVS / MITRE questions the scanner can't ask.
+- Pair with `rafter run` on the same diff — the scanner finds known-bad patterns, this skill asks the questions patterns miss.
+
+A security-relevant task marked complete without BOTH the skill walkthrough and a `rafter run` pass has been under-delivered. Do not claim done until both are recorded.

--- a/python/rafter_cli/resources/cursor-rules/rafter-secure-design.mdc
+++ b/python/rafter_cli/resources/cursor-rules/rafter-secure-design.mdc
@@ -1,0 +1,14 @@
+---
+description: "REQUIRED before writing code for any feature touching auth, payments, credentials, tokens, sessions, file upload, user data, or data deletion. Invoke it, record answers inline in the design doc or PR description, then write the code. Skipping this is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. If the feature touches any of those surfaces and this hasn't run, the design is incomplete — do not proceed to implementation."
+alwaysApply: false
+---
+
+# rafter-secure-design — shift-left design review
+
+Pointer rule. Use the `rafter-secure-design` skill at `.claude/skills/rafter-secure-design/SKILL.md` BEFORE writing code for any feature on the surface listed above.
+
+- Read the matching sub-doc (auth / data-storage / api-design / ingestion / deployment / dependencies).
+- Each sub-doc is a set of questions a security engineer would ask at kickoff — answer them inline in the design or PR description.
+- Pair with `rafter-code-review` (mid-lifecycle) and `rafter run` (detection) once code exists.
+
+Skipping this skill on the listed surfaces is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. Do not proceed to implementation until it has run.

--- a/python/rafter_cli/resources/cursor-rules/rafter-skill-review.mdc
+++ b/python/rafter_cli/resources/cursor-rules/rafter-skill-review.mdc
@@ -1,0 +1,14 @@
+---
+description: "REQUIRED before copying any third-party SKILL.md, MCP manifest, Cursor rule, or agent config into this machine or forwarding one to a user. Installing a skill grants Read/Bash/network under your identity — this is `curl | sh` in a different costume. Do not install, load, recommend, or forward any third-party agent asset until this skill has vetted it. Bypassing this turns the agent into a delivery vector."
+alwaysApply: false
+---
+
+# rafter-skill-review — vet before you install
+
+Pointer rule. Use the `rafter-skill-review` skill at `.claude/skills/rafter-skill-review/SKILL.md` BEFORE installing or forwarding any third-party agent asset.
+
+- Run `rafter skill review <path-or-url>` against the SKILL.md / MCP manifest / Cursor rule / agent config.
+- Read the skill's sub-docs for the deeper review questions (telemetry, allowed-tools, network egress).
+- Do NOT install, load, recommend, or forward the asset until the skill has produced a verdict.
+
+Installing a skill grants Read/Bash/network under your identity — `curl | sh` in a different costume. Bypassing this turns the agent into a delivery vector.

--- a/python/rafter_cli/resources/cursor-rules/rafter.mdc
+++ b/python/rafter_cli/resources/cursor-rules/rafter.mdc
@@ -1,0 +1,15 @@
+---
+description: "Entry point for rafter. Invoke when a sub-skill is unclear, or when the task needs `rafter run` (remote SAST+SCA), `rafter secrets` (local secrets-only), `rafter audit`, policy checks, or command-risk evaluation. If a task is security-relevant and no rafter skill or CLI call has been made, invoke this before handing the task off — an un-evaluated \"done\" on security-relevant work is not done."
+alwaysApply: false
+---
+
+# rafter — security toolkit router
+
+Pointer rule. Use the `rafter` skill (full guidance at `.claude/skills/rafter/SKILL.md`, also installed as a Cursor sub-agent at `.cursor/agents/rafter.md`).
+
+- Run `rafter run` for the default tier — remote SAST + SCA + secrets. Needs `RAFTER_API_KEY`.
+- Run `rafter run --mode plus` for agentic deep-dive on suspicious patterns.
+- Run `rafter secrets <path>` for offline secrets-only (NOT a code security scan).
+- Run `rafter agent exec --dry-run -- <cmd>` to classify a shell command's risk before running it.
+
+If unsure which tier to pick, Read `.claude/skills/rafter/SKILL.md` and follow the routing table.

--- a/python/tests/test_agent_init.py
+++ b/python/tests/test_agent_init.py
@@ -734,3 +734,171 @@ class TestContinueDevHooksPruned:
             assert any(s.get("name") == "rafter" for s in servers)
         else:
             assert "rafter" in (servers or {})
+
+
+# ── Cursor deep support (rf-svn3) ────────────────────────────────────
+
+# Skills shipped as both Cursor rules and skills package — must mirror
+# AGENT_SKILLS_CURSOR in rafter_cli/commands/agent.py.
+_CURSOR_SHIPPED_SKILLS = (
+    "rafter",
+    "rafter-secure-design",
+    "rafter-code-review",
+    "rafter-skill-review",
+)
+
+
+class TestInstallCursorHooks:
+    """Cursor hooks must cover preToolUse, postToolUse, and beforeShellExecution."""
+
+    def test_writes_all_three_events_from_scratch(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_hooks
+        _install_cursor_hooks(tmp_path)
+
+        hooks_path = tmp_path / ".cursor" / "hooks.json"
+        assert hooks_path.exists()
+        cfg = json.loads(hooks_path.read_text())
+        assert cfg["version"] == 1
+        for event in ("preToolUse", "postToolUse", "beforeShellExecution"):
+            entries = cfg["hooks"][event]
+            assert isinstance(entries, list) and entries, f"missing {event}"
+
+        pre = next(e for e in cfg["hooks"]["preToolUse"] if "rafter" in e.get("command", ""))
+        assert pre["command"] == "rafter hook pretool --format cursor"
+        post = next(e for e in cfg["hooks"]["postToolUse"] if "rafter" in e.get("command", ""))
+        assert post["command"] == "rafter hook posttool --format cursor"
+
+    def test_idempotent_no_duplicates(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_hooks
+        _install_cursor_hooks(tmp_path)
+        _install_cursor_hooks(tmp_path)
+        _install_cursor_hooks(tmp_path)
+
+        cfg = json.loads((tmp_path / ".cursor" / "hooks.json").read_text())
+        for event in ("preToolUse", "postToolUse", "beforeShellExecution"):
+            rafter_hooks = [
+                e for e in cfg["hooks"][event] if "rafter" in e.get("command", "")
+            ]
+            assert len(rafter_hooks) == 1, f"event {event} duplicated"
+
+    def test_preserves_non_rafter_entries(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_hooks
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "hooks.json").write_text(json.dumps({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{"command": "other pre", "type": "command"}],
+                "postToolUse": [{"command": "other post", "type": "command"}],
+                "beforeShellExecution": [{"command": "other shell", "type": "command"}],
+                "afterFileEdit": [{"command": "other edit", "type": "command"}],
+            },
+        }))
+
+        _install_cursor_hooks(tmp_path)
+
+        cfg = json.loads((cursor_dir / "hooks.json").read_text())
+        commands = lambda ev: [e.get("command") for e in cfg["hooks"][ev]]
+        assert "other pre" in commands("preToolUse")
+        assert "other post" in commands("postToolUse")
+        assert "other shell" in commands("beforeShellExecution")
+        # Unrelated event preserved untouched.
+        assert commands("afterFileEdit") == ["other edit"]
+
+
+class TestInstallCursorRules:
+    """Per-skill .mdc rules — one file per shipped skill."""
+
+    def test_writes_one_mdc_per_shipped_skill(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_rules
+        _install_cursor_rules(tmp_path)
+
+        rules_dir = tmp_path / ".cursor" / "rules"
+        for name in _CURSOR_SHIPPED_SKILLS:
+            assert (rules_dir / f"{name}.mdc").exists(), f"missing {name}.mdc"
+
+    def test_each_rule_has_alwaysApply_false_and_description(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_rules
+        _install_cursor_rules(tmp_path)
+
+        rules_dir = tmp_path / ".cursor" / "rules"
+        for name in _CURSOR_SHIPPED_SKILLS:
+            content = (rules_dir / f"{name}.mdc").read_text()
+            assert content.startswith("---\n"), f"{name}: missing frontmatter"
+            fm_end = content.find("\n---", 4)
+            assert fm_end > 0, f"{name}: missing closing frontmatter"
+            frontmatter = content[4:fm_end]
+            assert "alwaysApply: false" in frontmatter, f"{name}: alwaysApply must be false"
+            assert "description:" in frontmatter, f"{name}: description must exist"
+
+    def test_descriptions_are_action_forcing(self, tmp_path):
+        import re
+        from rafter_cli.commands.agent import _install_cursor_rules
+        _install_cursor_rules(tmp_path)
+
+        rules_dir = tmp_path / ".cursor" / "rules"
+        for name in _CURSOR_SHIPPED_SKILLS:
+            content = (rules_dir / f"{name}.mdc").read_text()
+            m = re.search(r'description:\s*"([^"]+)"', content)
+            assert m, f"{name}: cannot extract description"
+            desc = m.group(1)
+            assert len(desc) > 20, f"{name}: description too short"
+            assert re.match(r"^(REQUIRED|Use|Invoke|Entry|Run|Read|Stop)", desc), (
+                f"{name}: description must be action-forcing, got: {desc[:40]}"
+            )
+
+    def test_does_not_write_legacy_rafter_security_mdc(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_rules
+        _install_cursor_rules(tmp_path)
+        legacy = tmp_path / ".cursor" / "rules" / "rafter-security.mdc"
+        assert not legacy.exists(), "legacy consolidated rule must not be written"
+
+    def test_idempotent(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_rules
+        _install_cursor_rules(tmp_path)
+        rules_dir = tmp_path / ".cursor" / "rules"
+        before = {n: (rules_dir / f"{n}.mdc").read_text() for n in _CURSOR_SHIPPED_SKILLS}
+        _install_cursor_rules(tmp_path)
+        after = {n: (rules_dir / f"{n}.mdc").read_text() for n in _CURSOR_SHIPPED_SKILLS}
+        assert after == before
+
+
+class TestInstallCursorSubAgent:
+    """Cursor sub-agent — .cursor/agents/rafter.md."""
+
+    def test_writes_subagent_file(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_subagents
+        _install_cursor_subagents(tmp_path)
+        agent_path = tmp_path / ".cursor" / "agents" / "rafter.md"
+        assert agent_path.exists()
+
+    def test_frontmatter_has_name_description_no_tools(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_subagents
+        _install_cursor_subagents(tmp_path)
+
+        content = (tmp_path / ".cursor" / "agents" / "rafter.md").read_text()
+        assert content.startswith("---\n")
+        fm_end = content.find("\n---", 4)
+        frontmatter = content[4:fm_end]
+        assert "name: rafter" in frontmatter
+        assert "description:" in frontmatter
+        # Cursor frontmatter has no tools: field.
+        for line in frontmatter.splitlines():
+            assert not line.startswith("tools:"), \
+                "Cursor sub-agent frontmatter must not include tools:"
+
+    def test_body_references_all_three_cli_tiers(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_subagents
+        _install_cursor_subagents(tmp_path)
+        content = (tmp_path / ".cursor" / "agents" / "rafter.md").read_text()
+        assert "rafter run" in content
+        assert "--mode plus" in content
+        assert "rafter secrets" in content
+
+    def test_idempotent(self, tmp_path):
+        from rafter_cli.commands.agent import _install_cursor_subagents
+        _install_cursor_subagents(tmp_path)
+        agent_path = tmp_path / ".cursor" / "agents" / "rafter.md"
+        before = agent_path.read_text()
+        _install_cursor_subagents(tmp_path)
+        assert agent_path.read_text() == before

--- a/shared-docs/PLATFORM_PARITY_AUDIT.md
+++ b/shared-docs/PLATFORM_PARITY_AUDIT.md
@@ -12,7 +12,7 @@
 | Claude Code  | yes            | yes                     | yes (PreToolUse+Post) | yes                | yes   | **yes (rf-q7j)** | CLAUDE.md   | yes (hook)     |
 | Codex        | yes            | yes                     | yes (claude fmt)      | yes                | —     | n/a       | AGENTS.md        | partial (skills only) |
 | Gemini       | yes (rf-yit)   | partial                 | yes (BeforeTool)      | unverified         | yes   | n/a       | GEMINI.md        | partial (MCP only) |
-| Cursor       | **NO**         | n/a                     | yes (beforeShell)     | unverified         | yes   | n/a       | .cursor/rules/*.mdc | partial (MCP only) |
+| Cursor       | **NO**         | n/a                     | yes (preToolUse+postToolUse+beforeShell, rf-svn3) | unverified         | yes   | **yes (rf-svn3)** | per-skill `.cursor/rules/<skill>.mdc` (rf-svn3) | partial (MCP only) |
 | Windsurf     | **NO**         | n/a                     | yes (pre_run_command) | unverified         | yes   | n/a       | **none**         | partial (MCP only) |
 | Continue.dev | **NO**         | n/a                     | **none (pruned)**     | n/a                | yes   | n/a       | **none**         | **NOT CHECKED** |
 | Aider        | **NO**         | n/a                     | **none**              | n/a                | yes   | n/a       | **none**         | **NOT CHECKED** |
@@ -169,14 +169,14 @@ Windsurf reads `AGENTS.md` natively (any directory in workspace). Our rf-djw Cod
 
 ## Revised per-platform deep-support plan (replaces earlier plan)
 
-### Cursor — currently MCP only; can be full parity with Claude Code
+### Cursor — DONE (rf-svn3): full parity with Claude Code
 
-| Surface | Today | Goal |
+| Surface | Pre-rf-svn3 | Now |
 |---|---|---|
-| Hooks | `beforeShellExecution` only | Add `preToolUse` + `postToolUse` for full coverage |
-| Rules | one consolidated `.cursor/rules/rafter-security.mdc` | 4 per-skill `.cursor/rules/<skill>.mdc` files with description-based activation |
-| Sub-agent | none | `.cursor/agents/rafter.md` (rf-q7j content reuse — Cursor will also read existing `.claude/agents/`) |
-| MCP | yes | yes (no change) |
+| Hooks | `beforeShellExecution` only | `preToolUse` + `postToolUse` + `beforeShellExecution` (all three idempotent, non-rafter entries preserved) |
+| Rules | one consolidated `.cursor/rules/rafter-security.mdc` | 4 per-skill `.cursor/rules/<skill>.mdc` files with trigger-first descriptions reused verbatim from each SKILL.md (description-based activation) |
+| Sub-agent | none | `.cursor/agents/rafter.md` (reuses rf-q7j body; Cursor frontmatter has no `tools:` field) |
+| MCP | yes | yes (unchanged) |
 
 ### Windsurf — currently MCP + broken hooks; can be rules + AGENTS.md
 


### PR DESCRIPTION
## Summary

Brings Cursor up to Claude-Code parity for **rf-cia phase c (per-platform deep support)**, closing bead **rf-svn3**.

- **Hooks** (`~/.cursor/hooks.json`): adds `preToolUse` + `postToolUse` alongside the existing `beforeShellExecution`. Idempotent across all three events; non-rafter entries preserved.
- **Rules** (`~/.cursor/rules/`): replaces the consolidated `rafter-security.mdc` with **four per-skill files** — `rafter.mdc`, `rafter-secure-design.mdc`, `rafter-code-review.mdc`, `rafter-skill-review.mdc`. Each rule's frontmatter `description` is reused verbatim from its `SKILL.md` (trigger-first per rf-4ei/rf-8po). `alwaysApply: false` so Cursor decides per-task. The legacy file is auto-removed on reinstall.
- **Sub-agent** (`~/.cursor/agents/rafter.md`): reuses the rf-q7j Claude-Code sub-agent body. Cursor frontmatter has no `tools:` field — that line is stripped at install time; tools inherit from parent. Cursor will still read the existing `.claude/agents/rafter.md` for users on both platforms.
- **Components**: `cursor.instructions` now manages rules + sub-agent together for `rafter agent enable/disable`. `cursor.hooks` now covers all three events.
- Node + Python parity throughout.

### Implementation notes

- Sub-agent body sourced from rf-q7j (PR #57). Included here so this PR is self-contained — merging either order yields the same final file. If rf-q7j lands first, the rule/MCP/hook code in this PR still applies cleanly.
- Templates ship as static files under `node/resources/cursor-rules/` and `python/rafter_cli/resources/cursor-rules/` — copied at install time, no runtime templating.
- The `--with-cursor` install path now installs MCP **+** hooks **+** rules **+** sub-agent in one shot. Previously it only did MCP + the narrower beforeShell hook + the consolidated rule.
- Followed strict TDD — failing tests written and confirmed red before implementation.

## Test plan

- [x] `node/tests/cursor-deep-support.test.ts` (13 new tests, all green)
- [x] `python/tests/test_agent_init.py` `TestInstallCursorHooks` / `TestInstallCursorRules` / `TestInstallCursorSubAgent` (12 new tests, all green)
- [x] Node `tests/agent-components.test.ts` regression (passes)
- [x] Node `tests/platform-integration.test.ts` Cursor section (10/10 passes; updated rules-existence + idempotency expectations)
- [x] Node `tests/platform-integration.test.ts` "All 8 platforms" combined test (passes — Cursor row updated to assert per-skill rules + sub-agent)
- [x] Python `pytest python/tests/test_agent_init.py` (58/58 passes)
- [x] Live smoke: `rafter agent init --local --with-cursor` (Node + Python builds) writes the expected files in a clean tmp dir
- [x] Verified: legacy `.cursor/rules/rafter-security.mdc` is **not** written on fresh install and is **removed** when reinstalling on top of an old layout

## Out of scope

- `recipes/cursor.md` doc refresh — separate doc-only PR per bead instruction.
- Codex / Gemini / Windsurf / Continue.dev / Aider parity — separate beads.
- Migrating `rafter-skill-review` skill content into the Cursor rule body (rule body is intentionally a pointer, not a copy).
- `rafter agent verify --probe` runtime check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)