### PR TITLE
feat(rf-0vr3): Windsurf deep support — prune broken hooks + per-skill rules + AGENTS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Windsurf deep support: per-skill workspace rules + AGENTS.md + project-scope (`--local`) install** (Node + Python, rf-0vr3 / rf-cia phase c). `rafter agent init --with-windsurf` now ships Windsurf the way it actually consumes context:
+  - Writes 4 per-skill rules under `.windsurf/rules/<skill>.md` with Windsurf YAML frontmatter (`trigger: model_decision`, `description:`) so the agent fetches the right rule per task description.
+  - Writes `AGENTS.md` at workspace root — Windsurf reads it natively (so does Codex; one file covers both). `<!-- rafter:start --> ... <!-- rafter:end -->` marker preserves user content.
+  - Now installs at `--local` (project) scope as well as user scope. Project install ships rules + AGENTS.md; user install additionally registers the MCP entry under `~/.codeium/windsurf/mcp_config.json`.
+  - Backed by 5 new Node tests + 4 new Python tests, plus updates to the existing combined-platforms integration test.
+
 - **Cursor deep support: per-skill rules + sub-agent + full pre/post-tool hooks** (Node + Python, rf-svn3 / rf-cia phase c). `rafter agent init --with-cursor` now ships Cursor to Claude-Code parity:
   - Hooks at `~/.cursor/hooks.json` cover `preToolUse` + `postToolUse` + `beforeShellExecution` (was `beforeShellExecution` only). Idempotent across all three events; non-rafter entries preserved.
   - Replaces the single consolidated `.cursor/rules/rafter-security.mdc` with **four per-skill rules** (`rafter.mdc`, `rafter-secure-design.mdc`, `rafter-code-review.mdc`, `rafter-skill-review.mdc`). Each rule's frontmatter description is reused verbatim from the skill's `SKILL.md` (trigger-first), `alwaysApply: false`. The legacy file is auto-removed on reinstall.
@@ -15,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Backed by 13 new Node tests and 12 new Python tests. The `cursor.instructions` component now manages rules + sub-agent together for `rafter agent enable/disable`.
 
 ### Removed
+- **`rafter agent init --with-windsurf` no longer writes `~/.windsurf/hooks.json`** (Node + Python, rf-0vr3): Windsurf has no documented hook surface in current versions — `pre_run_command` / `pre_write_code` were not consumed by the IDE at runtime. The install was a silent no-op (independently flagged by gap reports rf-p1ri / rf-vayl and research bead rf-s1n3). Pruned along the same pattern as the Continue.dev hooks prune. Removed `installWindsurfHooks` from the Node init flow, `_windsurf_hooks` ComponentSpec from both registries, and the matching test expectations. The MCP install at `~/.codeium/windsurf/mcp_config.json` is unchanged.
+
 - **`rafter agent init --with-continue` no longer writes `~/.continue/settings.json`** (Node + Python, rf-cia): Continue.dev does not read `settings.json` and has no `hooks.PreToolUse`/`PostToolUse` field in its config schema (current versions use `config.yaml`, legacy uses `config.json`). The hook install was a silent no-op at runtime — files written, never consumed. Removed `installContinueDevHooks` from the Node init flow, `_continue_hooks` ComponentSpec from both Node and Python `rafter agent enable/disable` registries, and the matching test expectations. MCP install (`.continue/config.json` mcpServers entry) is unchanged. Continue.dev integration is now MCP-only — matches what `recipes/continue-dev.md` always claimed.
 
 ## [0.7.4] - 2026-04-21

--- a/node/resources/windsurf-rules/rafter-code-review.md
+++ b/node/resources/windsurf-rules/rafter-code-review.md
@@ -1,0 +1,14 @@
+---
+trigger: model_decision
+description: "REQUIRED before declaring a task done when the diff touches user input, SQL, shell, auth, credentials, file paths, serialization, or dependency surface. Walks OWASP/ASVS/MITRE questions the compiler and the test suite won't catch. Pair with `rafter run` on the same diff. A security-relevant task marked complete without both has been under-delivered — do not claim done."
+---
+
+# rafter-code-review — structured pre-merge review
+
+Pointer rule. Use the `rafter-code-review` skill at `.claude/skills/rafter-code-review/SKILL.md` BEFORE declaring done on any diff touching the surface listed above.
+
+- Read the matching sub-doc (web-app / api / llm / cli-library-iac).
+- Walk the OWASP / ASVS / MITRE questions the scanner can't ask.
+- Pair with `rafter run` on the same diff — the scanner finds known-bad patterns, this skill asks the questions patterns miss.
+
+A security-relevant task marked complete without BOTH the skill walkthrough and a `rafter run` pass has been under-delivered. Do not claim done until both are recorded.

--- a/node/resources/windsurf-rules/rafter-secure-design.md
+++ b/node/resources/windsurf-rules/rafter-secure-design.md
@@ -1,0 +1,14 @@
+---
+trigger: model_decision
+description: "REQUIRED before writing code for any feature touching auth, payments, credentials, tokens, sessions, file upload, user data, or data deletion. Invoke it, record answers inline in the design doc or PR description, then write the code. Skipping this is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. If the feature touches any of those surfaces and this hasn't run, the design is incomplete — do not proceed to implementation."
+---
+
+# rafter-secure-design — shift-left design review
+
+Pointer rule. Use the `rafter-secure-design` skill at `.claude/skills/rafter-secure-design/SKILL.md` BEFORE writing code for any feature on the surface listed above.
+
+- Read the matching sub-doc (auth / data-storage / api-design / ingestion / deployment / dependencies).
+- Each sub-doc is a set of questions a security engineer would ask at kickoff — answer them inline in the design or PR description.
+- Pair with `rafter-code-review` (mid-lifecycle) and `rafter run` (detection) once code exists.
+
+Skipping this skill on the listed surfaces is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. Do not proceed to implementation until it has run.

--- a/node/resources/windsurf-rules/rafter-skill-review.md
+++ b/node/resources/windsurf-rules/rafter-skill-review.md
@@ -1,0 +1,14 @@
+---
+trigger: model_decision
+description: "REQUIRED before copying any third-party SKILL.md, MCP manifest, Cursor rule, or agent config into this machine or forwarding one to a user. Installing a skill grants Read/Bash/network under your identity — this is `curl | sh` in a different costume. Do not install, load, recommend, or forward any third-party agent asset until this skill has vetted it. Bypassing this turns the agent into a delivery vector."
+---
+
+# rafter-skill-review — vet before you install
+
+Pointer rule. Use the `rafter-skill-review` skill at `.claude/skills/rafter-skill-review/SKILL.md` BEFORE installing or forwarding any third-party agent asset.
+
+- Run `rafter skill review <path-or-url>` against the SKILL.md / MCP manifest / Cursor rule / agent config.
+- Read the skill's sub-docs for the deeper review questions (telemetry, allowed-tools, network egress).
+- Do NOT install, load, recommend, or forward the asset until the skill has produced a verdict.
+
+Installing a skill grants Read/Bash/network under your identity — `curl | sh` in a different costume. Bypassing this turns the agent into a delivery vector.

--- a/node/resources/windsurf-rules/rafter.md
+++ b/node/resources/windsurf-rules/rafter.md
@@ -1,0 +1,15 @@
+---
+trigger: model_decision
+description: "Entry point for rafter. Invoke when a sub-skill is unclear, or when the task needs `rafter run` (remote SAST+SCA), `rafter secrets` (local secrets-only), `rafter audit`, policy checks, or command-risk evaluation. If a task is security-relevant and no rafter skill or CLI call has been made, invoke this before handing the task off — an un-evaluated \"done\" on security-relevant work is not done."
+---
+
+# rafter — security toolkit router
+
+Pointer rule. Use the `rafter` skill (full guidance at `.claude/skills/rafter/SKILL.md`).
+
+- Run `rafter run` for the default tier — remote SAST + SCA + secrets. Needs `RAFTER_API_KEY`.
+- Run `rafter run --mode plus` for agentic deep-dive on suspicious patterns.
+- Run `rafter secrets <path>` for offline secrets-only (NOT a code security scan).
+- Run `rafter agent exec --dry-run -- <cmd>` to classify a shell command's risk before running it.
+
+If unsure which tier to pick, Read `.claude/skills/rafter/SKILL.md` and follow the routing table.

--- a/node/src/commands/agent/components.ts
+++ b/node/src/commands/agent/components.ts
@@ -691,65 +691,61 @@ function geminiMcp(): ComponentSpec {
   };
 }
 
-function windsurfHooks(): ComponentSpec {
+/** Skills shipped as Windsurf rules at .windsurf/rules/<skill>.md (rf-0vr3). */
+const WINDSURF_RULE_SKILLS = [
+  "rafter",
+  "rafter-secure-design",
+  "rafter-code-review",
+  "rafter-skill-review",
+] as const;
+
+function windsurfRuleSourceDir(): string | null {
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "..", "resources", "windsurf-rules"),
+    path.resolve(__dirname, "..", "..", "resources", "windsurf-rules"),
+  ];
+  return candidates.find((p) => fs.existsSync(p)) ?? null;
+}
+
+/**
+ * Windsurf rules component: per-skill files at .windsurf/rules/<skill>.md.
+ *
+ * Project/workspace-scope by design — Windsurf reads workspace rules from
+ * .windsurf/rules/ (12KB cap per file). The cwd at the time install runs is
+ * what gets the rules. Shown in the registry as resolved to the current
+ * working directory.
+ *
+ * Replaces the prior `windsurf.hooks` component, pruned in rf-0vr3 because
+ * Windsurf has no documented hook surface.
+ */
+function windsurfRules(): ComponentSpec {
   const home = os.homedir();
-  const hooksPath = path.join(home, ".windsurf", "hooks.json");
+  const rulesDir = path.join(process.cwd(), ".windsurf", "rules");
   return {
-    id: "windsurf.hooks",
+    id: "windsurf.rules",
     platform: "windsurf",
-    kind: "hooks",
-    description: "Windsurf hooks (~/.windsurf/hooks.json)",
+    kind: "instructions",
+    description: "Windsurf per-skill rules (.windsurf/rules/*.md, workspace-scope)",
     detectDir: path.join(home, ".codeium", "windsurf"),
-    path: hooksPath,
-    isInstalled: () => {
-      if (!fs.existsSync(hooksPath)) return false;
-      const cfg = readJson(hooksPath);
-      for (const entry of cfg.hooks?.pre_run_command ?? []) {
-        if (String(entry?.command ?? "").includes("rafter hook pretool")) return true;
-      }
-      return false;
-    },
+    path: rulesDir,
+    isInstalled: () =>
+      WINDSURF_RULE_SKILLS.every((n) => fs.existsSync(path.join(rulesDir, `${n}.md`))),
     install: () => {
-      const dir = path.join(home, ".windsurf");
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-      const cfg: Record<string, any> = fs.existsSync(hooksPath) ? readJson(hooksPath) : {};
-      cfg.hooks ??= {};
-      cfg.hooks.pre_run_command ??= [];
-      cfg.hooks.pre_write_code ??= [];
-      cfg.hooks.pre_run_command = filterOutRafter(
-        cfg.hooks.pre_run_command,
-        (e) => String(e?.command ?? "").includes("rafter hook pretool"),
-      );
-      cfg.hooks.pre_write_code = filterOutRafter(
-        cfg.hooks.pre_write_code,
-        (e) => String(e?.command ?? "").includes("rafter hook pretool"),
-      );
-      cfg.hooks.pre_run_command.push({
-        command: "rafter hook pretool --format windsurf",
-        show_output: true,
-      });
-      cfg.hooks.pre_write_code.push({
-        command: "rafter hook pretool --format windsurf",
-        show_output: true,
-      });
-      writeJson(hooksPath, cfg);
+      fs.mkdirSync(rulesDir, { recursive: true });
+      const src = windsurfRuleSourceDir();
+      if (!src) return;
+      for (const name of WINDSURF_RULE_SKILLS) {
+        const from = path.join(src, `${name}.md`);
+        if (fs.existsSync(from)) {
+          fs.copyFileSync(from, path.join(rulesDir, `${name}.md`));
+        }
+      }
     },
     uninstall: () => {
-      if (!fs.existsSync(hooksPath)) return;
-      const cfg = readJson(hooksPath);
-      if (cfg.hooks?.pre_run_command) {
-        cfg.hooks.pre_run_command = filterOutRafter(
-          cfg.hooks.pre_run_command,
-          (e) => String(e?.command ?? "").includes("rafter hook pretool"),
-        );
+      for (const name of WINDSURF_RULE_SKILLS) {
+        const p = path.join(rulesDir, `${name}.md`);
+        if (fs.existsSync(p)) fs.rmSync(p, { force: true });
       }
-      if (cfg.hooks?.pre_write_code) {
-        cfg.hooks.pre_write_code = filterOutRafter(
-          cfg.hooks.pre_write_code,
-          (e) => String(e?.command ?? "").includes("rafter hook pretool"),
-        );
-      }
-      writeJson(hooksPath, cfg);
     },
   };
 }
@@ -914,7 +910,7 @@ export function getComponentRegistry(): ComponentSpec[] {
       cursorMcp(),
       geminiHooks(),
       geminiMcp(),
-      windsurfHooks(),
+      windsurfRules(),
       windsurfMcp(),
       continueMcp(),
       aiderMcp(),

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -51,6 +51,7 @@ function installGlobalInstructions(
     claudeCode?: boolean;
     codex?: boolean;
     gemini?: boolean;
+    windsurf?: boolean;
   },
   root: string,
   scope: "user" | "project",
@@ -66,16 +67,22 @@ function installGlobalInstructions(
     }
   }
 
-  // Codex — ~/.codex/AGENTS.md (user) or <cwd>/AGENTS.md (project)
-  if (platforms.codex) {
+  // AGENTS.md — read natively by Codex AND Windsurf. Codex at user scope keeps
+  // its own copy at ~/.codex/AGENTS.md; everything else (project scope, or any
+  // scope where Windsurf is in play) writes <root>/AGENTS.md once.
+  if (platforms.codex || platforms.windsurf) {
     try {
-      const filePath = scope === "user"
+      const codexUser = scope === "user" && platforms.codex && !platforms.windsurf;
+      const filePath = codexUser
         ? path.join(root, ".codex", "AGENTS.md")
         : path.join(root, "AGENTS.md");
       injectInstructionFile(filePath);
-      console.log(fmt.success(`Installed Rafter instructions to ${filePath}`));
+      const readers = [platforms.codex && "Codex", platforms.windsurf && "Windsurf"]
+        .filter(Boolean)
+        .join(" + ");
+      console.log(fmt.success(`Installed Rafter instructions for ${readers} to ${filePath}`));
     } catch (e) {
-      console.log(fmt.warning(`Failed to write Codex instructions: ${e}`));
+      console.log(fmt.warning(`Failed to write AGENTS.md: ${e}`));
     }
   }
 
@@ -405,47 +412,50 @@ function installGeminiHooks(root: string): void {
   console.log(fmt.success(`Installed hooks to ${settingsPath}`));
 }
 
-function installWindsurfHooks(root: string): void {
-  const windsurfDir = path.join(root, ".windsurf");
+/** Skills shipped as Windsurf per-workspace rules at .windsurf/rules/<skill>.md (rf-0vr3). */
+const WINDSURF_RULE_SKILLS = [
+  "rafter",
+  "rafter-secure-design",
+  "rafter-code-review",
+  "rafter-skill-review",
+] as const;
 
-  if (!fs.existsSync(windsurfDir)) {
-    fs.mkdirSync(windsurfDir, { recursive: true });
+/**
+ * Install per-skill Windsurf rules at <root>/.windsurf/rules/<skill>.md.
+ *
+ * Windsurf reads workspace rules from .windsurf/rules/*.md (12KB cap per file
+ * per docs). Each file uses Windsurf YAML frontmatter (`trigger: model_decision`
+ * + `description:`) so the agent fetches the rule when its description matches
+ * the task. Body content mirrors the Cursor pointer-rule pattern.
+ *
+ * Replaces the prior `~/.windsurf/hooks.json` install, which was a silent
+ * no-op — Windsurf has no documented hook surface as of v1.x (research bead
+ * rf-s1n3, gap reports rf-p1ri / rf-vayl).
+ */
+function installWindsurfRules(root: string): void {
+  const rulesDir = path.join(root, ".windsurf", "rules");
+  fs.mkdirSync(rulesDir, { recursive: true });
+
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "..", "resources", "windsurf-rules"),
+    path.resolve(__dirname, "..", "..", "resources", "windsurf-rules"),
+  ];
+  const sourceDir = candidates.find((p) => fs.existsSync(p));
+  if (!sourceDir) {
+    console.log(fmt.warning(`Windsurf rule templates not found in resources/windsurf-rules`));
+    return;
   }
 
-  const hooksPath = path.join(windsurfDir, "hooks.json");
-
-  let config: Record<string, any> = {};
-  if (fs.existsSync(hooksPath)) {
-    try {
-      config = JSON.parse(fs.readFileSync(hooksPath, "utf-8"));
-    } catch {
-      console.log(fmt.warning("Existing Windsurf hooks.json was unreadable, creating new one"));
+  for (const name of WINDSURF_RULE_SKILLS) {
+    const src = path.join(sourceDir, `${name}.md`);
+    const dest = path.join(rulesDir, `${name}.md`);
+    if (!fs.existsSync(src)) {
+      console.log(fmt.warning(`Windsurf rule template missing: ${src}`));
+      continue;
     }
+    fs.copyFileSync(src, dest);
+    console.log(fmt.success(`Installed Windsurf rule to ${dest}`));
   }
-
-  if (!config.hooks) config.hooks = {};
-  if (!config.hooks.pre_run_command) config.hooks.pre_run_command = [];
-  if (!config.hooks.pre_write_code) config.hooks.pre_write_code = [];
-
-  // Remove existing rafter hooks
-  config.hooks.pre_run_command = config.hooks.pre_run_command.filter(
-    (entry: any) => !entry.command?.includes("rafter hook pretool")
-  );
-  config.hooks.pre_write_code = config.hooks.pre_write_code.filter(
-    (entry: any) => !entry.command?.includes("rafter hook pretool")
-  );
-
-  config.hooks.pre_run_command.push({
-    command: "rafter hook pretool --format windsurf",
-    show_output: true,
-  });
-  config.hooks.pre_write_code.push({
-    command: "rafter hook pretool --format windsurf",
-    show_output: true,
-  });
-
-  fs.writeFileSync(hooksPath, JSON.stringify(config, null, 2), "utf-8");
-  console.log(fmt.success(`Installed hooks to ${hooksPath}`));
 }
 
 
@@ -782,7 +792,9 @@ export function createInitCommand(): Command {
       let wantCodex = opts.withCodex || opts.all;
       let wantGemini = opts.withGemini || opts.all;
       let wantCursor = opts.withCursor || opts.all;
-      let wantWindsurf = opts.withWindsurf || (opts.all && !opts.local);
+      // Windsurf can install at --local scope (project rules + AGENTS.md)
+      // since rf-0vr3. User scope still also installs the MCP entry.
+      let wantWindsurf = opts.withWindsurf || opts.all;
       let wantContinue = opts.withContinue || (opts.all && !opts.local);
       let wantAider = opts.withAider || (opts.all && !opts.local);
       let wantGitleaks = opts.withGitleaks || (opts.all && !opts.local);
@@ -1012,18 +1024,28 @@ export function createInitCommand(): Command {
         }
       }
 
-      // Install Windsurf MCP + hooks if opted in
+      // Install Windsurf integration if opted in.
+      // - User scope: MCP entry under ~/.codeium/windsurf/ + per-skill rules
+      //   at .windsurf/rules/ (workspace) + AGENTS.md (workspace, written by
+      //   installGlobalInstructions below).
+      // - Project scope (--local): per-skill rules + AGENTS.md only (no
+      //   user-scope MCP entry written from a project init).
+      // The previous ~/.windsurf/hooks.json install was pruned: Windsurf has
+      // no documented hook surface (rf-0vr3).
       let windsurfOk = false;
-      if (hasWindsurf && wantWindsurf) {
+      if (wantWindsurf && (hasWindsurf || opts.local)) {
         try {
-          windsurfOk = installWindsurfMcp(root);
-          installWindsurfHooks(root);
-          if (windsurfOk) manager.set("agent.environments.windsurf.enabled", true);
+          if (hasWindsurf) {
+            windsurfOk = installWindsurfMcp(root);
+            if (windsurfOk) manager.set("agent.environments.windsurf.enabled", true);
+          }
+          installWindsurfRules(root);
+          // AGENTS.md is written below in installGlobalInstructions when
+          // platforms.windsurf is true.
+          if (!hasWindsurf) windsurfOk = true; // local-scope success: rules + AGENTS.md
         } catch (e) {
           console.error(fmt.error(`Failed to install Windsurf integration: ${e}`));
         }
-      } else if (opts.local && wantWindsurf) {
-        localUnsupported("Windsurf");
       }
 
       // Install Continue.dev MCP + hooks if opted in
@@ -1059,6 +1081,7 @@ export function createInitCommand(): Command {
         claudeCode: claudeCodeOk,
         codex: codexOk,
         gemini: geminiOk,
+        windsurf: windsurfOk,
       }, root, scope);
 
       console.log();

--- a/node/tests/agent-components.test.ts
+++ b/node/tests/agent-components.test.ts
@@ -66,7 +66,7 @@ describe("rafter agent list", () => {
       "cursor.mcp",
       "gemini.hooks",
       "gemini.mcp",
-      "windsurf.hooks",
+      "windsurf.rules",
       "windsurf.mcp",
       "continue.mcp",
       "aider.mcp",

--- a/node/tests/platform-integration.test.ts
+++ b/node/tests/platform-integration.test.ts
@@ -1414,54 +1414,79 @@ describe("Platform Integration — MCP Installs via CLI", () => {
     });
   });
 
-  // ── 15. Windsurf hooks ────────────────────────────────────────────
+  // ── 15. Windsurf integration (rf-0vr3) ─────────────────────────────
+  //
+  // The prior install wrote ~/.windsurf/hooks.json with pre_run_command /
+  // pre_write_code entries — Windsurf has no documented hook surface, so
+  // that file was a silent no-op (research bead rf-s1n3, gap reports
+  // rf-p1ri / rf-vayl). Pruned in rf-0vr3 along the same pattern as the
+  // Continue.dev prune (rf-cia phase b).
+  //
+  // Replaced by per-skill rules at .windsurf/rules/<skill>.md (workspace
+  // scope per Windsurf docs) + AGENTS.md (Windsurf reads it natively).
 
-  describe("Windsurf hooks (--with-windsurf)", () => {
-    it("should install pre_run_command/pre_write_code hooks to ~/.windsurf/hooks.json", () => {
+  describe("Windsurf integration (--with-windsurf)", () => {
+    it("does NOT write ~/.windsurf/hooks.json (Windsurf has no hook surface)", () => {
       fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), { recursive: true });
 
       runCli("agent init --with-windsurf", testHomeDir);
 
-      const hooksPath = path.join(testHomeDir, ".windsurf", "hooks.json");
-      expect(fs.existsSync(hooksPath)).toBe(true);
-
-      const config = JSON.parse(fs.readFileSync(hooksPath, "utf-8"));
-      expect(config.hooks).toBeDefined();
-      expect(config.hooks.pre_run_command).toBeDefined();
-      expect(config.hooks.pre_write_code).toBeDefined();
-
-      // Both hook arrays should have rafter entries
-      const runCmd = config.hooks.pre_run_command.find(
-        (e: any) => e.command?.includes("rafter")
-      );
-      expect(runCmd).toBeDefined();
-      expect(runCmd.command).toContain("--format windsurf");
-      expect(runCmd.show_output).toBe(true);
-
-      const writeCmd = config.hooks.pre_write_code.find(
-        (e: any) => e.command?.includes("rafter")
-      );
-      expect(writeCmd).toBeDefined();
-      expect(writeCmd.command).toContain("--format windsurf");
+      expect(fs.existsSync(path.join(testHomeDir, ".windsurf", "hooks.json"))).toBe(false);
     });
 
-    it("should deduplicate hooks on repeated installs", () => {
+    it("writes per-skill rules under .windsurf/rules/<skill>.md", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), { recursive: true });
+
+      runCli("agent init --with-windsurf", testHomeDir);
+
+      for (const name of ["rafter", "rafter-secure-design", "rafter-code-review", "rafter-skill-review"]) {
+        const rulePath = path.join(testHomeDir, ".windsurf", "rules", `${name}.md`);
+        expect(fs.existsSync(rulePath), `windsurf rule missing: ${name}`).toBe(true);
+
+        const body = fs.readFileSync(rulePath, "utf-8");
+        expect(body, `windsurf rule ${name} missing trigger`).toMatch(/^---\ntrigger:\s*model_decision/m);
+        expect(body, `windsurf rule ${name} missing description`).toMatch(/^description:\s*"/m);
+      }
+    });
+
+    it("writes AGENTS.md at workspace root (read natively by Windsurf)", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), { recursive: true });
+
+      runCli("agent init --with-windsurf", testHomeDir);
+
+      const agentsMd = path.join(testHomeDir, "AGENTS.md");
+      expect(fs.existsSync(agentsMd)).toBe(true);
+      const body = fs.readFileSync(agentsMd, "utf-8");
+      expect(body).toContain("<!-- rafter:start -->");
+      expect(body).toContain("<!-- rafter:end -->");
+    });
+
+    it("still installs MCP entry under ~/.codeium/windsurf/mcp_config.json", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), { recursive: true });
+
+      runCli("agent init --with-windsurf", testHomeDir);
+
+      const mcpPath = path.join(testHomeDir, ".codeium", "windsurf", "mcp_config.json");
+      expect(fs.existsSync(mcpPath)).toBe(true);
+      const cfg = JSON.parse(fs.readFileSync(mcpPath, "utf-8"));
+      expect(cfg.mcpServers?.rafter).toBeDefined();
+    });
+
+    it("is idempotent across repeat installs", () => {
       fs.mkdirSync(path.join(testHomeDir, ".codeium", "windsurf"), { recursive: true });
 
       runCli("agent init --with-windsurf", testHomeDir);
       runCli("agent init --with-windsurf", testHomeDir);
 
-      const config = JSON.parse(
-        fs.readFileSync(path.join(testHomeDir, ".windsurf", "hooks.json"), "utf-8")
-      );
-      const rafterRun = config.hooks.pre_run_command.filter(
-        (e: any) => e.command?.includes("rafter")
-      );
-      expect(rafterRun).toHaveLength(1);
-      const rafterWrite = config.hooks.pre_write_code.filter(
-        (e: any) => e.command?.includes("rafter")
-      );
-      expect(rafterWrite).toHaveLength(1);
+      // Rules still present, AGENTS.md still has exactly one rafter block.
+      const agentsMd = fs.readFileSync(path.join(testHomeDir, "AGENTS.md"), "utf-8");
+      expect((agentsMd.match(/<!-- rafter:start -->/g) ?? []).length).toBe(1);
+
+      for (const name of ["rafter", "rafter-secure-design", "rafter-code-review", "rafter-skill-review"]) {
+        expect(
+          fs.existsSync(path.join(testHomeDir, ".windsurf", "rules", `${name}.md`)),
+        ).toBe(true);
+      }
     });
   });
 
@@ -1609,9 +1634,17 @@ describe("Platform Integration — MCP Installs via CLI", () => {
         fs.existsSync(path.join(testHomeDir, ".cursor", "agents", "rafter.md")),
       ).toBe(true);
 
-      // ── Windsurf: MCP + hooks ──
+      // ── Windsurf: MCP + per-skill rules + AGENTS.md (rf-0vr3) ──
+      // hooks.json is NOT written (Windsurf has no hook surface, pruned in rf-0vr3).
       expect(fs.existsSync(path.join(testHomeDir, ".codeium", "windsurf", "mcp_config.json"))).toBe(true);
-      expect(fs.existsSync(path.join(testHomeDir, ".windsurf", "hooks.json"))).toBe(true);
+      expect(fs.existsSync(path.join(testHomeDir, ".windsurf", "hooks.json"))).toBe(false);
+      for (const name of ["rafter", "rafter-secure-design", "rafter-code-review", "rafter-skill-review"]) {
+        expect(
+          fs.existsSync(path.join(testHomeDir, ".windsurf", "rules", `${name}.md`)),
+          `windsurf rule missing: ${name}`,
+        ).toBe(true);
+      }
+      expect(fs.existsSync(path.join(testHomeDir, "AGENTS.md"))).toBe(true);
 
       // ── Continue.dev: MCP only (hooks pruned in rf-cia phase b) ──
       expect(fs.existsSync(path.join(testHomeDir, ".continue", "config.json"))).toBe(true);

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -229,6 +229,7 @@ def _install_global_instructions(
     cursor: bool,
     root: Path,
     scope: str,
+    windsurf: bool = False,
 ) -> None:
     """Install Rafter instruction files for platforms that support them.
 
@@ -237,9 +238,11 @@ def _install_global_instructions(
         Codex CLI   — user: ~/.codex/AGENTS.md      project: <cwd>/AGENTS.md
         Gemini CLI  — user: ~/.gemini/GEMINI.md     project: <cwd>/GEMINI.md
         Cursor      — user: ~/.cursor/rules/*.mdc   project: <cwd>/.cursor/rules/*.mdc
+        Windsurf    — <cwd>/AGENTS.md (read natively, workspace scope)
 
-    Codex (AGENTS.md) and Gemini (GEMINI.md) each have the same filename at
-    user and project scope — only the location differs — so scope is explicit.
+    AGENTS.md is the cross-platform instruction file: Codex (project scope) and
+    Windsurf (any scope) both read it. When either is enabled we write it once
+    at the project root; only Codex at user scope gets its own ~/.codex/AGENTS.md.
     """
     if claude_code:
         try:
@@ -249,13 +252,19 @@ def _install_global_instructions(
         except Exception as e:
             rprint(fmt.warning(f"Failed to write Claude Code instructions: {e}"))
 
-    if codex:
+    if codex or windsurf:
         try:
-            file_path = root / ".codex" / "AGENTS.md" if scope == "user" else root / "AGENTS.md"
+            codex_user = scope == "user" and codex and not windsurf
+            file_path = (
+                root / ".codex" / "AGENTS.md" if codex_user else root / "AGENTS.md"
+            )
             _inject_instruction_file(file_path)
-            rprint(fmt.success(f"Installed Rafter instructions to {file_path}"))
+            readers = " + ".join(
+                name for name, on in [("Codex", codex), ("Windsurf", windsurf)] if on
+            )
+            rprint(fmt.success(f"Installed Rafter instructions for {readers} to {file_path}"))
         except Exception as e:
-            rprint(fmt.warning(f"Failed to write Codex instructions: {e}"))
+            rprint(fmt.warning(f"Failed to write AGENTS.md: {e}"))
 
     if gemini:
         try:
@@ -599,6 +608,42 @@ def _install_windsurf_mcp(root: Path) -> bool:
     return True
 
 
+# Skills shipped as Windsurf rules at .windsurf/rules/<skill>.md (rf-0vr3).
+_WINDSURF_RULE_SKILLS: tuple[str, ...] = (
+    "rafter",
+    "rafter-secure-design",
+    "rafter-code-review",
+    "rafter-skill-review",
+)
+
+
+def _install_windsurf_rules(root: Path) -> None:
+    """Install per-skill Windsurf rules at <root>/.windsurf/rules/<skill>.md.
+
+    Workspace-scope rules consumed by Windsurf's rules system (.windsurf/rules/*.md,
+    12KB cap per file per docs). Each rule uses Windsurf's YAML frontmatter
+    (`trigger: model_decision` + `description:`) so the agent fetches the rule
+    when the description matches the task.
+
+    Replaces the prior `~/.windsurf/hooks.json` install — Windsurf has no
+    documented hook surface (rf-0vr3 prune; same pattern as Continue.dev hooks
+    prune in rf-cia phase b).
+    """
+    rules_dir = root / ".windsurf" / "rules"
+    rules_dir.mkdir(parents=True, exist_ok=True)
+
+    res = importlib.resources.files("rafter_cli.resources")
+    for name in _WINDSURF_RULE_SKILLS:
+        try:
+            content = res.joinpath("windsurf-rules", f"{name}.md").read_text(encoding="utf-8")
+        except Exception:
+            rprint(fmt.warning(f"Windsurf rule template missing: {name}.md"))
+            continue
+        dest = rules_dir / f"{name}.md"
+        dest.write_text(content, encoding="utf-8")
+        rprint(fmt.success(f"Installed Windsurf rule to {dest}"))
+
+
 def _install_continue_dev_mcp(root: Path) -> bool:
     """Install MCP server config for Continue.dev (<root>/.continue/config.json)."""
     continue_dir = root / ".continue"
@@ -703,7 +748,9 @@ def init(
     want_codex = with_codex or all_integrations
     want_gemini = with_gemini or all_integrations
     want_cursor = with_cursor or all_integrations
-    want_windsurf = with_windsurf or (all_integrations and not local)
+    # Windsurf can install at --local scope (project rules + AGENTS.md) since
+    # rf-0vr3. User scope still also installs the MCP entry.
+    want_windsurf = with_windsurf or all_integrations
     want_continue = with_continue or (all_integrations and not local)
     want_aider = with_aider or (all_integrations and not local)
     want_gitleaks = with_gitleaks or (all_integrations and not local)
@@ -888,17 +935,26 @@ def init(
         except Exception as e:
             rprint(fmt.error(f"Failed to install Cursor integration: {e}"))
 
-    # Install Windsurf MCP if opted in
+    # Install Windsurf integration if opted in (rf-0vr3).
+    # - User scope: MCP entry under ~/.codeium/windsurf/ + per-skill workspace
+    #   rules at .windsurf/rules/ + AGENTS.md (written below by
+    #   _install_global_instructions).
+    # - Project scope (--local): rules + AGENTS.md only.
+    # The previous ~/.windsurf/hooks.json install was pruned: Windsurf has no
+    # documented hook surface.
     windsurf_ok = False
-    if has_windsurf and want_windsurf:
+    if want_windsurf and (has_windsurf or local):
         try:
-            windsurf_ok = _install_windsurf_mcp(root)
-            if windsurf_ok:
-                manager.set("agent.environments.windsurf.enabled", True)
+            if has_windsurf:
+                windsurf_ok = _install_windsurf_mcp(root)
+                if windsurf_ok:
+                    manager.set("agent.environments.windsurf.enabled", True)
+            _install_windsurf_rules(root)
+            if not has_windsurf:
+                # Project-scope success: rules + AGENTS.md (written below).
+                windsurf_ok = True
         except Exception as e:
             rprint(fmt.error(f"Failed to install Windsurf integration: {e}"))
-    elif local and want_windsurf:
-        _local_unsupported("Windsurf")
 
     # Install Continue.dev MCP if opted in
     continue_ok = False
@@ -930,6 +986,7 @@ def init(
         codex=codex_ok,
         gemini=gemini_ok,
         cursor=cursor_ok,
+        windsurf=windsurf_ok,
         root=root,
         scope=scope,
     )

--- a/python/rafter_cli/commands/agent_components.py
+++ b/python/rafter_cli/commands/agent_components.py
@@ -627,48 +627,55 @@ def _gemini_mcp() -> ComponentSpec:
     )
 
 
-def _windsurf_hooks() -> ComponentSpec:
+# Skills shipped as Windsurf rules at .windsurf/rules/<skill>.md (rf-0vr3).
+_WINDSURF_RULE_SKILLS: tuple[str, ...] = (
+    "rafter",
+    "rafter-secure-design",
+    "rafter-code-review",
+    "rafter-skill-review",
+)
+
+
+def _windsurf_rules() -> ComponentSpec:
+    """Windsurf per-skill workspace rules at .windsurf/rules/<skill>.md.
+
+    Replaces the prior `windsurf.hooks` component (pruned in rf-0vr3 — Windsurf
+    has no documented hook surface). Workspace-scope by design; the rules dir
+    is resolved against the cwd at registry-build time.
+    """
     home = Path.home()
     detect_dir = home / ".codeium" / "windsurf"
-    hooks_path = home / ".windsurf" / "hooks.json"
+    rules_dir = Path.cwd() / ".windsurf" / "rules"
 
     def is_installed() -> bool:
-        if not hooks_path.exists():
-            return False
-        cfg = _read_json(hooks_path)
-        for entry in cfg.get("hooks", {}).get("pre_run_command", []) or []:
-            if "rafter hook pretool" in str(entry.get("command", "") if isinstance(entry, dict) else ""):
-                return True
-        return False
+        return all((rules_dir / f"{n}.md").exists() for n in _WINDSURF_RULE_SKILLS)
 
     def install() -> None:
-        hooks_path.parent.mkdir(parents=True, exist_ok=True)
-        cfg = _read_json(hooks_path) if hooks_path.exists() else {}
-        cfg.setdefault("hooks", {})
-        h = cfg["hooks"]
-        for k in ("pre_run_command", "pre_write_code"):
-            h.setdefault(k, [])
-            h[k] = [e for e in h[k] if "rafter hook pretool" not in str(e.get("command", "") if isinstance(e, dict) else "")]
-            h[k].append({"command": "rafter hook pretool --format windsurf", "show_output": True})
-        _write_json(hooks_path, cfg)
+        rules_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            res = importlib.resources.files("rafter_cli.resources")
+        except Exception:
+            return
+        for name in _WINDSURF_RULE_SKILLS:
+            try:
+                content = res.joinpath("windsurf-rules", f"{name}.md").read_text(encoding="utf-8")
+            except Exception:
+                continue
+            (rules_dir / f"{name}.md").write_text(content, encoding="utf-8")
 
     def uninstall() -> None:
-        if not hooks_path.exists():
-            return
-        cfg = _read_json(hooks_path)
-        h = cfg.get("hooks") or {}
-        for k in ("pre_run_command", "pre_write_code"):
-            if k in h:
-                h[k] = [e for e in h[k] if "rafter hook pretool" not in str(e.get("command", "") if isinstance(e, dict) else "")]
-        _write_json(hooks_path, cfg)
+        for name in _WINDSURF_RULE_SKILLS:
+            p = rules_dir / f"{name}.md"
+            if p.exists():
+                p.unlink()
 
     return ComponentSpec(
-        id="windsurf.hooks",
+        id="windsurf.rules",
         platform="windsurf",
-        kind="hooks",
-        description="Windsurf hooks (~/.windsurf/hooks.json)",
+        kind="instructions",
+        description="Windsurf per-skill rules (.windsurf/rules/*.md, workspace-scope)",
         detect_dir=detect_dir,
-        path=hooks_path,
+        path=rules_dir,
         is_installed=is_installed,
         install=install,
         uninstall=uninstall,
@@ -861,7 +868,7 @@ def get_registry() -> list[ComponentSpec]:
             _cursor_mcp(),
             _gemini_hooks(),
             _gemini_mcp(),
-            _windsurf_hooks(),
+            _windsurf_rules(),
             _windsurf_mcp(),
             _continue_mcp(),
             _aider_mcp(),

--- a/python/rafter_cli/resources/windsurf-rules/rafter-code-review.md
+++ b/python/rafter_cli/resources/windsurf-rules/rafter-code-review.md
@@ -1,0 +1,14 @@
+---
+trigger: model_decision
+description: "REQUIRED before declaring a task done when the diff touches user input, SQL, shell, auth, credentials, file paths, serialization, or dependency surface. Walks OWASP/ASVS/MITRE questions the compiler and the test suite won't catch. Pair with `rafter run` on the same diff. A security-relevant task marked complete without both has been under-delivered — do not claim done."
+---
+
+# rafter-code-review — structured pre-merge review
+
+Pointer rule. Use the `rafter-code-review` skill at `.claude/skills/rafter-code-review/SKILL.md` BEFORE declaring done on any diff touching the surface listed above.
+
+- Read the matching sub-doc (web-app / api / llm / cli-library-iac).
+- Walk the OWASP / ASVS / MITRE questions the scanner can't ask.
+- Pair with `rafter run` on the same diff — the scanner finds known-bad patterns, this skill asks the questions patterns miss.
+
+A security-relevant task marked complete without BOTH the skill walkthrough and a `rafter run` pass has been under-delivered. Do not claim done until both are recorded.

--- a/python/rafter_cli/resources/windsurf-rules/rafter-secure-design.md
+++ b/python/rafter_cli/resources/windsurf-rules/rafter-secure-design.md
@@ -1,0 +1,14 @@
+---
+trigger: model_decision
+description: "REQUIRED before writing code for any feature touching auth, payments, credentials, tokens, sessions, file upload, user data, or data deletion. Invoke it, record answers inline in the design doc or PR description, then write the code. Skipping this is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. If the feature touches any of those surfaces and this hasn't run, the design is incomplete — do not proceed to implementation."
+---
+
+# rafter-secure-design — shift-left design review
+
+Pointer rule. Use the `rafter-secure-design` skill at `.claude/skills/rafter-secure-design/SKILL.md` BEFORE writing code for any feature on the surface listed above.
+
+- Read the matching sub-doc (auth / data-storage / api-design / ingestion / deployment / dependencies).
+- Each sub-doc is a set of questions a security engineer would ask at kickoff — answer them inline in the design or PR description.
+- Pair with `rafter-code-review` (mid-lifecycle) and `rafter run` (detection) once code exists.
+
+Skipping this skill on the listed surfaces is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. Do not proceed to implementation until it has run.

--- a/python/rafter_cli/resources/windsurf-rules/rafter-skill-review.md
+++ b/python/rafter_cli/resources/windsurf-rules/rafter-skill-review.md
@@ -1,0 +1,14 @@
+---
+trigger: model_decision
+description: "REQUIRED before copying any third-party SKILL.md, MCP manifest, Cursor rule, or agent config into this machine or forwarding one to a user. Installing a skill grants Read/Bash/network under your identity — this is `curl | sh` in a different costume. Do not install, load, recommend, or forward any third-party agent asset until this skill has vetted it. Bypassing this turns the agent into a delivery vector."
+---
+
+# rafter-skill-review — vet before you install
+
+Pointer rule. Use the `rafter-skill-review` skill at `.claude/skills/rafter-skill-review/SKILL.md` BEFORE installing or forwarding any third-party agent asset.
+
+- Run `rafter skill review <path-or-url>` against the SKILL.md / MCP manifest / Cursor rule / agent config.
+- Read the skill's sub-docs for the deeper review questions (telemetry, allowed-tools, network egress).
+- Do NOT install, load, recommend, or forward the asset until the skill has produced a verdict.
+
+Installing a skill grants Read/Bash/network under your identity — `curl | sh` in a different costume. Bypassing this turns the agent into a delivery vector.

--- a/python/rafter_cli/resources/windsurf-rules/rafter.md
+++ b/python/rafter_cli/resources/windsurf-rules/rafter.md
@@ -1,0 +1,15 @@
+---
+trigger: model_decision
+description: "Entry point for rafter. Invoke when a sub-skill is unclear, or when the task needs `rafter run` (remote SAST+SCA), `rafter secrets` (local secrets-only), `rafter audit`, policy checks, or command-risk evaluation. If a task is security-relevant and no rafter skill or CLI call has been made, invoke this before handing the task off — an un-evaluated \"done\" on security-relevant work is not done."
+---
+
+# rafter — security toolkit router
+
+Pointer rule. Use the `rafter` skill (full guidance at `.claude/skills/rafter/SKILL.md`).
+
+- Run `rafter run` for the default tier — remote SAST + SCA + secrets. Needs `RAFTER_API_KEY`.
+- Run `rafter run --mode plus` for agentic deep-dive on suspicious patterns.
+- Run `rafter secrets <path>` for offline secrets-only (NOT a code security scan).
+- Run `rafter agent exec --dry-run -- <cmd>` to classify a shell command's risk before running it.
+
+If unsure which tier to pick, Read `.claude/skills/rafter/SKILL.md` and follow the routing table.

--- a/python/tests/test_agent_components.py
+++ b/python/tests/test_agent_components.py
@@ -59,7 +59,7 @@ class TestAgentList:
             "cursor.mcp",
             "gemini.hooks",
             "gemini.mcp",
-            "windsurf.hooks",
+            "windsurf.rules",
             "windsurf.mcp",
             "continue.mcp",
             "aider.mcp",

--- a/python/tests/test_agent_init.py
+++ b/python/tests/test_agent_init.py
@@ -10,6 +10,7 @@ from rafter_cli.commands.agent import (
     _install_gemini_mcp,
     _install_cursor_mcp,
     _install_windsurf_mcp,
+    _install_windsurf_rules,
     _install_continue_dev_mcp,
     _install_aider_mcp,
 )
@@ -145,6 +146,42 @@ class TestInstallWindsurfMcp:
         assert mcp_path.exists()
         config = json.loads(mcp_path.read_text())
         assert config["mcpServers"]["rafter"]["command"] == "rafter"
+
+
+class TestInstallWindsurfRules:
+    """rf-0vr3 — per-skill rules at .windsurf/rules/<skill>.md replace
+    the broken ~/.windsurf/hooks.json install (Windsurf has no hook surface)."""
+
+    SKILL_NAMES = ("rafter", "rafter-secure-design", "rafter-code-review", "rafter-skill-review")
+
+    def test_writes_one_rule_per_skill(self, tmp_path):
+        _install_windsurf_rules(tmp_path)
+        rules_dir = tmp_path / ".windsurf" / "rules"
+        for name in self.SKILL_NAMES:
+            assert (rules_dir / f"{name}.md").exists(), f"missing rule: {name}"
+
+    def test_rules_have_windsurf_frontmatter(self, tmp_path):
+        _install_windsurf_rules(tmp_path)
+        rules_dir = tmp_path / ".windsurf" / "rules"
+        for name in self.SKILL_NAMES:
+            body = (rules_dir / f"{name}.md").read_text()
+            assert body.startswith("---\ntrigger: model_decision"), (
+                f"{name}.md missing Windsurf trigger frontmatter"
+            )
+            assert "description:" in body.split("---")[1]
+
+    def test_does_not_write_hooks_json(self, tmp_path):
+        _install_windsurf_rules(tmp_path)
+        # hooks.json explicitly not created — Windsurf has no hook surface (rf-0vr3).
+        assert not (tmp_path / ".windsurf" / "hooks.json").exists()
+
+    def test_idempotent_on_reinstall(self, tmp_path):
+        _install_windsurf_rules(tmp_path)
+        _install_windsurf_rules(tmp_path)
+        rules_dir = tmp_path / ".windsurf" / "rules"
+        # Still exactly the four files; no duplicates appended to filenames.
+        files = sorted(p.name for p in rules_dir.iterdir())
+        assert files == sorted(f"{n}.md" for n in self.SKILL_NAMES)
 
 
 class TestInstallContinueDevMcp:

--- a/recipes/windsurf.md
+++ b/recipes/windsurf.md
@@ -1,20 +1,73 @@
 # Windsurf Setup
 
-Rafter integrates with Windsurf (Codeium) through an **MCP server** that exposes scanning and auditing tools.
+Rafter integrates with Windsurf (Codeium) through three surfaces:
+
+1. **Per-skill workspace rules** at `.windsurf/rules/<skill>.md` — Windsurf's
+   agent fetches the matching rule when its description matches the task.
+2. **`AGENTS.md`** at the workspace root — Windsurf reads it natively as
+   persistent project context (and so does Codex; one file covers both).
+3. **MCP server** under `~/.codeium/windsurf/mcp_config.json` — exposes
+   `scan_secrets`, `evaluate_command`, `read_audit_log`, and `get_config` tools.
+
+> Windsurf has **no documented hook surface** in current versions. Earlier
+> versions of `rafter agent init --with-windsurf` wrote `~/.windsurf/hooks.json`
+> with `pre_run_command` / `pre_write_code` entries — the file existed but was
+> never consumed by the IDE. That install was pruned in `rf-0vr3`.
 
 ## Automatic setup
 
 ```sh
+# At a project root (rules + AGENTS.md, no Windsurf install required):
+rafter agent init --local --with-windsurf
+
+# At user scope (additionally registers the MCP server):
 rafter agent init --with-windsurf
 ```
 
-This auto-detects `~/.codeium/windsurf` and installs the MCP server config. Done.
+The user-scope install auto-detects `~/.codeium/windsurf`. The project-scope
+install (`--local`) writes only to the current workspace, so it works even on
+a machine without Windsurf installed.
+
+## What gets installed
+
+| Path | Scope | Purpose |
+|---|---|---|
+| `<cwd>/.windsurf/rules/rafter.md` | workspace | Tier router rule (delegates to the `rafter` skill) |
+| `<cwd>/.windsurf/rules/rafter-secure-design.md` | workspace | Shift-left design review rule |
+| `<cwd>/.windsurf/rules/rafter-code-review.md` | workspace | Pre-merge code-review rule |
+| `<cwd>/.windsurf/rules/rafter-skill-review.md` | workspace | Vet third-party agent assets before install |
+| `<cwd>/AGENTS.md` | workspace | Persistent project context (also read by Codex) |
+| `~/.codeium/windsurf/mcp_config.json` | user (only with user-scope install) | MCP server entry |
+
+Each rule uses Windsurf's YAML frontmatter:
+
+```yaml
+---
+trigger: model_decision
+description: "REQUIRED before declaring a task done when the diff touches ..."
+---
+```
+
+The `trigger: model_decision` mode lets Windsurf's agent decide when to fetch
+the rule based on the description.
 
 ## Manual setup
 
-### 1. MCP server
+### 1. Workspace rules
 
-Add to your `~/.codeium/windsurf/mcp_config.json`:
+Create `.windsurf/rules/rafter.md` (and similar files for the other three
+skills) with the frontmatter shape above. Cap each file at 12,000 characters
+per Windsurf's per-file limit.
+
+### 2. AGENTS.md
+
+Create or extend `AGENTS.md` at the workspace root with a rafter content block
+between `<!-- rafter:start -->` and `<!-- rafter:end -->` markers. Re-running
+`rafter agent init --with-windsurf` will preserve content outside that block.
+
+### 3. MCP server
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
 
 ```json
 {
@@ -27,12 +80,12 @@ Add to your `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
-Provides `scan_secrets`, `evaluate_command`, `read_audit_log`, and `get_config` tools.
-
 ## Verify
 
 ```sh
 rafter agent verify
 ```
 
-Confirms MCP server is configured and Windsurf is detected.
+Confirms the rules, AGENTS.md, and (where applicable) the MCP server entry
+are in place. Restart Windsurf after install so the agent picks up the new
+rules and MCP server.

--- a/shared-docs/PLATFORM_PARITY_AUDIT.md
+++ b/shared-docs/PLATFORM_PARITY_AUDIT.md
@@ -316,3 +316,11 @@ All linked via `discovered-from:rf-guvb,rf-cia`. See each bead for scope and acc
 - **rf-0lig** (P3) — OpenClaw: confirm activity / users before further investment
 
 The recipes-stale gap is folded into each per-platform bead's acceptance. Sub-agent for Claude Code is tracked under the existing rf-q7j (in flight).
+
+## Update (2026-05-03 — phase c progress)
+
+- **Cursor deep support shipped** — PR #81 (rf-svn3, merged). `preToolUse` + `postToolUse` + `beforeShellExecution` hooks, 4 per-skill `.cursor/rules/<skill>.mdc` files, and `.cursor/agents/rafter.md` sub-agent. Closes the Cursor matrix-row gaps (skills, hooks, sub-agent). rf-p1fs closed as duplicate of rf-svn3.
+- **Windsurf deep support shipped** — this PR (rf-0vr3). Pruned the silent-no-op `~/.windsurf/hooks.json` install (Windsurf has no hook surface), added 4 per-skill rules under `.windsurf/rules/<skill>.md`, extended `installGlobalInstructions` so `--with-windsurf` writes `AGENTS.md` at workspace root (Windsurf reads it natively). Windsurf now installs at `--local` scope as well. rf-jrs0 closed as duplicate of rf-0vr3.
+- **Codex hook schema verification** — newly beaded as rf-ovql (P1) after the rf-cia gap reports independently flagged it. Tracks the unverified assumption that Codex consumes Claude Code's `PreToolUse`/`PostToolUse` schema verbatim.
+
+Outstanding rf-cia work after this PR: rf-acz0 (Continue rules), rf-du2o (Aider prune+RAFTER.md), rf-044o (Gemini re-verify), rf-ovql (Codex schema), rf-65zg (`agent verify` enhancements), rf-o329 (onboarding doc), rf-0lig (OpenClaw activity check).


### PR DESCRIPTION
## Summary

Brings Windsurf to the integration shape Windsurf actually consumes (rf-cia phase c). Closes bead **rf-0vr3** and supersedes **rf-jrs0** (closed as duplicate).

### Pruned

- **`~/.windsurf/hooks.json`** install (Node + Python). Windsurf has no documented hook surface; `pre_run_command` / `pre_write_code` were silently ignored at runtime. Independently flagged by the rf-cia gap reports (rf-p1ri, rf-vayl) and the research bead (rf-s1n3). Same prune pattern as the Continue.dev hooks prune (rf-cia phase b).
- `windsurf.hooks` ComponentSpec dropped from both Node and Python registries; `agent enable/disable` no longer offers it.

### Added

- **Per-skill rules under `.windsurf/rules/<skill>.md`** with Windsurf YAML frontmatter (`trigger: model_decision` + `description:`). Four files mirror the Cursor pointer-rule pattern: `rafter`, `rafter-secure-design`, `rafter-code-review`, `rafter-skill-review`.
- `windsurf.rules` ComponentSpec replaces `windsurf.hooks` in the registry.
- **`AGENTS.md`** write at workspace root for `--with-windsurf`. `installGlobalInstructions` now consolidates Codex + Windsurf into a single `AGENTS.md` (both read it natively); the `<!-- rafter:start --> ... <!-- rafter:end -->` marker preserves user content.
- **`--local` (project) install** for Windsurf. Project install ships rules + `AGENTS.md`; user install additionally registers the MCP entry under `~/.codeium/windsurf/mcp_config.json`.
- Recipe `recipes/windsurf.md` rewritten to document the new shape (rules + AGENTS.md + MCP, no hooks).

### Test plan

- [x] 5 new Node tests in \`describe(\"Windsurf integration (--with-windsurf)\")\` — green
- [x] 4 new Python tests in \`TestInstallWindsurfRules\` — green
- [x] \`agent-components\` tests in both impls updated to expect \`windsurf.rules\` — green
- [x] Combined \"All 8 platforms\" integration test updated and green
- [x] Live smoke (Node): \`rafter agent init --local --with-windsurf\` writes 4 rules + AGENTS.md, no hooks.json
- [x] Live smoke (Python): same

The 9 pre-existing Gemini failures in \`node/tests/platform-integration.test.ts\` are unchanged by this work — they fail on \`main\` too.

### Out of scope

- \`~/.codeium/windsurf/memories/global_rules.md\` global pointer (6KB cap, marker injection across multiple skills) — deferred to a follow-up if needed.
- Cursor / Continue.dev / Aider / Gemini / Codex parity — separate beads.
- \`rafter agent verify --probe\` runtime check — rf-65zg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)