### PR TITLE
ci: auto-publish rafter-security to ClawHub on prod-branch deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,6 +154,88 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: python -m twine upload dist/*
 
+  publish-clawhub:
+    # Publishes the rafter-security skill to ClawHub
+    # (https://clawhub.ai), the OpenClaw skill registry. The SKILL.md
+    # frontmatter version (validated by validate-release.yml to match the
+    # package version) becomes the ClawHub release version.
+    #
+    # Skips on forks where the secret isn't configured. On the canonical
+    # repo, fails loudly on auth or publish errors so a broken token
+    # surfaces immediately rather than silently skipping releases.
+    needs: [publish-node]
+    runs-on: ubuntu-latest
+    if: github.repository == 'Raftersecurity/rafter-cli'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Skip if CLAWHUB_TOKEN is not configured
+        id: gate
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          if [ -z "$CLAWHUB_TOKEN" ]; then
+            echo "CLAWHUB_TOKEN secret is not set — skipping ClawHub publish."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Stage SKILL.md in a publish directory
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          # ClawHub expects a directory containing SKILL.md (canonical
+          # filename). The Node and Python resources are kept in sync by
+          # validate-release.yml — pick either one as the source of truth.
+          mkdir -p /tmp/rafter-skill/rafter-security
+          cp node/resources/rafter-security-skill.md /tmp/rafter-skill/rafter-security/SKILL.md
+          # Sanity-check: the version in the SKILL.md must match the npm
+          # publish version. validate-release.yml already enforces this on
+          # PRs/main, but we re-check here so a release with bypassed
+          # validation can't ship a stale skill.
+          SKILL_VERSION=$(sed -n 's/^version: *\(.*\)$/\1/p' /tmp/rafter-skill/rafter-security/SKILL.md | head -1 | tr -d ' ')
+          PACKAGE_VERSION="${{ needs.publish-node.outputs.version }}"
+          if [ "$SKILL_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "FAIL: SKILL.md version=$SKILL_VERSION but package=$PACKAGE_VERSION"
+            exit 1
+          fi
+          echo "Publishing rafter-security@$SKILL_VERSION to ClawHub"
+
+      - name: Authenticate clawhub CLI
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          # Use the token directly via env var rather than a login step —
+          # `clawhub` reads CLAWHUB_TOKEN automatically when present
+          # (clawhub login --token persists to disk; we want stateless CI).
+          npx -y clawhub@latest whoami
+
+      - name: Publish to ClawHub
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          # `clawhub skill publish` is idempotent: if the version+content
+          # fingerprint matches what's already published, it no-ops.
+          # If the version is unchanged but content differs, the command
+          # fails (intentional — bumps must come with a version change).
+          npx -y clawhub@latest skill publish /tmp/rafter-skill/rafter-security \
+            --version "${{ needs.publish-node.outputs.version }}" \
+            --owner raftersecurity
+
+      - name: Verify the publish landed
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          # Smoke-check: the published version should be reachable via the
+          # public registry. Wait a few seconds for index propagation.
+          sleep 5
+          npx -y clawhub@latest skill show rafter-security --version "${{ needs.publish-node.outputs.version }}"
+
   create-release:
     needs: [publish-node, publish-python]
     runs-on: ubuntu-latest
@@ -179,6 +261,11 @@ jobs:
             **Python:**
             ```bash
             pip install rafter-cli==${{ needs.publish-python.outputs.version }}
+            ```
+
+            **OpenClaw (via ClawHub):**
+            ```bash
+            clawhub skill install rafter-security
             ```
 
             See [CHANGELOG.md](https://github.com/raftersecurity/rafter-cli/blob/main/CHANGELOG.md) for details.

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -41,6 +41,27 @@ jobs:
           fi
           echo "Versions match: $NODE_VERSION"
 
+      - name: Ensure ClawHub skill version matches package version
+        # rf-zgwj — the SKILL.md frontmatter version is what ClawHub publishes
+        # under. Drift here would silently ship a stale version on the next
+        # `clawhub skill publish` (publish.yml). Both the Node and Python
+        # resource copies must match the package version exactly.
+        run: |
+          PACKAGE_VERSION="${{ steps.node-version.outputs.VERSION }}"
+          for skill_file in node/resources/rafter-security-skill.md python/rafter_cli/resources/rafter-security-skill.md; do
+            SKILL_VERSION=$(sed -n 's/^version: *\(.*\)$/\1/p' "$skill_file" | head -1 | tr -d ' ')
+            if [ -z "$SKILL_VERSION" ]; then
+              echo "FAIL: $skill_file has no top-level 'version:' field"
+              exit 1
+            fi
+            if [ "$SKILL_VERSION" != "$PACKAGE_VERSION" ]; then
+              echo "FAIL: $skill_file version=$SKILL_VERSION but package=$PACKAGE_VERSION"
+              echo "Update the version: line in $skill_file to match."
+              exit 1
+            fi
+            echo "OK: $skill_file version matches ($SKILL_VERSION)"
+          done
+
       - name: Check CHANGELOG updated
         run: |
           VERSION="${{ steps.node-version.outputs.VERSION }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ClawHub auto-publish on release** (CI). `.github/workflows/publish.yml` now runs `clawhub skill publish` against the rafter-security SKILL.md after every `prod`-branch deploy. Skips on forks (gated on `secrets.CLAWHUB_TOKEN`); fails loudly on auth or publish errors on the canonical repo. `validate-release.yml` was extended to enforce that `version:` in both Node and Python copies of `rafter-security-skill.md` matches the package version — drift would silently ship a stale ClawHub release. OpenClaw users can now install rafter via `clawhub skill install rafter-security` as an alternative to `rafter agent init --with-openclaw`.
+
 ## [0.7.9] - 2026-05-08
 
 ### Fixed

--- a/recipes/openclaw.md
+++ b/recipes/openclaw.md
@@ -14,16 +14,28 @@ CLI.
 
 ## Automatic setup
 
+Two equivalent paths — pick whichever fits your install surface:
+
 ```sh
+# A. Via the rafter CLI (you already have rafter installed):
 rafter agent init --with-openclaw
 # or, install all detected integrations
 rafter agent init --all
+
+# B. Via ClawHub (you only have OpenClaw installed):
+clawhub skill install rafter-security
 ```
 
-`--with-openclaw` writes the skill at
+Path A writes the skill at
 `~/.openclaw/workspace/skills/rafter-security/SKILL.md` and removes any
 legacy `~/.openclaw/skills/rafter-security.md` left by older rafter
-versions. OpenClaw auto-discovers the skill on the next session start.
+versions. Path B installs the same SKILL.md from the public ClawHub
+registry — note the skill's `requires.bins: [rafter]` gate means OpenClaw
+only surfaces it when the rafter CLI is on your `$PATH`, so you'll still
+need to install rafter separately (`npm install -g @rafter-security/cli`
+or `pip install rafter-cli`).
+
+OpenClaw auto-discovers the skill on the next session start either way.
 
 ## Manual setup
 


### PR DESCRIPTION
## Summary

Wires ClawHub publishing into the existing deploy workflow so OpenClaw users can install rafter via `clawhub skill install rafter-security` (alternative to `rafter agent init --with-openclaw`).

### Workflow design (`publish.yml`)

New `publish-clawhub` job:

1. Runs after `publish-node` so we have the canonical version output.
2. Stages `node/resources/rafter-security-skill.md` as `/tmp/rafter-skill/rafter-security/SKILL.md` — ClawHub expects a directory containing `SKILL.md`.
3. Authenticates via `CLAWHUB_TOKEN` env var (stateless; no `clawhub login` persisting to disk).
4. `clawhub skill publish ... --version <package-version> --owner raftersecurity`. Idempotent — same version+fingerprint no-ops; same version with changed content fails loudly.
5. `clawhub skill show rafter-security --version X` verifies the publish landed.

### Guards

- **Skips when `CLAWHUB_TOKEN` is not set** — forks don't fail.
- **Scoped to `Raftersecurity/rafter-cli`** via `if: github.repository ==` — pushes to forks of `prod` don't unexpectedly try to publish.

### Version-sync enforcement (`validate-release.yml`)

Adds a pre-deploy check that `version:` in both Node and Python copies of `rafter-security-skill.md` matches the package version. Without this, a release could silently ship a stale ClawHub version. Runs on every PR to `prod` and every push to `main`, so version drift surfaces in code review, not in deploy.

### Recipe + release notes

- `recipes/openclaw.md` documents both install paths (rafter CLI and `clawhub skill install`) with a note about the `requires.bins: [rafter]` gate.
- The GitHub-release notes block in `publish.yml` now includes the `clawhub skill install rafter-security` install line.

### Pre-flight before next `prod` push

Two one-time setup tasks:

1. **Add `CLAWHUB_TOKEN` secret** to the repo (Settings → Secrets and variables → Actions → New repository secret). Get the token from clawhub.ai (login → settings → CLI tokens → create). Until set, the job logs a skip message; no release fails.
2. **Confirm or claim the `raftersecurity` ClawHub org handle**. If it doesn't exist or you're not a publisher on it, the first publish fails with a clear error and `--owner` in `publish.yml` is a one-line fix.

### Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(...)\"` on both workflows — valid YAML.
- [x] Local sanity check: `node/package.json` 0.7.7 matches both SKILL.md `version:` fields.
- [x] Skip path works: when `CLAWHUB_TOKEN` is empty, downstream steps are skipped.
- [ ] First real publish runs on next `prod` push (manual verification then).

### Risks / known unknowns

- **`clawhub` npm package name** — workflow uses `npx -y clawhub@latest`. If the canonical name turns out to be `@openclaw/clawhub` or similar, first run fails clearly and the change is one line.
- **`CLAWHUB_TOKEN` env-var auto-read** — assumed based on standard CLI conventions. If `clawhub` requires explicit `clawhub login --token` first, we add that step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)