### PR TITLE
fix(ci): use 'rafter' as the ClawHub owner handle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -226,7 +226,7 @@ jobs:
           # fails (intentional — bumps must come with a version change).
           npx -y clawhub@latest skill publish /tmp/rafter-skill/rafter-security \
             --version "${{ needs.publish-node.outputs.version }}" \
-            --owner raftersecurity
+            --owner rafter
 
       - name: Verify the publish landed
         if: steps.gate.outputs.skip != 'true'


### PR DESCRIPTION
The actual ClawHub handle is \`rafter\`, not \`raftersecurity\`. One-line fix in \`publish.yml\` so the first real publish doesn't fail with "owner not found."

🤖 Generated with [Claude Code](https://claude.com/claude-code)