### PR TITLE
docs(rf-z6sv): bump README pre-commit rev pins to v0.7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Rafter works as a [pre-commit](https://pre-commit.com) hook. Add to your `.pre-c
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.7.1
+    rev: v0.7.9
     hooks:
       - id: rafter-scan-node
 ```
@@ -430,7 +430,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.7.1
+    rev: v0.7.9
     hooks:
       - id: rafter-scan-node      # auto-installs via npm
       # - id: rafter-scan-python  # auto-installs via pip


### PR DESCRIPTION
Both `rev:` pins in the pre-commit README examples were stuck at `v0.7.1`. Repo is at `v0.7.9`. New adopters who copy-paste fall back to old behavior. Bumped both lines to `v0.7.9`. Closes rf-z6sv.