### PR TITLE
fix(ci): clawhub needs explicit login --token + Node 22 (post-mortem)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,7 +171,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # Node 22 — clawhub's transitive dep p-retry@8 requires >=22.
+          # Node 20 produces an EBADENGINE warning but the real failure
+          # surfaces later as a non-obvious runtime error.
+          node-version: "22"
 
       - name: Skip if CLAWHUB_TOKEN is not configured
         id: gate
@@ -210,15 +213,16 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
-          # Use the token directly via env var rather than a login step —
-          # `clawhub` reads CLAWHUB_TOKEN automatically when present
-          # (clawhub login --token persists to disk; we want stateless CI).
+          # `clawhub` does NOT auto-read CLAWHUB_TOKEN — the CLI requires an
+          # explicit `clawhub login --token` to persist auth before any
+          # publish/show command (rf-zgwj follow-up after first-publish
+          # failure on prod). The persisted token lives in the runner's
+          # ephemeral filesystem and is discarded when the job ends.
+          npx -y clawhub@latest login --token "$CLAWHUB_TOKEN"
           npx -y clawhub@latest whoami
 
       - name: Publish to ClawHub
         if: steps.gate.outputs.skip != 'true'
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           # `clawhub skill publish` is idempotent: if the version+content
           # fingerprint matches what's already published, it no-ops.


### PR DESCRIPTION
## What happened

First prod publish failed:

```
Run npx -y clawhub@latest whoami
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'p-retry@8.0.0',
npm warn EBADENGINE   required: { node: '>=22' },
npm warn EBADENGINE   current: { node: 'v20.20.2', npm: '10.8.2' }
npm warn EBADENGINE }
Error: Not logged in. Run: clawhub login
Error: Process completed with exit code 1.
```

## What was wrong

Two assumptions in the original wiring (PR #94) didn't hold:

1. **`clawhub` doesn't auto-read `CLAWHUB_TOKEN` from env.** The CLI requires an explicit `clawhub login --token` to persist auth before any publish/show command. Confirmed against [clawhub/docs/auth.md](https://github.com/openclaw/clawhub/blob/main/docs/auth.md).
2. **Node 20 is below `p-retry@8`'s engine requirement.** The original setup-node was pinned at 20; \`p-retry\` (a clawhub transitive dep) needs >=22.

## Fix

- Add explicit \`clawhub login --token \"\$CLAWHUB_TOKEN\"\` before \`whoami\`. Persisted token lives in the runner's ephemeral filesystem and is discarded when the job ends.
- Bump \`setup-node\` from 20 → 22 in the \`publish-clawhub\` job specifically (other jobs unaffected — they don't need clawhub).

Total: 1 file, +10/-6.

## Test plan

- [x] YAML lint clean.
- [ ] Next prod push validates the fix end-to-end. If \`clawhub login --token\` itself errors (e.g. token format), that surfaces clearly now since auth is its own step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)