### PR TITLE
chore(release): bump to v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-12
+
+### Fixed
+- **CI ClawHub publish auth + Node 22** (#101). The first post-0.8.0 publish failed with `Error: Not logged in. Run: clawhub login` on the `whoami` step — the assumption baked into the original ClawHub wiring that the CLI auto-reads `CLAWHUB_TOKEN` from env was wrong. Added an explicit `clawhub login --token "$CLAWHUB_TOKEN"` line before any `clawhub` call; the persisted token lives in the runner's ephemeral filesystem and is discarded when the job ends. Also bumped `setup-node` in the `publish-clawhub` job from 20 → 22 because clawhub's transitive dep `p-retry@8` requires Node ≥22 (Node 20 surfaced as an `EBADENGINE` warning in the failed run, but would have hit a real runtime error later).
+- **Stale test diagnostic + obsolete assertions across the test suite.** rf-of20 (Claude Code sub-agent idempotency test: diagnostic now surfaces the actual divergence on failure), rf-b1hf (drop obsolete sub-docs mirror assertion in `brief.test.ts` — sub-docs no longer ship under skills root), rf-ax2p (e2e regex updated to match the wrapped "Secrets only" help text). Cross-runtime parity tests + the comprehensive test suite updated for the rf-0pch wrapped-JSON shape and to use `rafter secrets` in place of the deprecated `rafter scan local` alias.
+- **rc-bc9: deleted `node/.claude/skills/`.** A stale development copy of the skill content that drifted from the canonical `node/resources/skills/`. Removing it eliminates the drift class entirely; the resources tree is the single source of truth.
+
 ## [0.8.0] - 2026-05-10
 
 ### Changed

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.0
+version: 0.8.1
 homepage: https://rafter.so
 metadata:
   openclaw:
@@ -15,7 +15,7 @@ metadata:
       - name: RAFTER_API_KEY
         required: false
         description: API key for `rafter run` (remote SAST + SCA + agentic deep-dive). Without it, `rafter secrets` (local secrets scan) still works.
-last_updated: 2026-05-07
+last_updated: 2026-05-12
 ---
 
 # Rafter Security

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.8.0"
+version = "0.8.1"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.0
+version: 0.8.1
 homepage: https://rafter.so
 metadata:
   openclaw:
@@ -15,7 +15,7 @@ metadata:
       - name: RAFTER_API_KEY
         required: false
         description: API key for `rafter run` (remote SAST + SCA + agentic deep-dive). Without it, `rafter secrets` (local secrets scan) still works.
-last_updated: 2026-05-07
+last_updated: 2026-05-12
 ---
 
 # Rafter Security


### PR DESCRIPTION
Patch release. Bumps node/package.json + python/pyproject.toml + both SKILL.md `version:` frontmatters to 0.8.1; appends `[0.8.1] - 2026-05-12` to CHANGELOG.

Bundled fixes since v0.8.0:
- #101 — CI ClawHub publish auth + Node 22 (post-mortem of the failed first publish)
- rf-of20, rf-b1hf, rf-ax2p — test diagnostic + obsolete-assertion cleanups
- rc-bc9 — deleted stale `node/.claude/skills/` (drifted dev copy)

No production behavior change beyond the CI fix. Merging this into `main` then opening a `main → prod` PR will trigger `publish.yml` to npm/PyPI + (this time, for real) ClawHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)