### PR TITLE
Release v0.8.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,7 +171,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # Node 22 — clawhub's transitive dep p-retry@8 requires >=22.
+          # Node 20 produces an EBADENGINE warning but the real failure
+          # surfaces later as a non-obvious runtime error.
+          node-version: "22"
 
       - name: Skip if CLAWHUB_TOKEN is not configured
         id: gate
@@ -210,15 +213,16 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
-          # Use the token directly via env var rather than a login step —
-          # `clawhub` reads CLAWHUB_TOKEN automatically when present
-          # (clawhub login --token persists to disk; we want stateless CI).
+          # `clawhub` does NOT auto-read CLAWHUB_TOKEN — the CLI requires an
+          # explicit `clawhub login --token` to persist auth before any
+          # publish/show command (rf-zgwj follow-up after first-publish
+          # failure on prod). The persisted token lives in the runner's
+          # ephemeral filesystem and is discarded when the job ends.
+          npx -y clawhub@latest login --token "$CLAWHUB_TOKEN"
           npx -y clawhub@latest whoami
 
       - name: Publish to ClawHub
         if: steps.gate.outputs.skip != 'true'
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           # `clawhub skill publish` is idempotent: if the version+content
           # fingerprint matches what's already published, it no-ops.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-12
+
+### Fixed
+- **CI ClawHub publish auth + Node 22** (#101). The first post-0.8.0 publish failed with `Error: Not logged in. Run: clawhub login` on the `whoami` step — the assumption baked into the original ClawHub wiring that the CLI auto-reads `CLAWHUB_TOKEN` from env was wrong. Added an explicit `clawhub login --token "$CLAWHUB_TOKEN"` line before any `clawhub` call; the persisted token lives in the runner's ephemeral filesystem and is discarded when the job ends. Also bumped `setup-node` in the `publish-clawhub` job from 20 → 22 because clawhub's transitive dep `p-retry@8` requires Node ≥22 (Node 20 surfaced as an `EBADENGINE` warning in the failed run, but would have hit a real runtime error later).
+- **Stale test diagnostic + obsolete assertions across the test suite.** rf-of20 (Claude Code sub-agent idempotency test: diagnostic now surfaces the actual divergence on failure), rf-b1hf (drop obsolete sub-docs mirror assertion in `brief.test.ts` — sub-docs no longer ship under skills root), rf-ax2p (e2e regex updated to match the wrapped "Secrets only" help text). Cross-runtime parity tests + the comprehensive test suite updated for the rf-0pch wrapped-JSON shape and to use `rafter secrets` in place of the deprecated `rafter scan local` alias.
+- **rc-bc9: deleted `node/.claude/skills/`.** A stale development copy of the skill content that drifted from the canonical `node/resources/skills/`. Removing it eliminates the drift class entirely; the resources tree is the single source of truth.
+
 ## [0.8.0] - 2026-05-10
 
 ### Changed

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.0
+version: 0.8.1
 homepage: https://rafter.so
 metadata:
   openclaw:
@@ -15,7 +15,7 @@ metadata:
       - name: RAFTER_API_KEY
         required: false
         description: API key for `rafter run` (remote SAST + SCA + agentic deep-dive). Without it, `rafter secrets` (local secrets scan) still works.
-last_updated: 2026-05-07
+last_updated: 2026-05-12
 ---
 
 # Rafter Security

--- a/node/tests/claude-code-subagent.test.ts
+++ b/node/tests/claude-code-subagent.test.ts
@@ -28,10 +28,15 @@ function cleanupDir(dir: string) {
   }
 }
 
+// 30s default per-call timeout. The original 15s flaked on slow CI runners
+// (rf-of20 documented the same root cause for the idempotency test: cold-start
+// ubuntu+node-22 + spawnSync with shell:true occasionally takes >15s for a
+// single `agent init` run). Apply the same fix to every install-doing test
+// here rather than just the idempotent one.
 function runCli(
   args: string,
   homeDir: string,
-  timeout = 15_000
+  timeout = 30_000
 ): { stdout: string; stderr: string; exitCode: number } {
   const result = spawnSync(`node ${CLI_ENTRY} ${args}`, {
     cwd: PROJECT_ROOT,
@@ -75,12 +80,20 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
 
   it("sub-agent file has the required frontmatter (name, description, tools)", () => {
     fs.mkdirSync(path.join(testHomeDir, ".claude"), { recursive: true });
-    runCli("agent init --with-claude-code", testHomeDir);
+    const r = runCli("agent init --with-claude-code", testHomeDir);
 
-    const content = fs.readFileSync(
-      path.join(testHomeDir, ".claude", "agents", "rafter.md"),
-      "utf-8"
-    );
+    // Diagnostic gate before readFileSync — without this, a slow CI install
+    // surfaces as a bare ENOENT that hides whether `agent init` returned
+    // non-zero (real bug) or silently exceeded the timeout (timing/fs issue).
+    // Mirrors the rf-of20 pattern from the idempotency test.
+    const subagentPath = path.join(testHomeDir, ".claude", "agents", "rafter.md");
+    expect(r.exitCode, `agent init failed: ${r.stderr || r.stdout}`).toBe(0);
+    expect(
+      fs.existsSync(subagentPath),
+      `subagent missing after install. stdout=${r.stdout} stderr=${r.stderr}`,
+    ).toBe(true);
+
+    const content = fs.readFileSync(subagentPath, "utf-8");
 
     // Frontmatter delimiters
     expect(content.startsWith("---\n")).toBe(true);
@@ -95,12 +108,16 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
 
   it("sub-agent body references current rafter commands and tier hierarchy", () => {
     fs.mkdirSync(path.join(testHomeDir, ".claude"), { recursive: true });
-    runCli("agent init --with-claude-code", testHomeDir);
+    const r = runCli("agent init --with-claude-code", testHomeDir);
 
-    const content = fs.readFileSync(
-      path.join(testHomeDir, ".claude", "agents", "rafter.md"),
-      "utf-8"
-    );
+    const subagentPath = path.join(testHomeDir, ".claude", "agents", "rafter.md");
+    expect(r.exitCode, `agent init failed: ${r.stderr || r.stdout}`).toBe(0);
+    expect(
+      fs.existsSync(subagentPath),
+      `subagent missing after install. stdout=${r.stdout} stderr=${r.stderr}`,
+    ).toBe(true);
+
+    const content = fs.readFileSync(subagentPath, "utf-8");
 
     // Trigger phrasing that maps to user's question
     expect(content).toContain("safe / secure / production worthy");
@@ -149,7 +166,7 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
       const result = spawnSync(`node ${CLI_ENTRY} agent init --local --with-claude-code`, {
         cwd: projectDir,
         encoding: "utf-8",
-        timeout: 15_000,
+        timeout: 30_000,
         shell: true,
         env: {
           ...process.env,
@@ -158,10 +175,12 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
         },
         stdio: ["pipe", "pipe", "pipe"],
       });
-      expect(result.status).toBe(0);
-
       const subagentPath = path.join(projectDir, ".claude", "agents", "rafter.md");
-      expect(fs.existsSync(subagentPath)).toBe(true);
+      expect(result.status, `agent init --local failed: ${result.stderr || result.stdout}`).toBe(0);
+      expect(
+        fs.existsSync(subagentPath),
+        `subagent missing after --local install. stdout=${result.stdout} stderr=${result.stderr}`,
+      ).toBe(true);
     } finally {
       cleanupDir(projectDir);
     }

--- a/node/tests/claude-code-subagent.test.ts
+++ b/node/tests/claude-code-subagent.test.ts
@@ -117,11 +117,19 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
   it("is idempotent on repeated installs", () => {
     fs.mkdirSync(path.join(testHomeDir, ".claude"), { recursive: true });
 
-    runCli("agent init --with-claude-code", testHomeDir);
+    // Bumped from default 15s → 30s. rf-of20 flaked on cross-platform
+    // (ubuntu-latest, 18) once: spawnSync with shell:true on cold-start
+    // ubuntu+node-18 occasionally exceeds 15s for two back-to-back
+    // `agent init` runs. Keep diagnostics below so a real install
+    // failure is distinguishable from a missing file.
+    const r1 = runCli("agent init --with-claude-code", testHomeDir, 30_000);
     const subagentPath = path.join(testHomeDir, ".claude", "agents", "rafter.md");
+    expect(r1.exitCode, `first install failed: ${r1.stderr || r1.stdout}`).toBe(0);
+    expect(fs.existsSync(subagentPath), `subagent missing after first install. stdout=${r1.stdout} stderr=${r1.stderr}`).toBe(true);
     const first = fs.readFileSync(subagentPath, "utf-8");
 
-    runCli("agent init --with-claude-code", testHomeDir);
+    const r2 = runCli("agent init --with-claude-code", testHomeDir, 30_000);
+    expect(r2.exitCode, `second install failed: ${r2.stderr || r2.stdout}`).toBe(0);
     const second = fs.readFileSync(subagentPath, "utf-8");
 
     expect(second).toBe(first);

--- a/node/tests/mcp-server-stdio.test.ts
+++ b/node/tests/mcp-server-stdio.test.ts
@@ -381,12 +381,24 @@ describe("MCP Server — real stdio transport: lifecycle", () => {
     await client.close();
   });
 
+  // Three back-to-back spawn/connect/listTools/close cycles. Each
+  // iteration spawns `node dist/index.js mcp serve` as a fresh
+  // subprocess; on cold-start CI the subprocess teardown can race the
+  // next iteration's connect (race shows as "MCP error -32000:
+  // Connection closed" from StdioClientTransport.onclose). Two
+  // mitigations:
+  //   1. 200ms inter-iteration sleep — gives the previous subprocess
+  //      time to finish exiting before we spawn another.
+  //   2. 60s per-test timeout (default is 5s) — accounts for the 3x
+  //      cold-start cost on slow runners.
   it("should handle sequential connect/disconnect cycles", async () => {
     for (let i = 0; i < 3; i++) {
       const { client } = await createConnectedClient();
       const { tools } = await client.listTools();
       expect(tools).toHaveLength(6);
       await client.close();
+      // Let the subprocess's exit propagate before the next spawn.
+      if (i < 2) await new Promise((resolve) => setTimeout(resolve, 200));
     }
-  });
+  }, 60_000);
 });

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.8.0"
+version = "0.8.1"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.0
+version: 0.8.1
 homepage: https://rafter.so
 metadata:
   openclaw:
@@ -15,7 +15,7 @@ metadata:
       - name: RAFTER_API_KEY
         required: false
         description: API key for `rafter run` (remote SAST + SCA + agentic deep-dive). Without it, `rafter secrets` (local secrets scan) still works.
-last_updated: 2026-05-07
+last_updated: 2026-05-12
 ---
 
 # Rafter Security


### PR DESCRIPTION
## v0.8.1 — main → prod

Ships everything from `prod` (last at v0.7.9) through current `main` (now at v0.8.1). The intermediate v0.8.0 commit landed on `main` but never made it to `prod`, so this single deploy publishes both versions' worth of changes — package version on `main` is **0.8.1**, which is what npm/PyPI will publish.

### v0.8.1 (top of stack — patch)

**Fixed:**
- **#101** — CI ClawHub publish needed explicit `clawhub login --token "$CLAWHUB_TOKEN"` (the auto-env-read assumption was wrong) + bumped the `publish-clawhub` job to Node 22 (clawhub's `p-retry@8` transitive dep needs ≥22).
- rf-of20, rf-b1hf, rf-ax2p — test diagnostic + obsolete-assertion cleanups.
- rc-bc9 — deleted stale `node/.claude/skills/` dev copy (drift from `node/resources/skills/`).

### v0.8.0 (rolling up into this release — minor)

**Changed:**
- **Breaking:** secret-scanning engine migrated from gitleaks → betterleaks. `--with-gitleaks`, `--engine gitleaks`, `rafter agent update-gitleaks` all removed (error out). Use `--with-betterleaks`, `--engine betterleaks`, `rafter agent update-betterleaks`. Verify + status detect leftover `~/.rafter/bin/gitleaks` and emit a migration hint instead of failing.
- Pruned user-facing `rafter scan local` references in favor of `rafter secrets` (alias is retained for back-compat).

**Added:**
- `rafter agent init --dry-run` (rf-hrtd) — preview every file path the install would touch, no side effects.
- ClawHub auto-publish in the release workflow (the wiring this `v0.8.1` fix repairs).

**Fixed:**
- GitHub Action `finding-count` (rf-cfjc): jq query now handles the wrapped JSON shape.
- ClawHub owner handle (`raftersecurity` → `rafter`).
- README pre-commit `rev:` pins bumped to v0.7.9 (rf-z6sv).

### Deploy expectations

When this merges, `publish.yml` will:
1. Test + pack Node, publish `@rafter-security/cli@0.8.1` to npm.
2. Build + publish `rafter-cli==0.8.1` to PyPI.
3. **Publish `rafter-security@0.8.1` to ClawHub** under `--owner rafter` — first real run of this step after the auth fix from #101.
4. Create the `v0.8.1` GitHub release with combined release notes from `CHANGELOG.md`.
5. Smoke-test the published packages from npm and PyPI.

If the ClawHub step still fails, the failure now surfaces at the new `Authenticate clawhub CLI` step (auth is its own action) so the error message points directly at the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)