### PR TITLE
test(rf-of20): apply 30s timeout + diagnostic gate to all subagent install tests

### DIFF
--- a/node/tests/claude-code-subagent.test.ts
+++ b/node/tests/claude-code-subagent.test.ts
@@ -28,10 +28,15 @@ function cleanupDir(dir: string) {
   }
 }
 
+// 30s default per-call timeout. The original 15s flaked on slow CI runners
+// (rf-of20 documented the same root cause for the idempotency test: cold-start
+// ubuntu+node-22 + spawnSync with shell:true occasionally takes >15s for a
+// single `agent init` run). Apply the same fix to every install-doing test
+// here rather than just the idempotent one.
 function runCli(
   args: string,
   homeDir: string,
-  timeout = 15_000
+  timeout = 30_000
 ): { stdout: string; stderr: string; exitCode: number } {
   const result = spawnSync(`node ${CLI_ENTRY} ${args}`, {
     cwd: PROJECT_ROOT,
@@ -75,12 +80,20 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
 
   it("sub-agent file has the required frontmatter (name, description, tools)", () => {
     fs.mkdirSync(path.join(testHomeDir, ".claude"), { recursive: true });
-    runCli("agent init --with-claude-code", testHomeDir);
+    const r = runCli("agent init --with-claude-code", testHomeDir);
 
-    const content = fs.readFileSync(
-      path.join(testHomeDir, ".claude", "agents", "rafter.md"),
-      "utf-8"
-    );
+    // Diagnostic gate before readFileSync — without this, a slow CI install
+    // surfaces as a bare ENOENT that hides whether `agent init` returned
+    // non-zero (real bug) or silently exceeded the timeout (timing/fs issue).
+    // Mirrors the rf-of20 pattern from the idempotency test.
+    const subagentPath = path.join(testHomeDir, ".claude", "agents", "rafter.md");
+    expect(r.exitCode, `agent init failed: ${r.stderr || r.stdout}`).toBe(0);
+    expect(
+      fs.existsSync(subagentPath),
+      `subagent missing after install. stdout=${r.stdout} stderr=${r.stderr}`,
+    ).toBe(true);
+
+    const content = fs.readFileSync(subagentPath, "utf-8");
 
     // Frontmatter delimiters
     expect(content.startsWith("---\n")).toBe(true);
@@ -95,12 +108,16 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
 
   it("sub-agent body references current rafter commands and tier hierarchy", () => {
     fs.mkdirSync(path.join(testHomeDir, ".claude"), { recursive: true });
-    runCli("agent init --with-claude-code", testHomeDir);
+    const r = runCli("agent init --with-claude-code", testHomeDir);
 
-    const content = fs.readFileSync(
-      path.join(testHomeDir, ".claude", "agents", "rafter.md"),
-      "utf-8"
-    );
+    const subagentPath = path.join(testHomeDir, ".claude", "agents", "rafter.md");
+    expect(r.exitCode, `agent init failed: ${r.stderr || r.stdout}`).toBe(0);
+    expect(
+      fs.existsSync(subagentPath),
+      `subagent missing after install. stdout=${r.stdout} stderr=${r.stderr}`,
+    ).toBe(true);
+
+    const content = fs.readFileSync(subagentPath, "utf-8");
 
     // Trigger phrasing that maps to user's question
     expect(content).toContain("safe / secure / production worthy");
@@ -149,7 +166,7 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
       const result = spawnSync(`node ${CLI_ENTRY} agent init --local --with-claude-code`, {
         cwd: projectDir,
         encoding: "utf-8",
-        timeout: 15_000,
+        timeout: 30_000,
         shell: true,
         env: {
           ...process.env,
@@ -158,10 +175,12 @@ describe("Claude Code rafter sub-agent install (--with-claude-code)", () => {
         },
         stdio: ["pipe", "pipe", "pipe"],
       });
-      expect(result.status).toBe(0);
-
       const subagentPath = path.join(projectDir, ".claude", "agents", "rafter.md");
-      expect(fs.existsSync(subagentPath)).toBe(true);
+      expect(result.status, `agent init --local failed: ${result.stderr || result.stdout}`).toBe(0);
+      expect(
+        fs.existsSync(subagentPath),
+        `subagent missing after --local install. stdout=${result.stdout} stderr=${result.stderr}`,
+      ).toBe(true);
     } finally {
       cleanupDir(projectDir);
     }


### PR DESCRIPTION
Generalizes the rf-of20 fix (10c3c02) from the idempotency test to every install-doing test in `claude-code-subagent.test.ts`. The v0.8.1 release PR (#103) hit the same flake mode in `'sub-agent file has the required frontmatter'`:

```
Error: ENOENT: no such file or directory, open
  '/tmp/rafter-subagent-test-.../.claude/agents/rafter.md'
tests/claude-code-subagent.test.ts:80:24
```

Same root cause rf-of20 documented: cold-start ubuntu+node-22 + spawnSync with shell:true occasionally exceeds 15s for a single `agent init` run. The default in this file was chosen pre-betterleaks; the expanded dep tree now means cold-start module resolution is heavier and 15s no longer leaves comfortable headroom.

### Changes (no production code)

1. Default `runCli` timeout 15s → 30s — matches what rf-of20 used explicitly for the idempotency test.
2. Two tests (frontmatter, body-references) now check `exitCode === 0` + `existsSync` BEFORE `readFileSync`, with stdout/stderr interpolated into the assertion message. The previous bare ENOENT hid whether `agent init` returned non-zero (real bug) or silently exceeded the timeout (timing/fs issue).
3. The `--local` test (inline `spawnSync`) gets the same treatment: `timeout: 15_000` → `30_000` + diagnostic guards.

### After this merges

Re-run the failed checks on #103. If the flake recurs under 30s, the diagnostic message will tell us whether it's a real bug or a still-too-tight timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)