### PR TITLE
test: stabilize 'sequential connect/disconnect cycles' MCP stdio test

### DIFF
--- a/node/tests/mcp-server-stdio.test.ts
+++ b/node/tests/mcp-server-stdio.test.ts
@@ -381,12 +381,24 @@ describe("MCP Server — real stdio transport: lifecycle", () => {
     await client.close();
   });
 
+  // Three back-to-back spawn/connect/listTools/close cycles. Each
+  // iteration spawns `node dist/index.js mcp serve` as a fresh
+  // subprocess; on cold-start CI the subprocess teardown can race the
+  // next iteration's connect (race shows as "MCP error -32000:
+  // Connection closed" from StdioClientTransport.onclose). Two
+  // mitigations:
+  //   1. 200ms inter-iteration sleep — gives the previous subprocess
+  //      time to finish exiting before we spawn another.
+  //   2. 60s per-test timeout (default is 5s) — accounts for the 3x
+  //      cold-start cost on slow runners.
   it("should handle sequential connect/disconnect cycles", async () => {
     for (let i = 0; i < 3; i++) {
       const { client } = await createConnectedClient();
       const { tools } = await client.listTools();
       expect(tools).toHaveLength(6);
       await client.close();
+      // Let the subprocess's exit propagate before the next spawn.
+      if (i < 2) await new Promise((resolve) => setTimeout(resolve, 200));
     }
-  });
+  }, 60_000);
 });


### PR DESCRIPTION
Second flake on the v0.8.1 release PR (#103) — different test, same family of issue as the rf-of20 subagent flake (cold-start CI runners stressing the test).

```
FAIL  tests/mcp-server-stdio.test.ts > MCP Server — real stdio transport: lifecycle > should handle sequential connect/disconnect cycles
McpError: MCP error -32000: Connection closed
 ❯ StdioClientTransport._transport.onclose
```

### Root cause

Test spawns `node dist/index.js mcp serve` as a fresh subprocess **three iterations in a row** (connect → listTools → close, ×3). On cold-start CI the previous subprocess's exit races the next iteration's connect; the SDK surfaces this as `StdioClientTransport.onclose` → "Connection closed". Same heavier-cold-start root cause as the rf-of20 subagent flake, different symptom.

### Fix (no production code)

1. **200ms inter-iteration sleep.** Gives the previous subprocess time to finish exiting before the next spawn.
2. **60s per-test timeout** (vitest default is 5s). Three back-to-back cold spawns on a slow CI runner can comfortably exceed 5s.

The single-cycle test ("connect and disconnect cleanly") is unchanged — it only spawns once and isn't affected.

### Verification

Both lifecycle tests pass locally in ~25s after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)