### PR TITLE
fix(ci): drop bogus clawhub verify step + retry PyPI smoke install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -232,13 +232,11 @@ jobs:
             --version "${{ needs.publish-node.outputs.version }}" \
             --owner rafter
 
-      - name: Verify the publish landed
-        if: steps.gate.outputs.skip != 'true'
-        run: |
-          # Smoke-check: the published version should be reachable via the
-          # public registry. Wait a few seconds for index propagation.
-          sleep 5
-          npx -y clawhub@latest skill show rafter-security --version "${{ needs.publish-node.outputs.version }}"
+      # No verify step — `clawhub skill` is publish-only (rf-u9l4).
+      # The CLI exposes `publish`, `rename`, `merge`, `help` and nothing
+      # else, so we can't do a CLI-driven readback. The `publish` step
+      # itself errors on any auth or registry failure, which is the
+      # contract we rely on.
 
   create-release:
     needs: [publish-node, publish-python]
@@ -315,8 +313,26 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Wait for PyPI registry propagation
-        run: sleep 30
+      - name: Wait for PyPI to index the new version (rf-z22y)
+        # `twine upload` returns success once the upload lands in PyPI's
+        # backend, but the public index (warehouse) can lag behind by up
+        # to a couple of minutes on cold paths. The previous hardcoded
+        # `sleep 30` flaked on v0.8.1. Poll instead: query the JSON API
+        # for the exact version, retry up to 6× / ~3 min, fail loud at
+        # the end so the workflow surface stays "PyPI propagation
+        # failed" rather than "package not found".
+        run: |
+          VERSION="${{ needs.publish-python.outputs.version }}"
+          for attempt in 1 2 3 4 5 6; do
+            if curl -sf "https://pypi.org/pypi/rafter-cli/${VERSION}/json" -o /dev/null; then
+              echo "PyPI has rafter-cli==${VERSION} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "Attempt ${attempt}: rafter-cli==${VERSION} not yet on PyPI, sleeping 30s…"
+            sleep 30
+          done
+          echo "FAIL: PyPI did not index rafter-cli==${VERSION} within ~3 minutes"
+          exit 1
 
       - name: Create fresh venv and install from PyPI
         run: |


### PR DESCRIPTION
Two unrelated post-publish failures on the v0.8.1 deploy. Both fixed in one PR since both touch `publish.yml`.

## rf-u9l4 — ClawHub verify uses non-existent `skill show` subcommand

```
Run: npx -y clawhub@latest skill show rafter-security --version 0.8.1
error: unknown command 'show'
```

`clawhub skill` exposes only `publish`, `rename`, `merge`, `help` — there is no CLI-driven readback. The verify step was speculative when added in the rf-zgwj follow-up and never worked.

**Fix:** drop the verify step. `clawhub skill publish` already errors on any auth or registry failure (the contract we rely on), and the publish for 0.8.1 actually succeeded — only the verify step crashed. So 0.8.1 IS live on ClawHub.

If we want a real read-side smoke check later, the right shape is curling `https://clawhub.ai/api/v1/skills/rafter-security` (or whatever the public GET URL is). Out of scope for this PR.

## rf-z22y — PyPI smoke raced index propagation

```
ERROR: Could not find a version that satisfies the requirement rafter-cli==0.8.1
  (from versions: …, 0.7.9, 0.8.0)
```

`twine upload` returns success once the upload lands in PyPI's backend, but the public index (warehouse) can lag by up to a couple of minutes on cold paths. The hardcoded `sleep 30` flaked on v0.8.1.

**Fix:** replace `sleep 30` with a poll loop that queries the PyPI JSON API (`https://pypi.org/pypi/rafter-cli/<version>/json`) up to 6× / ~3 min. On success, install proceeds. On persistent absence, the workflow surface is "PyPI propagation failed" instead of the confusing "package not found".

Same retry pattern would help the npm smoke on slow-CDN days; left for a separate change since npm didn't flake this time.

## Verification

- [x] YAML lint clean.
- [ ] v0.8.2 (or re-run failed jobs on the v0.8.1 release) will validate both fixes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)