### PR TITLE
fix(ci): retry-poll npm registry index in smoke-test-node (sable-bac)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -282,8 +282,26 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Wait for npm registry propagation
-        run: sleep 30
+      - name: Wait for npm registry to index the new version (sable-bac)
+        # `npm publish` returns success once the upload lands in npm's
+        # backend, but the public registry can lag on slow-CDN days.
+        # Mirrors the rf-z22y PyPI fix: poll the registry HTTP API for
+        # the exact version, retry up to 6× / ~3 min, fail loud at the
+        # end so the workflow surface stays "npm propagation failed"
+        # rather than the confusing "no matching version".
+        # URL-encoded scope: '@rafter-security/cli' → '@rafter-security%2Fcli'.
+        run: |
+          VERSION="${{ needs.publish-node.outputs.version }}"
+          for attempt in 1 2 3 4 5 6; do
+            if curl -sf "https://registry.npmjs.org/@rafter-security%2Fcli/${VERSION}" -o /dev/null; then
+              echo "npm has @rafter-security/cli@${VERSION} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "Attempt ${attempt}: @rafter-security/cli@${VERSION} not yet on npm, sleeping 30s…"
+            sleep 30
+          done
+          echo "FAIL: npm did not index @rafter-security/cli@${VERSION} within ~3 minutes"
+          exit 1
 
       - name: Install from npm registry
         run: npm install -g @rafter-security/cli@${{ needs.publish-node.outputs.version }}


### PR DESCRIPTION
Mirror of rf-z22y (PyPI) for the npm side. The `smoke-test-node` job had a hardcoded `sleep 30` before `npm install -g`. `npm publish` returns success once the upload lands in npm's backend, but the public registry can lag on slow-CDN days, leaving the install with "no matching version".

Hasn't actually flaked yet (PyPI did on v0.8.1), but the pattern is identical so applying the same fix proactively.

### Fix

Replaced `sleep 30` with a poll loop against the npm registry HTTP API (`https://registry.npmjs.org/@rafter-security%2Fcli/<version>`), retries 6× / ~3 min, fails loud with "npm propagation failed" instead of the confusing "no matching version".

Note: scope URL-encoding — `@rafter-security/cli` → `@rafter-security%2Fcli`.

### Verification

- [x] YAML lint clean.
- [ ] Next prod push exercises this on a fresh release.

Closes sable-bac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)