### PR TITLE
fix(sable-vcx): bump pre-commit rev pins + homebrew URL to v0.8.1, guard against drift

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -62,6 +62,40 @@ jobs:
             echo "OK: $skill_file version matches ($SKILL_VERSION)"
           done
 
+      - name: Ensure pre-commit rev pins and recipe URLs match package version
+        # sable-vcx — README and recipe docs pin a `rev:` to a specific
+        # release tag (e.g. `rev: v0.7.9`). Bumping package.json/pyproject
+        # without bumping these pins leaves users with stale install
+        # instructions; CHANGELOG [0.6.1] documents this was already fixed
+        # once and drifted again. Same drift class hits the homebrew
+        # formula tarball URL. Fail the release on any drift.
+        run: |
+          VERSION="${{ steps.node-version.outputs.VERSION }}"
+          EXPECTED="v$VERSION"
+          fail=0
+          while IFS=: read -r file lineno match; do
+            actual=$(echo "$match" | sed -n 's/.*rev:[[:space:]]*\(v[0-9.]*\).*/\1/p')
+            if [ "$actual" != "$EXPECTED" ]; then
+              echo "FAIL: $file:$lineno pins rev: $actual but package is $EXPECTED"
+              fail=1
+            fi
+          done < <(grep -rn "^[[:space:]]*rev:[[:space:]]*v[0-9]" \
+              README.md recipes/pre-commit.md shared-docs/CLI_SPEC.md 2>/dev/null)
+          # Homebrew formula URL embeds the version literal in the tarball path.
+          if grep -q "cli/-/cli-${VERSION}\.tgz" recipes/homebrew-formula.rb; then
+            echo "OK: recipes/homebrew-formula.rb URL matches $VERSION"
+          else
+            echo "FAIL: recipes/homebrew-formula.rb URL does not embed version $VERSION"
+            grep -n "registry.npmjs.org/@rafter-security/cli/-/cli-" recipes/homebrew-formula.rb || true
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "Bump the rev: pins and homebrew URL to v$VERSION before releasing."
+            exit 1
+          fi
+          echo "OK: all rev: pins and recipe URLs match v$VERSION"
+
       - name: Check CHANGELOG updated
         run: |
           VERSION="${{ steps.node-version.outputs.VERSION }}"

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Rafter works as a [pre-commit](https://pre-commit.com) hook. Add to your `.pre-c
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.7.9
+    rev: v0.8.1
     hooks:
       - id: rafter-scan-node
 ```
@@ -430,7 +430,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.7.9
+    rev: v0.8.1
     hooks:
       - id: rafter-scan-node      # auto-installs via npm
       # - id: rafter-scan-python  # auto-installs via pip

--- a/recipes/homebrew-formula.rb
+++ b/recipes/homebrew-formula.rb
@@ -13,7 +13,7 @@
 class Rafter < Formula
   desc "Security toolkit for developers — secret scanning, policy enforcement, audit logging"
   homepage "https://rafter.so"
-  url "https://registry.npmjs.org/@rafter-security/cli/-/cli-0.6.5.tgz"
+  url "https://registry.npmjs.org/@rafter-security/cli/-/cli-0.8.1.tgz"
   sha256 :no_check # Replace with actual SHA256 from npm registry
   license "MIT"
 

--- a/recipes/pre-commit.md
+++ b/recipes/pre-commit.md
@@ -9,7 +9,7 @@ If you use the [pre-commit](https://pre-commit.com) framework, add this to `.pre
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.6.5
+    rev: v0.8.1
     hooks:
       - id: rafter-scan-node   # auto-installs via npm, no global install needed
 ```

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -1026,7 +1026,7 @@ Integration with [pre-commit](https://pre-commit.com/):
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.5.6
+    rev: v0.8.1
     hooks:
       - id: rafter-scan           # Node.js
       # - id: rafter-scan-python  # Python alternative


### PR DESCRIPTION
## Summary

- Pre-commit `rev:` pins in `README.md` (2×), `recipes/pre-commit.md`, and `shared-docs/CLI_SPEC.md` were stale (v0.7.9 / v0.6.5 / v0.5.6) while the package ships 0.8.1.
- `recipes/homebrew-formula.rb` embedded a stale tarball URL at v0.6.5.
- All four bumped to v0.8.1.
- `.github/workflows/validate-release.yml` gains a check that fails the release when any `rev:` pin or homebrew URL drifts from the package version, so this doesn't silently regress again. CHANGELOG [0.6.1] documents the previous regression of this exact class.

Target: `maylist` (per dispatcher instruction).

Closes sable-vcx.

## Test plan

- [x] Local dry-run of the new check: passes against the bumped files
- [ ] CI `validate-release` job passes
- [ ] CI `test-build` job passes (no changes to runtime code, only docs + workflow yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>