### PR TITLE
docs+ux(sable-b74): surface SHA256, soften quickstart --all, add verify hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ rafter secrets .
 **2. Install the pre-commit hook**
 
 ```sh
-rafter agent init --all
-# → Installs all detected integrations
-# → Downloads Betterleaks (or falls back to built-in scanner)
+rafter agent init                          # interactive: previews changes, then installs detected integrations
+# → For agents/CI: rafter agent init --all (non-interactive, all detected) or --dry-run (preview only)
 ```
+
+> Preview every file Rafter would touch with `rafter agent init --dry-run` before committing to changes. Confirm a finished install at any time with `rafter agent verify`.
 
 **3. Try to commit—hook blocks it**
 
@@ -185,6 +186,7 @@ This command:
 - Auto-detects Claude Code, Codex CLI, OpenClaw, Gemini, Cursor, Windsurf, Continue.dev, and Aider
 - With `--with-*` or `--all`: installs Rafter skills/extensions to opted-in agents
 - With `--with-betterleaks` or `--all`: downloads [Betterleaks](https://github.com/betterleaks/betterleaks) (the gitleaks successor maintained by the original gitleaks authors) for enhanced secret scanning. Falls back to built-in 21-pattern regex scanner.
+- **Binary integrity:** the Betterleaks download is checked against a SHA256 table pinned in this repo's source (`node/src/utils/binary-manager.ts`), so the default install does not trust the release-page `checksums.txt` to authenticate itself. Non-HTTPS download URLs are refused; tarballs that contain symlink/hardlink/device entries are rejected before extraction.
 
 Use `rafter agent list/enable/disable` for granular per-component control after the initial install — toggle any platform on or off without re-running `init`.
 

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -1455,6 +1455,7 @@ export function createInitCommand(): Command {
         console.log("No agent environments detected. Install an agent tool and re-run with --with-<tool>.");
       }
       console.log();
+      console.log("  - Verify: rafter agent verify (confirm hooks + binary integrity)");
       console.log("  - Run: rafter secrets . (test secret scanning)");
       console.log("  - Configure: rafter agent config show");
       console.log();

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -1376,6 +1376,7 @@ def init(
         rprint("No agent environments detected. Install an agent tool and re-run with --with-<tool>.")
 
     rprint()
+    rprint("  - Verify: rafter agent verify (confirm hooks + binary integrity)")
     rprint("  - Run: rafter secrets . (test secret scanning)")
     rprint("  - Configure: rafter agent config show")
     rprint()


### PR DESCRIPTION
## Summary

Addresses **three of the four** sable-b74 items from the maylist (A20 / consumer-perspective P0-1). The fourth — `rafter agent uninstall` — is non-trivial and split into **sable-3ep** with full acceptance criteria.

1. **README quickstart**: Step 2 now leads with `rafter agent init` (no `--all`). Adds an inline pointer to `--dry-run` for preview and to `rafter agent verify` for post-install confirmation. The `--all` form is repositioned as the non-interactive/CI shape.
2. **SHA256 surfaced in install copy**: README Setup explicitly describes the Betterleaks binary integrity guarantees (hashes pinned in `node/src/utils/binary-manager.ts`, no trust in release-page `checksums.txt`, non-HTTPS refused, symlink/hardlink/device entries rejected). This was buried in CHANGELOG 0.8.0 (line 23).
3. **Verify hint in init output**: `rafter agent init`'s next-steps now leads with `Verify: rafter agent verify (confirm hooks + binary integrity)`. Same line added to Node (`init.ts`) and Python (`agent.py`) so behavior matches.

`--dry-run` (item 1 of the original bead) was already shipped in PR #98 (rf-hrtd) — no change needed.

Target: `maylist` (per dispatcher).

Refs sable-b74. Split-out: sable-3ep (`rafter agent uninstall`).

## Test plan

- [x] TypeScript: builds clean (`pnpm run build`).
- [x] Python: `ast.parse` clean.
- [ ] Full test suite — local box too overloaded to run vitest globalSetup (build alone takes 2m+ vs the 120s setup timeout). Changes are non-behavioral (added one string each to existing output blocks); CI on prod-targeted PRs will catch regressions.
- [ ] Manual verify: run `rafter agent init` in a temp HOME and confirm the new line appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>