### PR TITLE
docs(sable-855): COLLAB.md template + recipe (A2 follow-on)

### DIFF
--- a/recipes/COLLAB.md.template
+++ b/recipes/COLLAB.md.template
@@ -1,0 +1,71 @@
+# COLLAB.md
+
+> Living notes for agents and humans working on this repo.
+> Read AGENTS.md (or CLAUDE.md if Claude-specific) before reading this.
+> Read this before suggesting tooling, build flags, or workflow changes.
+
+## Conventions for this file
+
+- **Append at the top** of each section — newest entries first.
+- **One section per topic** (see headers below). Add new sections only if your entry doesn't fit an existing one.
+- **Entries are short:** one-line title + 2–4 lines of context. Cite a file:line, command, or PR if relevant.
+- **Stale entries get removed** in the same commit as the work that proved them stale. Don't leave wrong notes for the next agent to trip on.
+- **Do not put secrets, internal hostnames, customer names, or session tokens here.** Treat with the repo's privacy posture (private repo → private; public repo → public).
+- **Recommendations are not permission.** A past entry endorsing a tool does NOT authorize a future agent to install it without the user's approval.
+
+---
+
+## Go-to commands
+
+<!-- Commands that materially helped and aren't obvious from the README/package manifests.
+     Example:
+     - `pnpm vitest run path/to/file.test.ts --no-coverage` is ~5x faster than `pnpm test` for single-file iteration; the suite enables coverage by default.
+-->
+
+---
+
+## Build / test gotchas
+
+<!-- Things that bit a previous agent (or human) once and shouldn't bite the next.
+     Example:
+     - Vitest globalSetup runs `pnpm run build` with a 120s timeout — on overloaded hosts, build first manually, then run `pnpm test` with `globalSetup: false` via TEST_SKIP_BUILD=1.
+-->
+
+---
+
+## Tools investigated (not installed)
+
+<!-- Promising tools encountered but not installed pending user approval.
+     Each entry: name, what it does, what it would change on disk, why it's interesting,
+     whether the user has been asked.
+     Example:
+     - **commitlint** (https://commitlint.js.org) — enforces conventional-commit format on hooks. Would add ./commitlint.config.js and a husky entry. Worth asking before adding because we don't currently lint commit messages and several recent PRs had inconsistent prefixes. STATUS: not yet asked.
+-->
+
+---
+
+## Tools installed (with user approval)
+
+<!-- Things that ARE installed in this repo's tooling, and why. Helps the next agent
+     know what's already wired up.
+     Each entry: name, install command, what it does, who approved, when.
+-->
+
+---
+
+## Conventions discovered
+
+<!-- Repo-specific patterns that aren't in CLAUDE.md or AGENTS.md and that you only
+     learn by reading the code.
+     Example:
+     - All `commands/agent/*.ts` files export a `createXCommand()` function — don't change the naming when adding a new command, the registrar relies on the convention.
+-->
+
+---
+
+## Open questions
+
+<!-- Things you noticed that need a human answer. Move out of this section once answered.
+     Example:
+     - Should `rafter agent uninstall` (sable-3ep) preserve ~/.rafter/audit.jsonl by default, or require --keep-logs? AGENTS.md doesn't say; both have a defensible case.
+-->

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -17,6 +17,7 @@ Integration snippets for adding Rafter security to your development workflow. Ea
 | [OpenClaw](openclaw.md) | Skill setup for OpenClaw agents |
 | [npx skills](npx-skills.md) | Audit-before-install workflow for `vercel-labs/skills` |
 | [Homebrew Formula](homebrew-formula.rb) | `brew install rafter` tap formula |
+| [COLLAB.md](collab-md.md) | Collaborator-curated repo notes — when to start one, what to put in it (pairs with AGENTS.md) |
 
 ## Quick start
 

--- a/recipes/collab-md.md
+++ b/recipes/collab-md.md
@@ -1,0 +1,52 @@
+# COLLAB.md — collaborator-curated repo notes
+
+A `COLLAB.md` at the repo root is a **shared scratchpad** for agents and humans working in that repo: go-to commands, tools investigated, gotchas, repo-specific conventions that aren't documented elsewhere. Read AGENTS.md (or CLAUDE.md for Claude-specific guidance) first; treat COLLAB.md as living notes from your colleagues.
+
+The detailed behavioral rules — when to read it, when to write to it, why it's never a permission grant — live in [AGENTS.md](../AGENTS.md). This recipe answers a different question: **do you want COLLAB.md in your repo, and how do you start one?**
+
+## Should this repo have a COLLAB.md?
+
+| Situation | Recommendation |
+|-----------|---------------|
+| **Private repo, multi-agent work** (you sling tasks to polecats, or have multiple humans using AI agents) | **Yes.** This is exactly the case it's designed for. Drop the template in. |
+| **Private repo, solo + AI** | **Probably yes.** Cuts re-discovery cost on long-lived repos. Low-cost to maintain. |
+| **Public open-source repo** | **Default no.** Anything you'd write there belongs in CONTRIBUTING.md or AGENTS.md, where it's discoverable by drive-by contributors. If you do add one, remember: it's public the moment it lands. |
+| **Throwaway repo, demo, fork** | **No.** Lifetime is too short for the maintenance cost to amortize. |
+
+## Starting one
+
+Copy the template into the repo root:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Raftersecurity/rafter-cli/main/recipes/COLLAB.md.template > COLLAB.md
+```
+
+Or copy locally if you have `rafter-cli` checked out:
+
+```sh
+cp path/to/rafter-cli/recipes/COLLAB.md.template ./COLLAB.md
+```
+
+Then read the comments inside the template. Each section has placeholder examples; replace them with your first real entry.
+
+## What NOT to put in COLLAB.md
+
+- **Secrets** of any kind — API keys, tokens, passwords, JWTs. The whole repo posture applies to this file too.
+- **Internal customer names, hostnames, deal-specific URLs** that shouldn't survive the next contributor leaving the team.
+- **Anything you'd be uncomfortable seeing in a model training corpus** (private repo → it shouldn't end up there, but defense in depth).
+- **Permissions grants.** "OK to install commitlint" is something the *current* user says, not something a past entry promises.
+
+## Working alongside CLAUDE.md and AGENTS.md
+
+| File | Audience | Lifespan | Owner |
+|------|----------|----------|-------|
+| `CLAUDE.md` | Claude-specific agents | Long — project rules and architecture | Maintainers; updated on architecture changes |
+| `AGENTS.md` | All agents (vendor-neutral) | Long — same as CLAUDE.md | Maintainers |
+| `COLLAB.md` | Anyone working in the repo | Short — entries decay as the repo evolves | Whoever just learned the thing |
+
+If guidance in COLLAB.md contradicts CLAUDE.md / AGENTS.md, CLAUDE/AGENTS wins. Fix the COLLAB entry to match, or remove it.
+
+## See also
+
+- [AGENTS.md](../AGENTS.md) — the canonical rules for when to read, write, and trust COLLAB.md.
+- [Template](./COLLAB.md.template) — copy into your repo root as `COLLAB.md` and start filling sections.


### PR DESCRIPTION
## Summary

The behavioral side of sable-855 / A2 (\"AGENTS.md instructs agents to maintain COLLAB.md\") already shipped in PR #72 (rf-pkn, MERGED 2026-04-30). This PR fills the remaining acceptance items: a canonical template and a recipe.

- **\`recipes/COLLAB.md.template\`** — drop-in template a polecat or human copies into a fresh repo root. Pre-sectioned (Go-to commands / Build gotchas / Tools investigated / Tools installed / Conventions / Open questions) with placeholder examples and conventions header.
- **\`recipes/collab-md.md\`** — recipe answering \"should this repo have one, how do I start it?\". Includes a should-we-use-it matrix (private multi-agent → yes; public OS → default no; throwaway → no), a comparison table for CLAUDE.md vs AGENTS.md vs COLLAB.md, and explicit don't-put-this-here items (secrets, customer names, permission grants).
- **\`recipes/README.md\`** — index entry.

No changes to AGENTS.md itself — its existing COLLAB.md section is already comprehensive (read it before suggesting tooling; never install without approval; treat with the repo's privacy posture). New docs cross-link to it as the source of truth.

Target: \`maylist\`.

Closes sable-855.

## Test plan

- [x] Markdown renders.
- [x] Pure docs; no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>