### PR TITLE
ci(sable-gxo): gate releases on skill docs/ folders shipping in npm tarball (A5)

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -172,6 +172,29 @@ jobs:
             || (echo "FAIL: resources/pre-commit-hook.sh not found in tarball" && exit 1)
           echo "OK: resources/pre-commit-hook.sh present in tarball"
 
+      - name: Verify skill docs/ folders ship in tarball
+        # sable-gxo — every SKILL.md references files under its own docs/.
+        # If the docs/ folder is silently stripped from the npm tarball, agents
+        # `Read docs/<x>.md` and get a missing-file error. installSkillDir
+        # copies the source tree recursively, but only matters if the source
+        # tree is in the published package. Fail the release if any expected
+        # docs file is missing.
+        run: |
+          TARBALL=$(ls rafter-security-cli-*.tgz | head -1)
+          missing=0
+          for skill in rafter-secure-design rafter-code-review; do
+            count=$(tar -tzf "$TARBALL" | grep -cE "package/resources/skills/${skill}/docs/.+\.md$" || true)
+            if [ "$count" -lt 1 ]; then
+              echo "FAIL: no docs/*.md files for skill '${skill}' in tarball"
+              missing=1
+            else
+              echo "OK: ${count} docs/*.md file(s) for skill '${skill}' in tarball"
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Test install-hook end-to-end from packed tarball
         run: |
           TARBALL=$(ls rafter-security-cli-*.tgz | head -1)


### PR DESCRIPTION
## Summary

Investigation of sable-gxo / A5 (\"Skill docs/ folder doesn't exist on disk\"): **the described bug does not exist at HEAD on maylist.** Verified three ways:

1. \`node/src/commands/agent/init.ts:907\` already uses \`fs.cpSync\` recursively — copies SKILL.md + docs/ + anything else under the source dir.
2. \`python/rafter_cli/commands/agent.py:_copy_skill_tree()\` walks the resource tree depth-first, also copying docs/.
3. \`npm pack --dry-run\` on this branch ships 9 docs/*.md for \`rafter-secure-design\` and 6 for \`rafter-code-review\` (verified locally).

This PR adds the missing **regression guard**: a release-time check that fails the build if any skill ships zero docs/ entries in the npm tarball. Pattern matches sable-vcx (rev-pin drift guard) and sable-gxo's existing \`resources/pre-commit-hook.sh\` check — gate at \`validate-release.yml\` rather than relying on a manual smoke.

Without this guard, a future change to package.json's \`files\` array, a refactor that relocates \`resources/skills/\`, or a \`.npmignore\` that excluded \`docs/\` would silently strip the reference material that SKILL.md links to — and the failure mode would be agents getting \"file not found\" on \`Read docs/<x>.md\` at runtime, not a CI failure at release.

Target: \`maylist\`.

Closes sable-gxo.

## Test plan

- [x] Local: \`npm pack && tar -tzf rafter-security-cli-0.8.1.tgz | grep -cE \"package/resources/skills/rafter-secure-design/docs/.+\\.md$\"\` → 9
- [x] Same for rafter-code-review → 6
- [x] YAML lint passes (existing workflow structure preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>