### PR TITLE
docs(sable-cu4): quickstart prerequisite note for rafter agent init

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ rafter agent init                          # interactive: previews changes, then
 # → For agents/CI: rafter agent init --all (non-interactive, all detected) or --dry-run (preview only)
 ```
 
+> **Prerequisite:** `rafter agent init` only installs hooks/skills for agent tools you *already have* (Claude Code, Codex CLI, Cursor, Windsurf, Continue.dev, Aider, Gemini CLI, OpenClaw). On a fresh machine with none of them installed, init prints `No agent environments detected.` and exits cleanly — that's expected, not an error. Install your editor/agent first; the pre-commit hook still works through `rafter agent install-hook`.
+>
 > Preview every file Rafter would touch with `rafter agent init --dry-run` before committing to changes. Confirm a finished install at any time with `rafter agent verify`.
 
 **3. Try to commit—hook blocks it**


### PR DESCRIPTION
## Summary

README quickstart Step 2 didn't explain that \`rafter agent init\` is conditional on having an agent tool already installed. Users on a fresh machine see \`No agent environments detected.\` and reasonably think it's an error.

Adds an explicit prerequisite note that:
- lists the eight supported agent tools (Claude Code, Codex CLI, Cursor, Windsurf, Continue.dev, Aider, Gemini CLI, OpenClaw),
- frames \"no environments detected\" as expected behavior on a clean install,
- points at \`rafter agent install-hook\` for the pre-commit path that works without any of them.

From os-audit-2026-05-12.md UX-1.

Target: \`maylist\`.

Closes sable-cu4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>