### PR TITLE
feat(sable-3ep): rafter agent uninstall — bulk revert of agent init (Node + Python parity)

### DIFF
--- a/node/src/commands/agent/index.ts
+++ b/node/src/commands/agent/index.ts
@@ -14,6 +14,7 @@ import { createBaselineCommand } from "./baseline.js";
 import { createListCommand } from "./list.js";
 import { createEnableCommand } from "./enable.js";
 import { createDisableCommand } from "./disable.js";
+import { createUninstallCommand } from "./uninstall.js";
 
 export function createAgentCommand(): Command {
   const agent = new Command("agent")
@@ -35,6 +36,7 @@ export function createAgentCommand(): Command {
   agent.addCommand(createListCommand());
   agent.addCommand(createEnableCommand());
   agent.addCommand(createDisableCommand());
+  agent.addCommand(createUninstallCommand());
 
   return agent;
 }

--- a/node/src/commands/agent/uninstall.ts
+++ b/node/src/commands/agent/uninstall.ts
@@ -1,0 +1,161 @@
+import { Command } from "commander";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { createInterface } from "readline";
+import {
+  getComponentRegistry,
+  recordComponentState,
+  resetComponentRegistryCache,
+  type ComponentSpec,
+} from "./components.js";
+import { fmt } from "../../utils/formatter.js";
+
+/**
+ * `rafter agent uninstall` — bulk revert of a prior `rafter agent init`.
+ *
+ * Walks every registered ComponentSpec and calls its `.uninstall()` callback,
+ * which removes only the entries rafter added (other tools' hook/MCP entries
+ * are preserved). Optionally also removes ~/.rafter/{config.json,bin,patterns}
+ * under --purge. The audit log is kept by default so a user can still inspect
+ * what rafter did before they ran uninstall.
+ *
+ * Idempotent: each ComponentSpec.uninstall() is a no-op when the component is
+ * not installed, so running uninstall twice writes nothing the second time.
+ *
+ * Exit codes: 0 success · 1 one or more component uninstalls failed.
+ */
+export function createUninstallCommand(): Command {
+  return new Command("uninstall")
+    .description("Remove all rafter agent integrations installed by 'rafter agent init'")
+    .option("--dry-run", "Preview what would be removed without changing anything")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .option(
+      "--purge",
+      "Also delete ~/.rafter (config, bin, patterns). Audit log is removed too.",
+    )
+    .option(
+      "--local",
+      "Operate against ./.rafter and ./.* platform dirs (matches 'agent init --local')",
+    )
+    .action(async (opts: { dryRun?: boolean; yes?: boolean; purge?: boolean; local?: boolean }) => {
+      // --local re-roots HOME at cwd so every component's os.homedir()-based
+      // path resolves into the project. Mirrors init's --local semantics
+      // without forking the per-component path logic.
+      if (opts.local) {
+        process.env.HOME = process.cwd();
+        resetComponentRegistryCache();
+      }
+
+      const home = os.homedir();
+      const rafterDir = path.join(home, ".rafter");
+      const registry = getComponentRegistry();
+
+      const installed: ComponentSpec[] = registry.filter((c) => {
+        try {
+          return c.isInstalled();
+        } catch {
+          return false;
+        }
+      });
+
+      const purgeTargets: string[] = [];
+      if (opts.purge) {
+        for (const sub of ["config.json", "audit.jsonl", "bin", "patterns"]) {
+          const p = path.join(rafterDir, sub);
+          if (fs.existsSync(p)) purgeTargets.push(p);
+        }
+      }
+
+      if (installed.length === 0 && purgeTargets.length === 0) {
+        console.log(fmt.info("Nothing to uninstall — no rafter agent components are installed."));
+        process.exit(0);
+      }
+
+      if (opts.dryRun) {
+        console.log(fmt.info("DRY RUN — no files will be modified."));
+        console.log(fmt.divider());
+        if (installed.length > 0) {
+          console.log("Components to remove:");
+          for (const c of installed) {
+            console.log(`  REMOVE  ${c.id.padEnd(28)} ${c.path}`);
+          }
+        }
+        if (purgeTargets.length > 0) {
+          console.log("Purge targets:");
+          for (const p of purgeTargets) console.log(`  DELETE  ${p}`);
+        }
+        if (!opts.purge) {
+          console.log(fmt.info(
+            "User data preserved: ~/.rafter/audit.jsonl, ~/.rafter/config.json, .rafter.yml (pass --purge to remove)",
+          ));
+        }
+        console.log(fmt.info("Re-run without --dry-run to apply."));
+        process.exit(0);
+      }
+
+      if (!opts.yes) {
+        const summary = `Uninstall ${installed.length} component${installed.length === 1 ? "" : "s"}` +
+          (opts.purge ? ` and purge ${rafterDir}` : "") + "?";
+        const ok = await askYesNo(summary, false);
+        if (!ok) {
+          console.log(fmt.info("Aborted."));
+          process.exit(0);
+        }
+      }
+
+      let exitCode = 0;
+      for (const spec of installed) {
+        try {
+          spec.uninstall();
+          recordComponentState(spec.id, false);
+          console.log(fmt.success(`Removed ${spec.id} (${spec.path})`));
+        } catch (e) {
+          console.error(fmt.error(`Failed to remove ${spec.id}: ${e}`));
+          exitCode = 1;
+        }
+      }
+
+      if (opts.purge) {
+        for (const target of purgeTargets) {
+          try {
+            fs.rmSync(target, { recursive: true, force: true });
+            console.log(fmt.success(`Purged ${target}`));
+          } catch (e) {
+            console.error(fmt.error(`Failed to purge ${target}: ${e}`));
+            exitCode = 1;
+          }
+        }
+        // Drop the now-empty ~/.rafter shell if nothing else remains.
+        try {
+          if (fs.existsSync(rafterDir) && fs.readdirSync(rafterDir).length === 0) {
+            fs.rmdirSync(rafterDir);
+          }
+        } catch {
+          /* leave it — purge is best-effort on the wrapping dir */
+        }
+      } else {
+        console.log(fmt.info(
+          "Preserved: ~/.rafter/audit.jsonl, ~/.rafter/config.json, .rafter.yml. " +
+          "Re-run with --purge to delete them too.",
+        ));
+      }
+
+      process.exit(exitCode);
+    });
+}
+
+function askYesNo(question: string, defaultYes: boolean): Promise<boolean> {
+  // Non-TTY (CI, piped stdin) gets the default — never blocks a script.
+  if (!process.stdin.isTTY) return Promise.resolve(defaultYes);
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  const suffix = defaultYes ? "[Y/n]" : "[y/N]";
+  return new Promise((resolve) => {
+    rl.question(`  ${question} ${suffix} `, (answer) => {
+      rl.close();
+      const t = answer.trim().toLowerCase();
+      if (t === "") resolve(defaultYes);
+      else resolve(t === "y" || t === "yes");
+    });
+  });
+}

--- a/node/tests/agent-uninstall.test.ts
+++ b/node/tests/agent-uninstall.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+import { randomBytes } from "crypto";
+
+/**
+ * Tests for `rafter agent uninstall` — the bulk revert of `rafter agent init`.
+ * Each test gets a fake HOME so we can inspect the on-disk side effects
+ * without clobbering the developer's real configs.
+ */
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const CLI_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
+
+function makeHome(): string {
+  const dir = path.join(os.tmpdir(), `rafter-uninstall-${Date.now()}-${randomBytes(4).toString("hex")}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function runCli(args: string, home: string): { stdout: string; stderr: string; code: number } {
+  const r = spawnSync(`node ${CLI_ENTRY} ${args}`, {
+    cwd: home,
+    encoding: "utf-8",
+    timeout: 15_000,
+    shell: true,
+    env: { ...process.env, HOME: home, XDG_CONFIG_HOME: path.join(home, ".config") },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return { stdout: r.stdout || "", stderr: r.stderr || "", code: r.status ?? 1 };
+}
+
+function snapshotTree(root: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) return;
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, ent.name);
+      if (ent.isDirectory()) walk(full);
+      else if (ent.isFile()) {
+        out[path.relative(root, full)] = fs.readFileSync(full, "utf-8");
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+describe("rafter agent uninstall", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = makeHome();
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("info-exits with no changes when nothing is installed", () => {
+    const r = runCli("agent uninstall --yes", home);
+    expect(r.code).toBe(0);
+    expect(r.stdout + r.stderr).toMatch(/Nothing to uninstall/i);
+  });
+
+  it("--dry-run writes nothing", () => {
+    fs.mkdirSync(path.join(home, ".cursor"), { recursive: true });
+    runCli("agent enable cursor.mcp", home);
+    const before = snapshotTree(home);
+
+    const r = runCli("agent uninstall --dry-run --yes", home);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toMatch(/DRY RUN/);
+    expect(r.stdout).toMatch(/cursor\.mcp/);
+
+    const after = snapshotTree(home);
+    expect(after).toEqual(before);
+  });
+
+  it("--yes skips confirmation and reverses installed components", () => {
+    fs.mkdirSync(path.join(home, ".cursor"), { recursive: true });
+    fs.mkdirSync(path.join(home, ".claude"), { recursive: true });
+    runCli("agent enable cursor.mcp", home);
+    runCli("agent enable claude-code.mcp", home);
+    runCli("agent enable claude-code.instructions", home);
+
+    expect(fs.existsSync(path.join(home, ".cursor", "mcp.json"))).toBe(true);
+
+    const r = runCli("agent uninstall --yes", home);
+    expect(r.code).toBe(0);
+
+    // cursor.mcp uninstall removes the rafter entry but leaves the file (other entries may exist).
+    const cursorCfg = JSON.parse(fs.readFileSync(path.join(home, ".cursor", "mcp.json"), "utf-8"));
+    expect(cursorCfg.mcpServers?.rafter).toBeUndefined();
+
+    // claude-code.mcp creates <cwd>/.mcp.json — when rafter is the only entry, uninstall removes the file.
+    expect(fs.existsSync(path.join(home, ".mcp.json"))).toBe(false);
+
+    // Instruction marker block is gone.
+    const claudeMd = path.join(home, ".claude", "CLAUDE.md");
+    if (fs.existsSync(claudeMd)) {
+      expect(fs.readFileSync(claudeMd, "utf-8")).not.toMatch(/rafter:start/);
+    }
+  });
+
+  it("preserves pre-existing non-rafter hook entries", () => {
+    fs.mkdirSync(path.join(home, ".claude"), { recursive: true });
+    const settingsPath = path.join(home, ".claude", "settings.json");
+    // User's pre-existing hook from some other tool.
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              { matcher: "Bash", hooks: [{ type: "command", command: "some-other-tool guard" }] },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    runCli("agent enable claude-code.hooks", home);
+    let s = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    const preCmds = (s.hooks.PreToolUse as any[]).flatMap((e) => e.hooks.map((h: any) => h.command));
+    expect(preCmds).toContain("some-other-tool guard");
+    expect(preCmds).toContain("rafter hook pretool");
+
+    const r = runCli("agent uninstall --yes", home);
+    expect(r.code).toBe(0);
+
+    s = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    const after = (s.hooks?.PreToolUse ?? []).flatMap((e: any) => e.hooks.map((h: any) => h.command));
+    expect(after).toContain("some-other-tool guard");
+    expect(after).not.toContain("rafter hook pretool");
+  });
+
+  it("round-trip: install → uninstall returns the filesystem to its prior shape", () => {
+    fs.mkdirSync(path.join(home, ".cursor"), { recursive: true });
+    fs.mkdirSync(path.join(home, ".claude"), { recursive: true });
+    // Capture filesystem state BEFORE any rafter writes.
+    const before = snapshotTree(home);
+
+    runCli("agent enable cursor.mcp", home);
+    runCli("agent enable claude-code.instructions", home);
+    runCli("agent enable claude-code.mcp", home);
+
+    const r = runCli("agent uninstall --yes", home);
+    expect(r.code).toBe(0);
+
+    // Everything rafter wrote should be gone. ~/.rafter/config.json IS allowed
+    // to exist (it records component state) — we filter it out before comparing.
+    const after = snapshotTree(home);
+    for (const key of Object.keys(after)) {
+      if (key.startsWith(".rafter/")) delete after[key];
+    }
+    expect(after).toEqual(before);
+  });
+
+  it("without --purge preserves ~/.rafter/audit.jsonl and ~/.rafter/config.json", () => {
+    const rafterDir = path.join(home, ".rafter");
+    fs.mkdirSync(rafterDir, { recursive: true });
+    fs.writeFileSync(path.join(rafterDir, "audit.jsonl"), '{"event":"test"}\n');
+    fs.writeFileSync(path.join(rafterDir, "config.json"), '{"keep":true}');
+
+    fs.mkdirSync(path.join(home, ".cursor"), { recursive: true });
+    runCli("agent enable cursor.mcp", home);
+
+    const r = runCli("agent uninstall --yes", home);
+    expect(r.code).toBe(0);
+
+    expect(fs.existsSync(path.join(rafterDir, "audit.jsonl"))).toBe(true);
+    expect(fs.readFileSync(path.join(rafterDir, "audit.jsonl"), "utf-8")).toContain("test");
+    expect(fs.existsSync(path.join(rafterDir, "config.json"))).toBe(true);
+  });
+
+  it("--purge removes ~/.rafter including audit log", () => {
+    const rafterDir = path.join(home, ".rafter");
+    fs.mkdirSync(path.join(rafterDir, "bin"), { recursive: true });
+    fs.writeFileSync(path.join(rafterDir, "audit.jsonl"), '{"event":"test"}\n');
+    fs.writeFileSync(path.join(rafterDir, "config.json"), '{"keep":true}');
+    fs.writeFileSync(path.join(rafterDir, "bin", "betterleaks"), "fake binary");
+
+    fs.mkdirSync(path.join(home, ".cursor"), { recursive: true });
+    runCli("agent enable cursor.mcp", home);
+
+    const r = runCli("agent uninstall --purge --yes", home);
+    expect(r.code).toBe(0);
+
+    expect(fs.existsSync(path.join(rafterDir, "audit.jsonl"))).toBe(false);
+    expect(fs.existsSync(path.join(rafterDir, "bin"))).toBe(false);
+  });
+
+  it("is idempotent — second run is a no-op", () => {
+    fs.mkdirSync(path.join(home, ".cursor"), { recursive: true });
+    runCli("agent enable cursor.mcp", home);
+    runCli("agent uninstall --yes", home);
+
+    const before = snapshotTree(home);
+    const r = runCli("agent uninstall --yes", home);
+    expect(r.code).toBe(0);
+    expect(r.stdout + r.stderr).toMatch(/Nothing to uninstall/i);
+    const after = snapshotTree(home);
+    expect(after).toEqual(before);
+  });
+});

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -3194,6 +3194,7 @@ from .agent_components import (  # noqa: E402
     _inject_instruction_file,
     get_registry as _components_get_registry,
     record_component_state as _components_record_state,
+    reset_registry_cache as _components_reset_cache,
     resolve_component as _components_resolve,
     snapshot_components as _components_snapshot,
 )
@@ -3316,6 +3317,116 @@ def components_disable(
         except Exception as err:
             rprint(fmt.error(f"Failed to disable {spec.id}: {err}"), file=sys.stderr)
             exit_code = 1
+
+    if exit_code:
+        raise typer.Exit(code=exit_code)
+
+
+# ── uninstall: bulk revert of 'agent init' ─────────────────────────────
+
+@agent_app.command("uninstall")
+def agent_uninstall(
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview what would be removed without changing anything"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt"),
+    purge: bool = typer.Option(False, "--purge", help="Also delete ~/.rafter (config, bin, patterns, audit log)"),
+    local: bool = typer.Option(False, "--local", help="Operate against ./.rafter and ./.* platform dirs (matches 'agent init --local')"),
+):
+    """Remove all rafter agent integrations installed by 'rafter agent init'."""
+    # --local re-roots HOME at cwd so every component's Path.home()-based
+    # path resolves into the project. Mirrors init's --local semantics
+    # without forking per-component path logic.
+    if local:
+        os.environ["HOME"] = str(Path.cwd())
+        _components_reset_cache()
+
+    home = Path.home()
+    rafter_dir = home / ".rafter"
+    registry = _components_get_registry()
+
+    installed = []
+    for spec in registry:
+        try:
+            if spec.is_installed():
+                installed.append(spec)
+        except Exception:
+            continue
+
+    purge_targets: list[Path] = []
+    if purge:
+        for sub in ("config.json", "audit.jsonl", "bin", "patterns"):
+            p = rafter_dir / sub
+            if p.exists():
+                purge_targets.append(p)
+
+    if not installed and not purge_targets:
+        rprint(fmt.info("Nothing to uninstall — no rafter agent components are installed."))
+        return
+
+    if dry_run:
+        rprint(fmt.info("DRY RUN — no files will be modified."))
+        rprint(fmt.divider())
+        if installed:
+            rprint("Components to remove:")
+            for spec in installed:
+                rprint(f"  REMOVE  {spec.id.ljust(28)} {spec.path}")
+        if purge_targets:
+            rprint("Purge targets:")
+            for p in purge_targets:
+                rprint(f"  DELETE  {p}")
+        if not purge:
+            rprint(fmt.info(
+                "User data preserved: ~/.rafter/audit.jsonl, ~/.rafter/config.json, .rafter.yml (pass --purge to remove)",
+            ))
+        rprint(fmt.info("Re-run without --dry-run to apply."))
+        return
+
+    if not yes:
+        summary = (
+            f"Uninstall {len(installed)} component{'' if len(installed) == 1 else 's'}"
+            + (f" and purge {rafter_dir}" if purge else "")
+            + "?"
+        )
+        # Non-TTY (CI, piped stdin) defaults to "no" — never blocks a script.
+        if not sys.stdin.isatty():
+            rprint(fmt.info(f"{summary} Aborted (non-interactive stdin). Re-run with --yes to confirm."))
+            return
+        confirmed = typer.confirm(summary, default=False)
+        if not confirmed:
+            rprint(fmt.info("Aborted."))
+            return
+
+    exit_code = 0
+    for spec in installed:
+        try:
+            spec.uninstall()
+            _components_record_state(spec.id, False)
+            rprint(fmt.success(f"Removed {spec.id} ({spec.path})"))
+        except Exception as err:
+            rprint(fmt.error(f"Failed to remove {spec.id}: {err}"), file=sys.stderr)
+            exit_code = 1
+
+    if purge:
+        for target in purge_targets:
+            try:
+                if target.is_dir():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink()
+                rprint(fmt.success(f"Purged {target}"))
+            except Exception as err:
+                rprint(fmt.error(f"Failed to purge {target}: {err}"), file=sys.stderr)
+                exit_code = 1
+        # Drop the now-empty ~/.rafter shell if nothing else remains.
+        try:
+            if rafter_dir.exists() and not any(rafter_dir.iterdir()):
+                rafter_dir.rmdir()
+        except Exception:
+            pass
+    else:
+        rprint(fmt.info(
+            "Preserved: ~/.rafter/audit.jsonl, ~/.rafter/config.json, .rafter.yml. "
+            "Re-run with --purge to delete them too.",
+        ))
 
     if exit_code:
         raise typer.Exit(code=exit_code)

--- a/python/tests/test_agent_uninstall.py
+++ b/python/tests/test_agent_uninstall.py
@@ -1,0 +1,171 @@
+"""Tests for `rafter agent uninstall` — the bulk revert of `rafter agent init`.
+Mirrors node/tests/agent-uninstall.test.ts.
+
+Each test gets a fake HOME so on-disk side effects are inspectable and the
+developer's real configs aren't touched.
+"""
+from __future__ import annotations
+
+import json
+import os
+import site
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Captured under the real HOME so user-site packages (typer, etc.) remain
+# importable in subprocesses launched with HOME overridden to tmp_path.
+_USER_BASE = site.getuserbase()
+
+
+def _run_cli(args: str, home: Path) -> tuple[str, str, int]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["XDG_CONFIG_HOME"] = str(home / ".config")
+    env["PYTHONUSERBASE"] = _USER_BASE
+    result = subprocess.run(
+        [sys.executable, "-m", "rafter_cli", *args.split()],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(home),
+        timeout=30,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def _snapshot_tree(root: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for p in root.rglob("*"):
+        if p.is_file():
+            out[str(p.relative_to(root))] = p.read_text(encoding="utf-8")
+    return out
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+class TestAgentUninstall:
+    def test_nothing_to_uninstall_when_empty(self, home: Path):
+        stdout, stderr, code = _run_cli("agent uninstall --yes", home)
+        assert code == 0
+        assert "Nothing to uninstall" in (stdout + stderr)
+
+    def test_dry_run_writes_nothing(self, home: Path):
+        (home / ".cursor").mkdir()
+        _run_cli("agent enable cursor.mcp", home)
+        before = _snapshot_tree(home)
+
+        stdout, _, code = _run_cli("agent uninstall --dry-run --yes", home)
+        assert code == 0
+        assert "DRY RUN" in stdout
+        assert "cursor.mcp" in stdout
+        assert _snapshot_tree(home) == before
+
+    def test_yes_skips_confirmation_and_reverses_components(self, home: Path):
+        (home / ".cursor").mkdir()
+        (home / ".claude").mkdir()
+        _run_cli("agent enable cursor.mcp", home)
+        _run_cli("agent enable claude-code.mcp", home)
+        _run_cli("agent enable claude-code.instructions", home)
+        assert (home / ".cursor" / "mcp.json").exists()
+
+        _, stderr, code = _run_cli("agent uninstall --yes", home)
+        assert code == 0, f"stderr={stderr!r}"
+
+        cursor_cfg = json.loads((home / ".cursor" / "mcp.json").read_text())
+        assert "rafter" not in (cursor_cfg.get("mcpServers") or {})
+
+        # claude-code.mcp writes <cwd>/.mcp.json; with only rafter present
+        # uninstall deletes the file.
+        assert not (home / ".mcp.json").exists()
+
+        claude_md = home / ".claude" / "CLAUDE.md"
+        if claude_md.exists():
+            assert "rafter:start" not in claude_md.read_text()
+
+    def test_preserves_pre_existing_non_rafter_hook(self, home: Path):
+        (home / ".claude").mkdir()
+        settings_path = home / ".claude" / "settings.json"
+        settings_path.write_text(json.dumps({
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Bash", "hooks": [
+                        {"type": "command", "command": "some-other-tool guard"},
+                    ]},
+                ],
+            },
+        }, indent=2))
+
+        _run_cli("agent enable claude-code.hooks", home)
+        _run_cli("agent uninstall --yes", home)
+
+        s = json.loads(settings_path.read_text())
+        cmds = [h["command"] for e in (s.get("hooks") or {}).get("PreToolUse", []) for h in e["hooks"]]
+        assert "some-other-tool guard" in cmds
+        assert "rafter hook pretool" not in cmds
+
+    def test_round_trip_returns_filesystem(self, home: Path):
+        (home / ".cursor").mkdir()
+        (home / ".claude").mkdir()
+        before = _snapshot_tree(home)
+
+        _run_cli("agent enable cursor.mcp", home)
+        _run_cli("agent enable claude-code.instructions", home)
+        _run_cli("agent enable claude-code.mcp", home)
+
+        _, _, code = _run_cli("agent uninstall --yes", home)
+        assert code == 0
+
+        after = _snapshot_tree(home)
+        # ~/.rafter/config.json is allowed to exist (records component state);
+        # exclude it from the comparison.
+        after = {k: v for k, v in after.items() if not k.startswith(".rafter/")}
+        assert after == before
+
+    def test_preserves_audit_log_without_purge(self, home: Path):
+        rafter_dir = home / ".rafter"
+        rafter_dir.mkdir()
+        (rafter_dir / "audit.jsonl").write_text('{"event":"test"}\n')
+        (rafter_dir / "config.json").write_text('{"keep":true}')
+
+        (home / ".cursor").mkdir()
+        _run_cli("agent enable cursor.mcp", home)
+
+        _, _, code = _run_cli("agent uninstall --yes", home)
+        assert code == 0
+
+        assert (rafter_dir / "audit.jsonl").exists()
+        assert "test" in (rafter_dir / "audit.jsonl").read_text()
+        assert (rafter_dir / "config.json").exists()
+
+    def test_purge_removes_rafter_dir(self, home: Path):
+        rafter_dir = home / ".rafter"
+        (rafter_dir / "bin").mkdir(parents=True)
+        (rafter_dir / "audit.jsonl").write_text('{"event":"test"}\n')
+        (rafter_dir / "config.json").write_text('{"keep":true}')
+        (rafter_dir / "bin" / "betterleaks").write_text("fake binary")
+
+        (home / ".cursor").mkdir()
+        _run_cli("agent enable cursor.mcp", home)
+
+        _, _, code = _run_cli("agent uninstall --purge --yes", home)
+        assert code == 0
+
+        assert not (rafter_dir / "audit.jsonl").exists()
+        assert not (rafter_dir / "bin").exists()
+
+    def test_idempotent_second_run_noop(self, home: Path):
+        (home / ".cursor").mkdir()
+        _run_cli("agent enable cursor.mcp", home)
+        _run_cli("agent uninstall --yes", home)
+
+        before = _snapshot_tree(home)
+        stdout, stderr, code = _run_cli("agent uninstall --yes", home)
+        assert code == 0
+        assert "Nothing to uninstall" in (stdout + stderr)
+        assert _snapshot_tree(home) == before


### PR DESCRIPTION
## Summary

Adds \`rafter agent uninstall\` — the missing bulk-revert command split off from sable-b74 in PR #110.

Walks every registered \`ComponentSpec\` and calls its existing \`.uninstall()\` callback, so hook-survival heuristics, MCP key removal, instruction marker-block stripping, and skill-file deletion all stay defined in one place (\`components.ts\`). Under \`--purge\`, also removes \`~/.rafter/{config.json,audit.jsonl,bin,patterns}\`.

**Flags:**
- \`--dry-run\` — preview every component + purge target without writing
- \`--yes\` / \`-y\` — skip confirmation
- \`--purge\` — also remove \`~/.rafter\` (config + audit log + binary cache)
- \`--local\` — operate against \`./.rafter\` + project-local platform dirs (mirrors \`init --local\`); implemented by re-rooting \`HOME\` at cwd so every component's path-resolution lands in the project without per-component path forking

**Safety:**
- Each \`ComponentSpec.uninstall()\` already preserves other tools' / users' hook + MCP entries — only entries with a \`command === \"rafter ...\"\` shape are touched
- Non-TTY stdin defaults the confirmation to \"no\" so CI never hangs
- Project \`.rafter.yml\` is never touched (it's user content, not rafter-managed state)
- Idempotent: re-running writes nothing

## Test plan

- \`node/tests/agent-uninstall.test.ts\` (new, ~215 lines):
  - install → uninstall round-trip leaves the filesystem byte-equivalent (modulo timestamps)
  - \`--dry-run\` writes nothing
  - \`--yes\` skips confirmation
  - pre-existing user hook with a NON-rafter command survives uninstall (the survival heuristic from \`components.ts\`)
  - audit log preserved by default
  - \`--purge\` removes \`~/.rafter\`
- \`python/tests/test_agent_uninstall.py\` (new, ~171 lines): same six scenarios.

**Local verification done:**
- \`pnpm exec tsc -p tsconfig.json --noEmit\` — exit 0, no errors
- \`python3 -c \"import ast; ast.parse(...)\"\` — clean on \`agent.py\` and \`test_agent_uninstall.py\`

**Not done locally:**
- vitest / pytest. Host is at load avg 80; \`pnpm run build\` alone exceeds 120s (the vitest globalSetup timeout). Will exercise once load drops or at the maylist→main promotion gate.

## Not in scope (deliberately punted)

- No \`--components <list>\` partial uninstall — \`rafter agent disable <id>\` already exists for that.
- Empty platform dirs (\`.cursor/\`, \`.windsurf/\`, etc.) left for the user to clean up — mirrors \`agent disable\` behavior.
- No CLI_SPEC.md update — the bead didn't ask for it; can be a follow-up.

Target: \`maylist\`.

Closes sable-3ep. Implemented by an isolated worktree subagent under crew sable's supervision; reviewed by sable before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>