### PR TITLE
fix(sable-23u): bump stale OpenClaw skill path references to ClawHub canonical location

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Add to any MCP client config:
 |-------|-------------|-----------|-------------------|
 | Claude Code | Hooks + Skills | `~/.claude` | `~/.claude/skills/rafter/` and `rafter-agent-security/` |
 | Codex CLI | Skills | `~/.codex` | `~/.agents/skills/rafter/` and `rafter-agent-security/` |
-| OpenClaw | Skills | `~/.openclaw` | `~/.openclaw/skills/rafter-security.md` |
+| OpenClaw | Skills | `~/.openclaw` | `~/.openclaw/workspace/skills/rafter-security/SKILL.md` |
 | Gemini CLI | MCP server | `~/.gemini` | `~/.gemini/settings.json` |
 | Cursor | MCP server | `~/.cursor` | `~/.cursor/mcp.json` |
 | Windsurf | MCP server | `~/.codeium/windsurf` | `~/.codeium/windsurf/mcp_config.json` |

--- a/SKILL.md
+++ b/SKILL.md
@@ -42,7 +42,7 @@ rafter agent init --with-claude-code --with-betterleaks
 |----------|-----------------|---------------------|
 | Claude Code | PreToolUse/PostToolUse hooks + skills | `~/.claude/settings.json` (hooks), `~/.claude/skills/rafter/` (skills) |
 | Codex CLI | Skills | `~/.agents/skills/rafter/` |
-| OpenClaw | Skills | `~/.openclaw/skills/rafter-security.md` |
+| OpenClaw | Skills | `~/.openclaw/workspace/skills/rafter-security/SKILL.md` |
 | Cursor | MCP server | `~/.cursor/mcp.json` |
 | Gemini CLI | MCP server | `~/.gemini/settings.json` |
 | Windsurf | MCP server | `~/.codeium/windsurf/mcp_config.json` |

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -1263,7 +1263,7 @@ export function createInitCommand(): Command {
         const result = await skillManager.installRafterSkillVerbose();
         openclawOk = result.ok;
         if (result.ok) {
-          console.log(fmt.success("Installed Rafter Security skill to ~/.openclaw/skills/rafter-security.md"));
+          console.log(fmt.success(`Installed Rafter Security skill to ${result.destPath}`));
           manager.set("agent.environments.openclaw.enabled", true);
         } else {
           console.log(fmt.error("Failed to install Rafter Security skill"));

--- a/node/src/commands/brief.ts
+++ b/node/src/commands/brief.ts
@@ -347,13 +347,13 @@ OpenClaw has native skill support.
 rafter agent init --with-openclaw
 \`\`\`
 
-This installs the security skill to \`~/.openclaw/skills/rafter-security.md\`.
+This installs the security skill to \`~/.openclaw/workspace/skills/rafter-security/SKILL.md\` — the canonical ClawHub path OpenClaw auto-discovers at session start.
 
 ## Manual Setup
 
 \`\`\`bash
-mkdir -p ~/.openclaw/skills
-rafter brief scanning > ~/.openclaw/skills/rafter-security.md
+mkdir -p ~/.openclaw/workspace/skills/rafter-security
+rafter brief scanning > ~/.openclaw/workspace/skills/rafter-security/SKILL.md
 \`\`\``,
 
   continue: `# Rafter Setup — Continue.dev

--- a/python/rafter_cli/commands/brief.py
+++ b/python/rafter_cli/commands/brief.py
@@ -201,13 +201,13 @@ OpenClaw has native skill support.
 rafter agent init --with-openclaw
 ```
 
-This installs the security skill to `~/.openclaw/skills/rafter-security.md`.
+This installs the security skill to `~/.openclaw/workspace/skills/rafter-security/SKILL.md` — the canonical ClawHub path OpenClaw auto-discovers at session start.
 
 ## Manual Setup
 
 ```bash
-mkdir -p ~/.openclaw/skills
-rafter brief scanning > ~/.openclaw/skills/rafter-security.md
+mkdir -p ~/.openclaw/workspace/skills/rafter-security
+rafter brief scanning > ~/.openclaw/workspace/skills/rafter-security/SKILL.md
 ```""",
 
     "continue": """\


### PR DESCRIPTION
## Summary

OpenClaw skill install moved to \`~/.openclaw/workspace/skills/rafter-security/SKILL.md\` in v0.7.9 (rf-zgwj) so OpenClaw actually auto-discovers it at session start. A handful of doc + console-log sites still showed the pre-migration path (\`~/.openclaw/skills/rafter-security.md\`, which OpenClaw never read).

Files bumped:
- \`README.md:481\` platform-integration table
- \`SKILL.md:45\` platform-integration table
- \`node/src/commands/agent/init.ts:1266\` — success log now uses \`\${result.destPath}\` so it tracks SkillManager's actual destination instead of a hardcoded stale string
- \`node/src/commands/brief.ts:350-356\` — embedded \`rafter brief openclaw\` setup doc
- \`python/rafter_cli/commands/brief.py:204-210\` — Python parity of the same brief

Legacy-path references in \`recipes/openclaw.md\`, \`CHANGELOG.md\`, and the two migration tests (\`node/tests/openclaw-integration.test.ts\`, \`python/tests/test_agent_init.py\`) are intentional — they document the migration step and are NOT touched.

Target: \`maylist\`.

Closes sable-23u.

## Test plan

- [x] \`pnpm exec tsc -p tsconfig.json --noEmit\` clean
- [x] \`python3 -c \"import ast; ast.parse(...)\"\` on agent.py + brief.py clean
- [x] Migration tests still reference the legacy path on purpose (verified intentional usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>