### PR TITLE
docs(sable-pe4): fix node/README rafter run example — --repo flag, not positional URL

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -27,8 +27,9 @@ rafter secrets .
 # Install Rafter into your AI coding agents (Claude Code, Codex, Cursor, etc.)
 rafter agent init --all
 
-# Scan a remote repo (needs RAFTER_API_KEY)
-rafter run https://github.com/owner/repo
+# Scan a remote repo (needs RAFTER_API_KEY). Omit --repo to scan the
+# current directory's repo (auto-detected from git remote).
+rafter run --repo owner/repo
 ```
 
 See the [root README](https://github.com/Raftersecurity/rafter-cli/blob/main/README.md) for the full command reference, supported platforms, and integration recipes.


### PR DESCRIPTION
## Summary

\`node/README.md:31\` showed \`rafter run https://github.com/owner/repo\` as if \`rafter run\` takes a positional URL. The actual CLI surface (\`node/src/commands/backend/run.ts:107-116\`) accepts \`-r/--repo <repo>\` where repo is \`org/repo\` shorthand, and no positional argument. Omitting \`--repo\` auto-detects from git remote.

Bumped to \`rafter run --repo owner/repo\` with a comment about auto-detect.

Root \`README.md\` and \`python/README.md\` already showed the correct flag-based shape — only \`node/README.md\` had drifted.

Target: \`maylist\`.

Closes sable-pe4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>