### PR TITLE
fix(sable-am4): convert execSync string-interp to execFileSync array form (CWE-78/CWE-94)

### DIFF
--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -6,7 +6,7 @@ import { SkillManager } from "../../utils/skill-manager.js";
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 import { createInterface } from "readline";
@@ -974,7 +974,7 @@ function installGeminiSkills(root: string): void {
 function registerGeminiSkills(skillsDir: string): void {
   // Probe for the `gemini` binary. Absence is expected on CI / fresh machines.
   try {
-    execSync("gemini --version", { stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
+    execFileSync("gemini", ["--version"], { stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
   } catch {
     console.log(fmt.warning(
       "gemini CLI not found on PATH — skipping skill registration. " +
@@ -985,7 +985,7 @@ function registerGeminiSkills(skillsDir: string): void {
 
   // Probe `gemini skills` subcommand (added in 0.35).
   try {
-    execSync("gemini skills --help", { stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
+    execFileSync("gemini", ["skills", "--help"], { stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
   } catch {
     console.log(fmt.warning(
       "gemini CLI does not support `skills` subcommand (needs ≥ 0.35). " +
@@ -998,7 +998,7 @@ function registerGeminiSkills(skillsDir: string): void {
     const absPath = path.resolve(skillsDir, skill.name);
     if (!fs.existsSync(absPath)) continue;
     try {
-      execSync(`gemini skills link ${JSON.stringify(absPath)}`, {
+      execFileSync("gemini", ["skills", "link", absPath], {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 10000,
       });
@@ -1464,7 +1464,7 @@ export function createInitCommand(): Command {
       try {
         const _require = createRequire(import.meta.url);
         const { version: thisVersion } = _require("../../../package.json");
-        const pathVersion = execSync("rafter --version", {
+        const pathVersion = execFileSync("rafter", ["--version"], {
           encoding: "utf-8",
           timeout: 5000,
           stdio: ["pipe", "pipe", "ignore"],

--- a/node/src/commands/agent/install-hook.ts
+++ b/node/src/commands/agent/install-hook.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { fileURLToPath } from 'url';
 import { fmt } from "../../utils/formatter.js";
 
@@ -45,14 +45,14 @@ function getTemplatePath(templateName: string): string {
  */
 async function installLocalHook(hookName: string, templateName: string): Promise<void> {
   try {
-    execSync("git rev-parse --git-dir", { stdio: "pipe" });
+    execFileSync("git", ["rev-parse", "--git-dir"], { stdio: "pipe" });
   } catch (e) {
     console.error(fmt.error("Not in a git repository"));
     console.error("   Run this command from inside a git repository");
     process.exit(1);
   }
 
-  const gitDir = execSync("git rev-parse --git-dir", { encoding: "utf-8" }).trim();
+  const gitDir = execFileSync("git", ["rev-parse", "--git-dir"], { encoding: "utf-8" }).trim();
   const hooksDir = path.resolve(gitDir, "hooks");
   const hookPath = path.join(hooksDir, hookName);
 
@@ -115,7 +115,7 @@ async function installGlobalHook(hookName: string, templateName: string): Promis
   fs.chmodSync(hookPath, 0o755);
 
   try {
-    execSync(`git config --global core.hooksPath "${globalHooksDir}"`, { stdio: "pipe" });
+    execFileSync("git", ["config", "--global", "core.hooksPath", globalHooksDir], { stdio: "pipe" });
     console.log(fmt.success(`Installed Rafter ${hookName} hook globally`));
     console.log(`  Location: ${hookPath}`);
     console.log(`  Git config: core.hooksPath = ${globalHooksDir}`);


### PR DESCRIPTION
## Summary

Two flagged sites + three adjacent ones in the same files converted in one pass. All five drop \`execSync\` with string interpolation in favor of \`execFileSync\` with an array of args, eliminating shell-parsing of any interpolated value.

### install-hook.ts

- **\`:118\`** (flagged) — \`git config --global core.hooksPath \"\${globalHooksDir}\"\`. \`globalHooksDir\` was interpolated through the shell; even with double quotes, a path containing \`\` ` \`\` (backtick) or \`$(...)\` would expand. Now passed as a discrete arg.
- **\`:48\`, \`:55\`** — \`git rev-parse --git-dir\` probes. Static strings, already safe; converted for consistency.

### init.ts

- **\`:1001\`** (flagged) — \`gemini skills link \${JSON.stringify(absPath)}\`. \`JSON.stringify()\` quotes for JSON, **not** for shell. An \`absPath\` containing \`\` ` \`\` or \`$(...)\` would execute. Reachability is low (path comes from internal \`AGENT_SKILLS\` constant and \`process.cwd()\`-derived paths) but the pattern is wrong. Now passed as a discrete arg.
- **\`:977\`, \`:988\`, \`:1467\`** — \`gemini --version\`, \`gemini skills --help\`, \`rafter --version\` probes. Static strings; converted for consistency.

### Python parity

Already correct. \`python/rafter_cli/commands/agent.py\` uses \`subprocess.run([...], ...)\` array form everywhere relevant (lines 560, 578, 2040, 2130, 2476, 2905, 3411). No Python change needed.

### Sister findings out of scope (will land separately)

- \`node/src/utils/git.ts:4\` — \`execSync(\`git \${cmd}\`)\` wrapper. Already tracked by **sable-16b**.
- \`node/src/commands/agent/status.ts:46\` — \`execSync(\`\"\${localBetterleaks}\" version\`)\`. **No bead yet — filing.**

Target: \`maylist\`.

Closes sable-am4 (SEC-3/SEC-4 from \`os-audit-2026-05-12.md\`).

## Test plan

- [x] \`pnpm exec tsc -p tsconfig.json --noEmit\` clean
- [x] No behavioral change: each \`execFileSync\` call carries the same \`stdio\`/\`timeout\`/\`encoding\` options as the \`execSync\` it replaced
- [ ] vitest blocked by host load — covered by existing install-hook + init integration tests once box recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>