### PR TITLE
fix(sable-16b, sable-k7g): convert remaining execSync sites to execFileSync array form

### DIFF
--- a/node/src/commands/agent/status.ts
+++ b/node/src/commands/agent/status.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { getRafterDir, getAuditLogPath, getBinDir } from "../../core/config-defaults.js";
 import { AuditLogger } from "../../core/audit-logger.js";
 import { ConfigManager } from "../../core/config-manager.js";
@@ -38,12 +38,12 @@ export function createStatusCommand(): Command {
       const localBetterleaks = path.join(getBinDir(), `betterleaks${exeExt}`);
       let betterleaksStatus = "not found — run: rafter agent init --with-betterleaks";
       try {
-        const ver = execSync("betterleaks version", { timeout: 5000, encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] }).trim();
+        const ver = execFileSync("betterleaks", ["version"], { timeout: 5000, encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] }).trim();
         betterleaksStatus = `${ver} (PATH)`;
       } catch {
         if (fs.existsSync(localBetterleaks)) {
           try {
-            const ver = execSync(`"${localBetterleaks}" version`, { timeout: 5000, encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] }).trim();
+            const ver = execFileSync(localBetterleaks, ["version"], { timeout: 5000, encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] }).trim();
             betterleaksStatus = `${ver} (local)`;
           } catch {
             betterleaksStatus = `${localBetterleaks} (binary error)`;

--- a/node/src/utils/git.ts
+++ b/node/src/utils/git.ts
@@ -1,16 +1,16 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
-export function git(cmd: string): string {
-  return execSync(`git ${cmd}`, { stdio: ["ignore", "pipe", "ignore"] })
+export function git(args: string[]): string {
+  return execFileSync("git", args, { stdio: ["ignore", "pipe", "ignore"] })
     .toString()
     .trim();
 }
 
-export function safeBranch(gitFn: (c: string) => string): string {
+export function safeBranch(gitFn: (a: string[]) => string): string {
   try {
-    return gitFn("symbolic-ref --quiet --short HEAD");
+    return gitFn(["symbolic-ref", "--quiet", "--short", "HEAD"]);
   } catch {
-    return gitFn("rev-parse --short HEAD");
+    return gitFn(["rev-parse", "--short", "HEAD"]);
   }
 }
 
@@ -29,9 +29,9 @@ export function detectRepo(opts: { repo?: string; branch?: string; quiet?: boole
   let branch = opts.branch || branchEnv;
   try {
     if (!repoSlug || !branch) {
-      if (git("rev-parse --is-inside-work-tree") !== "true")
+      if (git(["rev-parse", "--is-inside-work-tree"]) !== "true")
         throw new Error("not a repo");
-      if (!repoSlug) repoSlug = parseRemote(git("remote get-url origin"));
+      if (!repoSlug) repoSlug = parseRemote(git(["remote", "get-url", "origin"]));
       if (!branch) {
         try {
           branch = safeBranch(git);


### PR DESCRIPTION
## Summary

Continues the shell-injection cleanup started in sable-am4 (PR #121). Two more sites converted to array-form \`execFileSync\`:

### \`node/src/utils/git.ts\`

Tracked by **sable-16b**. The \`git(cmd: string)\` helper interpolates \`cmd\` into a backtick string passed to \`execSync\`. Changed to \`git(args: string[])\` using \`execFileSync\`. \`safeBranch()\` signature updated to match. Internal callers in \`detectRepo()\` updated to pass arg arrays. The only public export users hit is \`detectRepo()\`, and its signature is unchanged.

### \`node/src/commands/agent/status.ts:41,46\`

Tracked by **sable-k7g** (filed as a sister to sable-am4). The \`localBetterleaks\` interpolation was the real shell-interp case — even with the double quotes, a binary path containing \`\` ` \`\` or \`$(...)\` would expand. Reachability is low (path comes from a hardcoded \`~/.rafter/bin/betterleaks\` location), but the pattern is wrong.

### Python parity

Already correct. \`python/rafter_cli/commands/agent.py\` uses \`subprocess.run([...], ...)\` array form everywhere relevant. Verified during sable-am4.

### NOT the last execSync sweep

Audit during this PR found more execSync sites in \`node/src/\` that warrant individual review (\`agent exec\` runs user-passed commands by design; \`binary-manager\`, \`hook/pretool\`, \`docs-loader\`, \`init-project\`, \`policy-loader\` all use static strings but should convert for idiom). Filed as **sable-wxe** as a follow-up audit bead.

Target: \`maylist\`.

Closes sable-16b and sable-k7g.

## Test plan

- [x] \`pnpm exec tsc -p tsconfig.json --noEmit\` clean
- [x] No behavioral change: each \`execFileSync\` call carries the same options as the \`execSync\` it replaced
- [x] Public \`detectRepo\` signature unchanged
- [ ] vitest blocked by host load — \`git\` + \`status\` integration tests will exercise these paths once box recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>