### PR TITLE
fix(sable-euu): reject .rafter.yml audit.logPath that escapes the rafter tree (CWE-22)

### DIFF
--- a/node/src/core/audit-logger.ts
+++ b/node/src/core/audit-logger.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from "crypto";
 import dns from "dns/promises";
 import fs from "fs";
 import net from "net";
+import os from "os";
 import path from "path";
 import { getAuditLogPath } from "./config-defaults.js";
 import { ConfigManager } from "./config-manager.js";
@@ -97,6 +98,29 @@ function isPrivateIp(ip: string): boolean {
   }
 
   return false;
+}
+
+/**
+ * Validate a policy-supplied audit.logPath (from .rafter.yml).
+ *
+ * Resolves the path and requires that it stays under either the project's
+ * own rafter dir (cwd/.rafter — covers --local mode) or the global rafter
+ * dir (~/.rafter). A malicious .rafter.yml could otherwise set the path
+ * to ../../etc/passwd or anywhere else writable; refusing the override
+ * forces those configs to fall back to the default. Empty / undefined
+ * input also returns false (caller falls back to default).
+ */
+function isPolicyLogPathSafe(raw: string | undefined): raw is string {
+  if (!raw || typeof raw !== "string") return false;
+  const resolved = path.resolve(raw);
+  const allowedRoots = [
+    path.resolve(process.cwd(), ".rafter"),
+    path.resolve(os.homedir(), ".rafter"),
+  ];
+  return allowedRoots.some((root) => {
+    const rel = path.relative(root, resolved);
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  });
 }
 
 export type EventType =
@@ -240,15 +264,20 @@ export class AuditLogger {
     if (logPath) {
       this.logPath = logPath;
     } else {
-      // Project-local override from .rafter.yml (via loadWithPolicy) beats global
+      // Project-local override from .rafter.yml (via loadWithPolicy) beats global.
+      // The policy value is user-supplied: a malicious .rafter.yml could set
+      // audit.logPath to ../../etc/passwd. Resolve it and require containment
+      // under the project's rafter dir (cwd/.rafter) or the global rafter dir
+      // (~/.rafter). Anything else is silently ignored — we fall back to the
+      // global default rather than letting policy redirect writes off-tree.
       let policyPath: string | undefined;
       try {
         policyPath = this.configManager.loadWithPolicy()?.agent?.audit?.logPath;
       } catch {
         // fall through to global
       }
-      this.logPath = policyPath
-        ? path.resolve(policyPath)
+      this.logPath = isPolicyLogPathSafe(policyPath)
+        ? path.resolve(policyPath as string)
         : getAuditLogPath();
     }
 

--- a/python/rafter_cli/core/audit_logger.py
+++ b/python/rafter_cli/core/audit_logger.py
@@ -142,12 +142,40 @@ def find_git_repo_root(start_dir: Path, max_depth: int = 20) -> str | None:
     return None
 
 
+def _is_policy_log_path_safe(raw: str | None) -> bool:
+    """Validate a policy-supplied audit.log_path (from .rafter.yml).
+
+    Resolves the path and requires that it stays under either the project's
+    own rafter dir (cwd/.rafter — covers --local mode) or the global rafter
+    dir (~/.rafter). A malicious .rafter.yml could otherwise set the path
+    to ../../etc/passwd; refusing the override forces those configs to
+    fall back to the default. Empty / None input returns False.
+    """
+    if not raw or not isinstance(raw, str):
+        return False
+    resolved = Path(raw).expanduser().resolve()
+    allowed_roots = [
+        (Path.cwd() / ".rafter").resolve(),
+        (Path.home() / ".rafter").resolve(),
+    ]
+    for root in allowed_roots:
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
 class AuditLogger:
     def __init__(self, log_path: Path | None = None):
         if log_path is not None:
             self._path = log_path
         else:
-            # Project-local override from .rafter.yml beats global
+            # Project-local override from .rafter.yml beats global. The policy
+            # value is user-supplied: a malicious .rafter.yml could redirect
+            # writes outside the rafter tree. Containment is enforced by
+            # _is_policy_log_path_safe; rejected paths fall back to default.
             policy_path = None
             try:
                 from .config_manager import ConfigManager
@@ -155,7 +183,11 @@ class AuditLogger:
                 policy_path = merged.agent.audit.log_path
             except Exception:
                 pass
-            self._path = Path(policy_path).expanduser() if policy_path else get_audit_log_path()
+            self._path = (
+                Path(policy_path).expanduser().resolve()
+                if _is_policy_log_path_safe(policy_path)
+                else get_audit_log_path()
+            )
         self._session_id = f"{int(time.time() * 1000)}-{random.randbytes(4).hex()}"
         self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
 


### PR DESCRIPTION
## Summary

\`audit-logger.ts\` and \`audit_logger.py\` accepted the policy-supplied \`audit.logPath\` from \`.rafter.yml\` verbatim — resolve and assign. A malicious \`.rafter.yml\` could set:

\`\`\`yaml
audit:
  logPath: ../../etc/passwd
\`\`\`

and audit writes would land outside the rafter tree (overwriting / appending to arbitrary files reachable by the user). The defensive case matters: rafter is a security tool; users running it on a freshly-cloned repo should not have it act as a write-anywhere vector.

### Fix

Both implementations run the resolved policy path through a containment check that requires the resolved target to live under either:
- \`./.rafter\` (covers \`--local\` mode where the rafter dir is project-local)
- \`~/.rafter\` (the global rafter dir)

Rejected paths cause a silent fall-back to the default audit log path. Per-test direct passing (\`new AuditLogger(logPath)\`) is unchanged — the validation only applies to policy-supplied input.

Containment check uses \`path.relative\` (Node) / \`Path.relative_to\` (Python) — both correctly reject any resolved path that escapes the root.

### Test plan

- [x] \`pnpm exec tsc -p tsconfig.json --noEmit\` clean
- [x] \`python3 -c \"import ast; ast.parse(...)\"\` clean on the modified Python file
- [ ] vitest / pytest blocked by host load. The existing audit-logger tests pass logPath= directly in the constructor (the path that bypasses validation by design), so this change should be backwards-compatible with existing tests. Need a new test for the policy-supplied path validation — filing as follow-up.

Target: \`maylist\`.

Closes sable-euu (SEC-2 from \`os-audit-2026-05-12.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>