### PR TITLE
docs(sable-d5d): audit + tighten rafter-skill-review skill (A15)

### DIFF
--- a/node/resources/skills/rafter-skill-review/SKILL.md
+++ b/node/resources/skills/rafter-skill-review/SKILL.md
@@ -11,14 +11,16 @@ Skills are executable context. Installing one gives it Read, sometimes Bash, som
 
 Before you copy any third-party `SKILL.md`, MCP manifest, Cursor rule, or agent extension into your machine, run this skill.
 
-> This skill replaces `rafter agent audit-skill` (still usable but deprecated — emits a stderr warning and aliases to `rafter skill review`).
+> Canonical command: `rafter skill review`. `rafter agent audit-skill` is a
+> deprecated alias — emits a stderr warning and forwards to `skill review`.
+> New scripts and docs should call `rafter skill review` directly.
 
 ---
 
 ## Step 0: Always run the deterministic pass first
 
 ```bash
-rafter skill review <path-or-git-url>            # emits JSON to stdout
+rafter skill review <path-or-git-url>            # JSON to stdout (default)
 rafter skill review <path> --format text         # human-readable summary
 ```
 
@@ -29,9 +31,43 @@ The command:
 - reads `SKILL.md` frontmatter (`allowed-tools`, `version`, etc.),
 - prints a structured JSON report — see `shared-docs/CLI_SPEC.md` §`rafter skill review`.
 
-Exit code `0` means the deterministic pass found nothing. **That does NOT mean the skill is safe.** LLM prompt injection, sneaky data practices, and authorship fraud are invisible to regex. Always follow up with the Choose-Your-Adventure branch below.
+Then, on the SKILL.md (and any sub-doc prose) specifically, run the
+mechanical prompt-injection scan:
+
+```bash
+rafter scan injection <skill>/SKILL.md --fail-on medium
+# Repeat per sub-doc, or wire into a loop:
+find <skill> -name '*.md' -print0 | xargs -0 -n1 rafter scan injection --fail-on medium
+```
+
+This catches the zero-width / bidi / role-override class regex misses by
+eye. It is experimental; treat non-zero exit as "stop and read the
+finding", not as a verdict on its own.
+
+Exit code `0` from either pass does NOT mean the skill is safe. LLM prompt
+injection, sneaky data practices, and authorship fraud sit just outside
+regex reach. Always follow up with the Choose-Your-Adventure branch below.
 
 ---
+
+## Watch-items at a glance
+
+Every item below has a mechanical check. If any check trips, stop and walk
+the linked sub-doc before deciding.
+
+| Risk | Mechanical check | Sub-doc |
+|---|---|---|
+| Prompt-injection in the skill body (zero-width / bidi / override prose) | `rafter scan injection <skill>/SKILL.md --fail-on medium` (see `docs/prompt-injection.md` §0 for the zero-width / bidi grep) | `docs/prompt-injection.md` |
+| Hidden tool invocations in install steps (`curl \| sh`, `npm` postinstall) | `rg -n 'curl.*\|.*(sh\|bash)\|wget.*\|.*(sh\|bash)\|eval "\$\(curl' <skill>`; `jq '.scripts' <skill>/package.json` | `docs/malware-indicators.md` §2–3 |
+| Exfiltration (curl to attacker host, base64 phone-home) | `rg -n 'base64 -d\|atob\(\|fromCharCode\|fetch\([^)]*track\|navigator\.sendBeacon' <skill>`; review every outbound URL in the JSON report | `docs/telemetry.md`, `docs/data-practices.md` §3 |
+| Overbroad `allowed-tools` (markdown formatter asks for `Bash, Write, WebFetch`) | `rg -n '^allowed-tools' <skill>/SKILL.md` — then justify each tool against the stated purpose in one sentence | `docs/data-practices.md` §5 |
+| Typo-squat / stale package name (`eslint-config-airbn` vs `…airbnb`) | `npm view <pkg>` / `pip show <pkg>`; compute Levenshtein vs the popular name; check registration date | `docs/authorship-provenance.md` §4 |
+| Sabotage of other skills (disable, override, hijack peer SKILL.md) | `rg -n 'SKILL\.md\|allowed-tools\|settings\.json\|\.rafter\.yml\|mcp__' <skill>` — any write/override of peer files = reject | `docs/prompt-injection.md` §6, `docs/data-practices.md` §6 |
+| Sensitive-path reads outside stated scope (`~/.ssh`, `~/.aws/credentials`, `.git-credentials`, keychain) | `rg -n '\.ssh\|\.aws/credentials\|\.gnupg\|\.netrc\|\.git-credentials\|Keychain\|gnome-keyring\|/proc/[^/]+/environ' <skill>` | `docs/malware-indicators.md` §6–7, `docs/data-practices.md` §1 |
+| MCP manifest grants new servers / tools silently | `jq '.mcpServers // .servers' <skill>/**/*.json`; cross-check every entry against an explicit list in SKILL.md | `docs/data-practices.md` §6 |
+
+These are floor checks. None of them clear the skill on their own —
+they only fail it fast.
 
 ## Choose Your Adventure
 
@@ -62,6 +98,7 @@ Use this when: a new version of a skill you already trust is out and you're abou
 
 Use this when: something smells wrong (someone reported it, the name is a typo-squat, it showed up uninstalled, a finding from step 0 alarmed you).
 
+- **Run `rafter scan injection <skill>/SKILL.md`** on every markdown file — get the file:line evidence before reading prose.
 - **`Read docs/malware-indicators.md`** first — prioritize obfuscation and binary-blob checks.
 - **`Read docs/prompt-injection.md`** — the skill may be weaponized against the installer, not the end user.
 - **`Read docs/authorship-provenance.md`** — map the real author (not the claimed one), check other artifacts from the same account.
@@ -82,25 +119,30 @@ If any branch yields a concrete indicator: do not install. File the finding with
 ## Fast path — copy-paste
 
 ```bash
-# Local path
-rafter skill review ./third-party-skill/ --json > report.json
+SKILL=./third-party-skill   # or a git URL
 
-# Git URL (shallow-cloned into temp dir; removed after review)
-rafter skill review https://github.com/acme/their-skill.git --json > report.json
+# 1. Deterministic pass (secrets + URLs + shell + frontmatter)
+rafter skill review "$SKILL" --format json > /tmp/skill-review.json
 
-# Human-readable
-rafter skill review ./third-party-skill/
+# 2. Prompt-injection scan on every markdown file in the skill
+find "$SKILL" -name '*.md' -print0 \
+  | xargs -0 -n1 rafter scan injection --fail-on medium
+
+# 3. Allowed-tools sanity (eyeball against stated purpose)
+rg -n '^allowed-tools' "$SKILL"/SKILL.md
 ```
 
-If the command exits 1 → findings present → walk branch (a) or (c) above.
-If exit 0 → deterministic pass clean → still walk branch (a) for a new install.
+If any of those exit non-zero → walk branch (a) or (c) above.
+If all three exit 0 → deterministic floor is clean → still walk branch (a)
+for a new install. Regex passes are necessary, not sufficient.
 
 ## Decision rule
 
-Install only if **all three** are true:
+Install only if **all four** are true:
 
 1. `rafter skill review` exit 0 (or every finding is explained and accepted).
-2. The branch you walked has no unanswered questions.
-3. `allowed-tools` is narrower than or equal to what the skill's stated purpose requires.
+2. `rafter scan injection` exit 0 on every markdown file in the skill (or every finding is explained).
+3. The branch you walked has no unanswered questions.
+4. `allowed-tools` is narrower than or equal to what the skill's stated purpose requires.
 
 If in doubt, don't install. Re-evaluating later is cheap; removing a backdoor is not.

--- a/node/resources/skills/rafter-skill-review/docs/authorship-provenance.md
+++ b/node/resources/skills/rafter-skill-review/docs/authorship-provenance.md
@@ -32,7 +32,15 @@ Unsigned does not automatically mean bad. **Changed signatures** (used to sign, 
 - **Registry page**: `npm view <pkg>`, `pip show <pkg>`, plugin marketplace page.
 - **Download count / star count**: high numbers don't prove safety, but sudden spikes after a rename / transfer can indicate squatting.
 - **Transferred ownership**: `npm view <pkg> maintainers` history, `pypi` project audit log, GitHub transfer events. A skill that changed hands recently is a classic supply-chain pattern — the new owner publishes a trojaned version to existing users.
-- **Typo-squat check**: compare name to popular legitimate skills. Levenshtein distance of 1–2 from a well-known name, combined with recent registration, is a strong signal.
+- **Typo-squat check**: compare the name to popular legitimate skills/packages. Levenshtein distance of 1–2 from a well-known name, combined with recent registration, is a strong signal. Quick mechanical check (npm example):
+  ```bash
+  npm view <suspect-pkg> time.created     # is this brand new?
+  npm view <known-good-pkg> time.created  # is the lookalike old?
+  # If suspect is days/weeks old and a single-char edit of an old popular
+  # package, treat as typo-squat until proven otherwise. Examples seen in
+  # the wild: `eslint-config-airbn` (vs `eslint-config-airbnb`),
+  # `requets` (vs `requests`), `crossenv` (vs `cross-env`).
+  ```
 
 ## 5. Parallel artifacts from the same author
 

--- a/node/resources/skills/rafter-skill-review/docs/data-practices.md
+++ b/node/resources/skills/rafter-skill-review/docs/data-practices.md
@@ -58,9 +58,19 @@ Every `process.env.FOO` / `os.environ["FOO"]` is a potential credential sink. En
 
 Skills declare `allowed-tools` in frontmatter. Reconcile:
 
-- **Stated purpose vs. allowed-tools**: a "code review" skill that declares `allowed-tools: [Bash, Write, WebFetch]` is asking for more than the purpose justifies.
-- **Minimal grant**: `Read, Glob, Grep` is usually enough for analysis skills. Each extra tool (`Bash`, `Write`, `WebFetch`, `Edit`) needs a sentence of justification in SKILL.md.
+- **Stated purpose vs. allowed-tools**: a "code review" skill that declares `allowed-tools: [Bash, Write, WebFetch]` is asking for more than the purpose justifies. A markdown formatter asking for `Bash` is the canonical overbroad-grant red flag — reject.
+- **Minimal grant**: `Read, Glob, Grep` is usually enough for analysis skills. Each extra tool (`Bash`, `Write`, `WebFetch`, `Edit`, `NetworkAccess`) needs a sentence of justification in SKILL.md.
 - **Shell calls in `Bash`**: for every shell command the skill invokes, re-run `rafter skill review` worth of checks against that command specifically.
+
+Mechanical check:
+
+```bash
+rg -n '^allowed-tools' <skill>/SKILL.md          # what's granted
+rg -n '^(name|description):' <skill>/SKILL.md    # what's claimed
+```
+
+Write one sentence per granted tool justifying it from the description. If
+you can't, the grant is wider than the purpose. Reject.
 
 ## 6. Silent escalation
 

--- a/node/resources/skills/rafter-skill-review/docs/malware-indicators.md
+++ b/node/resources/skills/rafter-skill-review/docs/malware-indicators.md
@@ -54,6 +54,10 @@ Grep for:
 - Creation of cron entries, systemd units, launchd plists, `crontab -e` pipes.
 - Modification of PATH via shell rc injection.
 
+```bash
+rg -n '\.\./|/etc/|\.bashrc|\.zshrc|\.profile|crontab|systemctl|launchctl|/etc/cron|/Library/LaunchDaemons' <skill>
+```
+
 Any of these in an install script or a "helper" skill command = persistent foothold. Reject.
 
 ## 7. Process / introspection behaviour
@@ -63,7 +67,11 @@ Grep for:
 - Enumeration of `~/.ssh`, `~/.aws/credentials`, `.git-credentials`, browser profiles.
 - Reading clipboard history, keychain, or password-store files.
 
-These are intelligence-gathering primitives. Legitimate skills don't need them.
+```bash
+rg -n '~/\.ssh|\.aws/credentials|\.gnupg|\.netrc|\.git-credentials|Keychain|gnome-keyring|/proc/[^/]+/environ|pbpaste|xclip|wl-paste|chromium.*Login Data|Firefox.*logins\.json' <skill>
+```
+
+These are intelligence-gathering primitives. Legitimate skills don't need them. Any hit outside `<skill>/tests/` fixtures = reject.
 
 ## 8. Escape hatches in SKILL.md
 

--- a/node/resources/skills/rafter-skill-review/docs/prompt-injection.md
+++ b/node/resources/skills/rafter-skill-review/docs/prompt-injection.md
@@ -4,6 +4,22 @@ A skill is a prompt the agent will follow. Anyone who controls the skill content
 
 > The attacker isn't always the skill author. A skill that cites "upstream docs" and `WebFetch`es them on every run imports whatever prompt is currently on that remote page.
 
+## 0. Mechanical first pass
+
+Before reading prose, run the consolidated detector on every markdown file
+in the skill:
+
+```bash
+find <skill> -name '*.md' -print0 \
+  | xargs -0 -n1 rafter scan injection --fail-on medium
+```
+
+This catches the zero-width / bidi / role-override / "ignore previous" /
+hidden-instruction classes mechanically. It is experimental and noisy on
+security-oriented prose (the patterns it flags are also the ones we
+document below). Treat each finding as "stop and read", not as a verdict.
+Sections 1–7 are the human follow-up.
+
 ## 1. Hidden instructions
 
 Grep for:

--- a/python/rafter_cli/resources/skills/rafter-skill-review/SKILL.md
+++ b/python/rafter_cli/resources/skills/rafter-skill-review/SKILL.md
@@ -11,14 +11,16 @@ Skills are executable context. Installing one gives it Read, sometimes Bash, som
 
 Before you copy any third-party `SKILL.md`, MCP manifest, Cursor rule, or agent extension into your machine, run this skill.
 
-> This skill replaces `rafter agent audit-skill` (still usable but deprecated — emits a stderr warning and aliases to `rafter skill review`).
+> Canonical command: `rafter skill review`. `rafter agent audit-skill` is a
+> deprecated alias — emits a stderr warning and forwards to `skill review`.
+> New scripts and docs should call `rafter skill review` directly.
 
 ---
 
 ## Step 0: Always run the deterministic pass first
 
 ```bash
-rafter skill review <path-or-git-url>            # emits JSON to stdout
+rafter skill review <path-or-git-url>            # JSON to stdout (default)
 rafter skill review <path> --format text         # human-readable summary
 ```
 
@@ -29,9 +31,43 @@ The command:
 - reads `SKILL.md` frontmatter (`allowed-tools`, `version`, etc.),
 - prints a structured JSON report — see `shared-docs/CLI_SPEC.md` §`rafter skill review`.
 
-Exit code `0` means the deterministic pass found nothing. **That does NOT mean the skill is safe.** LLM prompt injection, sneaky data practices, and authorship fraud are invisible to regex. Always follow up with the Choose-Your-Adventure branch below.
+Then, on the SKILL.md (and any sub-doc prose) specifically, run the
+mechanical prompt-injection scan:
+
+```bash
+rafter scan injection <skill>/SKILL.md --fail-on medium
+# Repeat per sub-doc, or wire into a loop:
+find <skill> -name '*.md' -print0 | xargs -0 -n1 rafter scan injection --fail-on medium
+```
+
+This catches the zero-width / bidi / role-override class regex misses by
+eye. It is experimental; treat non-zero exit as "stop and read the
+finding", not as a verdict on its own.
+
+Exit code `0` from either pass does NOT mean the skill is safe. LLM prompt
+injection, sneaky data practices, and authorship fraud sit just outside
+regex reach. Always follow up with the Choose-Your-Adventure branch below.
 
 ---
+
+## Watch-items at a glance
+
+Every item below has a mechanical check. If any check trips, stop and walk
+the linked sub-doc before deciding.
+
+| Risk | Mechanical check | Sub-doc |
+|---|---|---|
+| Prompt-injection in the skill body (zero-width / bidi / override prose) | `rafter scan injection <skill>/SKILL.md --fail-on medium` (see `docs/prompt-injection.md` §0 for the zero-width / bidi grep) | `docs/prompt-injection.md` |
+| Hidden tool invocations in install steps (`curl \| sh`, `npm` postinstall) | `rg -n 'curl.*\|.*(sh\|bash)\|wget.*\|.*(sh\|bash)\|eval "\$\(curl' <skill>`; `jq '.scripts' <skill>/package.json` | `docs/malware-indicators.md` §2–3 |
+| Exfiltration (curl to attacker host, base64 phone-home) | `rg -n 'base64 -d\|atob\(\|fromCharCode\|fetch\([^)]*track\|navigator\.sendBeacon' <skill>`; review every outbound URL in the JSON report | `docs/telemetry.md`, `docs/data-practices.md` §3 |
+| Overbroad `allowed-tools` (markdown formatter asks for `Bash, Write, WebFetch`) | `rg -n '^allowed-tools' <skill>/SKILL.md` — then justify each tool against the stated purpose in one sentence | `docs/data-practices.md` §5 |
+| Typo-squat / stale package name (`eslint-config-airbn` vs `…airbnb`) | `npm view <pkg>` / `pip show <pkg>`; compute Levenshtein vs the popular name; check registration date | `docs/authorship-provenance.md` §4 |
+| Sabotage of other skills (disable, override, hijack peer SKILL.md) | `rg -n 'SKILL\.md\|allowed-tools\|settings\.json\|\.rafter\.yml\|mcp__' <skill>` — any write/override of peer files = reject | `docs/prompt-injection.md` §6, `docs/data-practices.md` §6 |
+| Sensitive-path reads outside stated scope (`~/.ssh`, `~/.aws/credentials`, `.git-credentials`, keychain) | `rg -n '\.ssh\|\.aws/credentials\|\.gnupg\|\.netrc\|\.git-credentials\|Keychain\|gnome-keyring\|/proc/[^/]+/environ' <skill>` | `docs/malware-indicators.md` §6–7, `docs/data-practices.md` §1 |
+| MCP manifest grants new servers / tools silently | `jq '.mcpServers // .servers' <skill>/**/*.json`; cross-check every entry against an explicit list in SKILL.md | `docs/data-practices.md` §6 |
+
+These are floor checks. None of them clear the skill on their own —
+they only fail it fast.
 
 ## Choose Your Adventure
 
@@ -62,6 +98,7 @@ Use this when: a new version of a skill you already trust is out and you're abou
 
 Use this when: something smells wrong (someone reported it, the name is a typo-squat, it showed up uninstalled, a finding from step 0 alarmed you).
 
+- **Run `rafter scan injection <skill>/SKILL.md`** on every markdown file — get the file:line evidence before reading prose.
 - **`Read docs/malware-indicators.md`** first — prioritize obfuscation and binary-blob checks.
 - **`Read docs/prompt-injection.md`** — the skill may be weaponized against the installer, not the end user.
 - **`Read docs/authorship-provenance.md`** — map the real author (not the claimed one), check other artifacts from the same account.
@@ -82,25 +119,30 @@ If any branch yields a concrete indicator: do not install. File the finding with
 ## Fast path — copy-paste
 
 ```bash
-# Local path
-rafter skill review ./third-party-skill/ --json > report.json
+SKILL=./third-party-skill   # or a git URL
 
-# Git URL (shallow-cloned into temp dir; removed after review)
-rafter skill review https://github.com/acme/their-skill.git --json > report.json
+# 1. Deterministic pass (secrets + URLs + shell + frontmatter)
+rafter skill review "$SKILL" --format json > /tmp/skill-review.json
 
-# Human-readable
-rafter skill review ./third-party-skill/
+# 2. Prompt-injection scan on every markdown file in the skill
+find "$SKILL" -name '*.md' -print0 \
+  | xargs -0 -n1 rafter scan injection --fail-on medium
+
+# 3. Allowed-tools sanity (eyeball against stated purpose)
+rg -n '^allowed-tools' "$SKILL"/SKILL.md
 ```
 
-If the command exits 1 → findings present → walk branch (a) or (c) above.
-If exit 0 → deterministic pass clean → still walk branch (a) for a new install.
+If any of those exit non-zero → walk branch (a) or (c) above.
+If all three exit 0 → deterministic floor is clean → still walk branch (a)
+for a new install. Regex passes are necessary, not sufficient.
 
 ## Decision rule
 
-Install only if **all three** are true:
+Install only if **all four** are true:
 
 1. `rafter skill review` exit 0 (or every finding is explained and accepted).
-2. The branch you walked has no unanswered questions.
-3. `allowed-tools` is narrower than or equal to what the skill's stated purpose requires.
+2. `rafter scan injection` exit 0 on every markdown file in the skill (or every finding is explained).
+3. The branch you walked has no unanswered questions.
+4. `allowed-tools` is narrower than or equal to what the skill's stated purpose requires.
 
 If in doubt, don't install. Re-evaluating later is cheap; removing a backdoor is not.

--- a/python/rafter_cli/resources/skills/rafter-skill-review/docs/authorship-provenance.md
+++ b/python/rafter_cli/resources/skills/rafter-skill-review/docs/authorship-provenance.md
@@ -32,7 +32,15 @@ Unsigned does not automatically mean bad. **Changed signatures** (used to sign, 
 - **Registry page**: `npm view <pkg>`, `pip show <pkg>`, plugin marketplace page.
 - **Download count / star count**: high numbers don't prove safety, but sudden spikes after a rename / transfer can indicate squatting.
 - **Transferred ownership**: `npm view <pkg> maintainers` history, `pypi` project audit log, GitHub transfer events. A skill that changed hands recently is a classic supply-chain pattern — the new owner publishes a trojaned version to existing users.
-- **Typo-squat check**: compare name to popular legitimate skills. Levenshtein distance of 1–2 from a well-known name, combined with recent registration, is a strong signal.
+- **Typo-squat check**: compare the name to popular legitimate skills/packages. Levenshtein distance of 1–2 from a well-known name, combined with recent registration, is a strong signal. Quick mechanical check (npm example):
+  ```bash
+  npm view <suspect-pkg> time.created     # is this brand new?
+  npm view <known-good-pkg> time.created  # is the lookalike old?
+  # If suspect is days/weeks old and a single-char edit of an old popular
+  # package, treat as typo-squat until proven otherwise. Examples seen in
+  # the wild: `eslint-config-airbn` (vs `eslint-config-airbnb`),
+  # `requets` (vs `requests`), `crossenv` (vs `cross-env`).
+  ```
 
 ## 5. Parallel artifacts from the same author
 

--- a/python/rafter_cli/resources/skills/rafter-skill-review/docs/data-practices.md
+++ b/python/rafter_cli/resources/skills/rafter-skill-review/docs/data-practices.md
@@ -58,9 +58,19 @@ Every `process.env.FOO` / `os.environ["FOO"]` is a potential credential sink. En
 
 Skills declare `allowed-tools` in frontmatter. Reconcile:
 
-- **Stated purpose vs. allowed-tools**: a "code review" skill that declares `allowed-tools: [Bash, Write, WebFetch]` is asking for more than the purpose justifies.
-- **Minimal grant**: `Read, Glob, Grep` is usually enough for analysis skills. Each extra tool (`Bash`, `Write`, `WebFetch`, `Edit`) needs a sentence of justification in SKILL.md.
+- **Stated purpose vs. allowed-tools**: a "code review" skill that declares `allowed-tools: [Bash, Write, WebFetch]` is asking for more than the purpose justifies. A markdown formatter asking for `Bash` is the canonical overbroad-grant red flag — reject.
+- **Minimal grant**: `Read, Glob, Grep` is usually enough for analysis skills. Each extra tool (`Bash`, `Write`, `WebFetch`, `Edit`, `NetworkAccess`) needs a sentence of justification in SKILL.md.
 - **Shell calls in `Bash`**: for every shell command the skill invokes, re-run `rafter skill review` worth of checks against that command specifically.
+
+Mechanical check:
+
+```bash
+rg -n '^allowed-tools' <skill>/SKILL.md          # what's granted
+rg -n '^(name|description):' <skill>/SKILL.md    # what's claimed
+```
+
+Write one sentence per granted tool justifying it from the description. If
+you can't, the grant is wider than the purpose. Reject.
 
 ## 6. Silent escalation
 

--- a/python/rafter_cli/resources/skills/rafter-skill-review/docs/malware-indicators.md
+++ b/python/rafter_cli/resources/skills/rafter-skill-review/docs/malware-indicators.md
@@ -54,6 +54,10 @@ Grep for:
 - Creation of cron entries, systemd units, launchd plists, `crontab -e` pipes.
 - Modification of PATH via shell rc injection.
 
+```bash
+rg -n '\.\./|/etc/|\.bashrc|\.zshrc|\.profile|crontab|systemctl|launchctl|/etc/cron|/Library/LaunchDaemons' <skill>
+```
+
 Any of these in an install script or a "helper" skill command = persistent foothold. Reject.
 
 ## 7. Process / introspection behaviour
@@ -63,7 +67,11 @@ Grep for:
 - Enumeration of `~/.ssh`, `~/.aws/credentials`, `.git-credentials`, browser profiles.
 - Reading clipboard history, keychain, or password-store files.
 
-These are intelligence-gathering primitives. Legitimate skills don't need them.
+```bash
+rg -n '~/\.ssh|\.aws/credentials|\.gnupg|\.netrc|\.git-credentials|Keychain|gnome-keyring|/proc/[^/]+/environ|pbpaste|xclip|wl-paste|chromium.*Login Data|Firefox.*logins\.json' <skill>
+```
+
+These are intelligence-gathering primitives. Legitimate skills don't need them. Any hit outside `<skill>/tests/` fixtures = reject.
 
 ## 8. Escape hatches in SKILL.md
 

--- a/python/rafter_cli/resources/skills/rafter-skill-review/docs/prompt-injection.md
+++ b/python/rafter_cli/resources/skills/rafter-skill-review/docs/prompt-injection.md
@@ -4,6 +4,22 @@ A skill is a prompt the agent will follow. Anyone who controls the skill content
 
 > The attacker isn't always the skill author. A skill that cites "upstream docs" and `WebFetch`es them on every run imports whatever prompt is currently on that remote page.
 
+## 0. Mechanical first pass
+
+Before reading prose, run the consolidated detector on every markdown file
+in the skill:
+
+```bash
+find <skill> -name '*.md' -print0 \
+  | xargs -0 -n1 rafter scan injection --fail-on medium
+```
+
+This catches the zero-width / bidi / role-override / "ignore previous" /
+hidden-instruction classes mechanically. It is experimental and noisy on
+security-oriented prose (the patterns it flags are also the ones we
+document below). Treat each finding as "stop and read", not as a verdict.
+Sections 1–7 are the human follow-up.
+
 ## 1. Hidden instructions
 
 Grep for:


### PR DESCRIPTION
## Summary

Maylist A15: pass through the rafter-skill-review skill and tighten its advice + mechanical checks.

Sable-bum (PR #122) intentionally deferred this skill to sable-d5d. This PR is that follow-up.

### What changed

Audit + light edits to the rafter-skill-review skill (Node + Python parity verified, byte-identical).

| File | Before | After |
|---|---|---|
| SKILL.md | 106 / 853w | 148 / 1287w |
| docs/authorship-provenance.md | 82 | 90 |
| docs/changelog-review.md | 99 | 99 (unchanged) |
| docs/data-practices.md | 88 | 98 |
| docs/malware-indicators.md | 79 | 87 |
| docs/prompt-injection.md | 85 | 101 |
| docs/telemetry.md | 78 | 78 (unchanged) |

SKILL.md grew (106 → 148) because the new \"Watch-items at a glance\" table is worth carrying in the main skill — it gives reviewers a single mechanical-check matrix instead of a hunt across 5 sub-docs. Still under the 150-line soft ceiling.

### Edits applied

- **SKILL.md "Watch-items at a glance" table** — 8 rows, each pairing a Rome-listed risk with a concrete \`rg\` / \`jq\` / CLI check and the sub-doc it links to.
- **SKILL.md step 0** — now points at \`rafter scan injection\` (PR #118 / sable-h6r) as the complementary mechanical pass; includes a loop-over-markdown command.
- **SKILL.md canonical-command note** — \`rafter agent audit-skill\` is the deprecated alias of \`rafter skill review\` (matches sable-bum edits to the sibling rafter SKILL.md).
- **SKILL.md fast path** — runnable three-step script (skill review + scan injection + allowed-tools eyeball).
- **SKILL.md decision rule** — extended to four items, adds the injection-scan gate.
- **SKILL.md branch (c)** — explicit \`rafter scan injection\` step before reading prose.
- **docs/prompt-injection.md §0** — new mechanical-first-pass referencing \`rafter scan injection\`.
- **docs/data-practices.md §5** — explicit \`allowed-tools\` reconciliation grep, calls out "markdown formatter asking for Bash" red flag.
- **docs/authorship-provenance.md §4** — \`npm view <pkg> time.created\` typosquat check with three real-world examples (eslint-config-airbn, requets, crossenv).
- **docs/malware-indicators.md §6** — consolidated \`rg\` for privileged writes / shell rc / cron / launchd.
- **docs/malware-indicators.md §7** — consolidated \`rg\` for credential-dir reads, keychain, /proc env, browser stores.

### PR #118 (sable-h6r) cross-references added

Six places in the skill now point at \`rafter scan injection\` as the mechanical complement to the structured human-judgment review.

### Punted (future bead candidates listed in the agent's report)

- \`docs/supply-chain-risks.md\` consolidating typosquat + dep drift + postinstall scripts (currently spread across 3 sub-docs).
- \`docs/agent-config-specific.md\` for MCP manifest / Cursor rule / Continue rule schema specifics.
- A sibling "post-install drift audit" skill — rafter-skill-review is explicitly pre-install only.

### Parity

\`diff -rq node/resources/skills/rafter-skill-review/ python/rafter_cli/resources/skills/rafter-skill-review/\` returns empty.

### Self-defense note

The agent deliberately did NOT embed literal zero-width / bidi characters in SKILL.md (those live in \`docs/prompt-injection.md\` §1 where they're documented). The shipped SKILL.md does not self-trigger \`rafter scan injection\`.

Target: \`maylist\`.

Closes sable-d5d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>