### PR TITLE
docs(sable-h2y): document betterleaks 1.1.2 AKIA miss + workaround

### DIFF
--- a/docs/local-toolkit.md
+++ b/docs/local-toolkit.md
@@ -86,6 +86,8 @@ Raw secret values are never included in output. Pipe to `jq`, feed to CI gates, 
 
 **Engine selection:** Uses Betterleaks when available (more patterns), falls back to built-in regex. Override with `--engine betterleaks|patterns|auto`.
 
+> **Known issue (betterleaks 1.1.2):** the bundled Betterleaks build does not detect the AWS access-key class (`AKIA[A-Z0-9]{16}`). The built-in 21-pattern engine catches it. If your secret-coverage story depends on AKIA detection — for example, in a CI gate or pre-commit hook — pass `--engine patterns` until a newer Betterleaks is pinned. The architectural fix (run both engines and union findings by default) is tracked separately; in the meantime, CI smoke tests in this repo use `--engine patterns` for the same reason.
+
 ## Pre-commit hook
 
 Automatically scan staged files before every `git commit`. The most effective way to prevent secrets from entering version control.


### PR DESCRIPTION
## Summary

The bundled Betterleaks build (\`BETTERLEAKS_VERSION = 1.1.2\` in \`node/src/utils/binary-manager.ts\`) does not detect the AWS access-key class (\`AKIA[A-Z0-9]{16}\`). The built-in 21-pattern engine catches it correctly. The quickstart walkthrough is broken when betterleaks is installed and \`--engine\` defaults to \`auto\` (which picks betterleaks).

Evidence the team is already aware: \`publish.yml:318\` runs CI smoke tests with \`rafter agent scan ... --engine patterns\` — explicit workaround.

### This PR

Documents the issue + the workaround in \`docs/local-toolkit.md\` so users hit the warning before the silent walkthrough failure.

### Not in this PR (filed as follow-up: sable-NEW)

The architectural fix: change \`auto\` mode to a new \`"both"\` engine value that runs Betterleaks AND patterns and unions the findings by (file, line, ruleId). Today's \`selectEngine\` returns either single engine; with both available, \`auto\` should give union semantics so rafter's 21-pattern guarantee always holds. This touches \`scan.ts\` selectEngine / scanFile / scanDirectory + \`mcp-server.test.ts:262\` (which currently pins \`auto = betterleaks\`). Substantial change that needs running tests; deferring until the host can run vitest.

Target: \`maylist\`.

Closes sable-h2y (mitigation level). Architectural fix tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>