### PR TITLE
perf(sable-6y0): pre-compile regex patterns in PatternEngine (Node + Python parity)

### DIFF
--- a/node/src/core/pattern-engine.ts
+++ b/node/src/core/pattern-engine.ts
@@ -18,11 +18,25 @@ const VARIABLE_NAME_RE = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/;
 const LOWERCASE_IDENT_RE = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$/;
 const QUOTED_VALUE_RE = /['"]([^'"]+)['"]/;
 
+interface CompiledPattern {
+  pattern: Pattern;
+  regex: RegExp;
+}
+
 export class PatternEngine {
   private patterns: Pattern[];
+  private compiled: CompiledPattern[];
 
   constructor(patterns: Pattern[]) {
     this.patterns = patterns;
+    // Compile each pattern's regex once. Malformed patterns are skipped
+    // with a stderr warning so a single bad regex can't take down the engine.
+    this.compiled = [];
+    for (const pattern of patterns) {
+      const regex = this.createRegex(pattern.regex);
+      if (regex === null) continue;
+      this.compiled.push({ pattern, regex });
+    }
   }
 
   /**
@@ -31,8 +45,8 @@ export class PatternEngine {
   scan(text: string): PatternMatch[] {
     const matches: PatternMatch[] = [];
 
-    for (const pattern of this.patterns) {
-      const regex = this.createRegex(pattern.regex);
+    for (const { pattern, regex } of this.compiled) {
+      regex.lastIndex = 0;
       let match;
 
       while ((match = regex.exec(text)) !== null) {
@@ -58,8 +72,8 @@ export class PatternEngine {
     for (let lineNum = 0; lineNum < lines.length; lineNum++) {
       const line = lines[lineNum];
 
-      for (const pattern of this.patterns) {
-        const regex = this.createRegex(pattern.regex);
+      for (const { pattern, regex } of this.compiled) {
+        regex.lastIndex = 0;
         let match;
 
         while ((match = regex.exec(line)) !== null) {
@@ -84,8 +98,8 @@ export class PatternEngine {
   redactText(text: string): string {
     let redacted = text;
 
-    for (const pattern of this.patterns) {
-      const regex = this.createRegex(pattern.regex);
+    for (const { pattern, regex } of this.compiled) {
+      regex.lastIndex = 0;
       redacted = redacted.replace(regex, (match) =>
         this.isFalsePositive(pattern, match) ? match : this.redact(match)
       );
@@ -123,9 +137,10 @@ export class PatternEngine {
   }
 
   /**
-   * Create RegExp from pattern string, extracting inline flags
+   * Create RegExp from pattern string, extracting inline flags.
+   * Returns null if the pattern is malformed (logs a warning).
    */
-  private createRegex(patternStr: string): RegExp {
+  private createRegex(patternStr: string): RegExp | null {
     // Extract inline flags like (?i) and convert to JS flags
     let flags = "g";
     let pattern = patternStr;
@@ -139,9 +154,9 @@ export class PatternEngine {
     try {
       return new RegExp(pattern, flags);
     } catch (e) {
-      // If pattern is invalid, return a regex that matches nothing
+      // Skip malformed patterns rather than crashing the engine
       console.error(`Invalid regex pattern: ${patternStr}`);
-      return /(?!)/;
+      return null;
     }
   }
 

--- a/python/rafter_cli/core/pattern_engine.py
+++ b/python/rafter_cli/core/pattern_engine.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+import sys
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -33,14 +34,19 @@ _QUOTED_VALUE_RE = re.compile(r"""['\"]([^'\"]+)['\"]""")
 class PatternEngine:
     def __init__(self, patterns: Sequence[Pattern]):
         self._patterns = list(patterns)
-
-    def scan(self, text: str) -> list[PatternMatch]:
-        """Scan text for pattern matches (no line info)."""
-        matches: list[PatternMatch] = []
+        # Compile each pattern's regex once. Malformed patterns are skipped
+        # with a stderr warning so a single bad regex can't take down the engine.
+        self._compiled: list[tuple[Pattern, re.Pattern[str]]] = []
         for pattern in self._patterns:
             compiled = self._compile(pattern.regex)
             if compiled is None:
                 continue
+            self._compiled.append((pattern, compiled))
+
+    def scan(self, text: str) -> list[PatternMatch]:
+        """Scan text for pattern matches (no line info)."""
+        matches: list[PatternMatch] = []
+        for pattern, compiled in self._compiled:
             for m in compiled.finditer(text):
                 if self._is_false_positive(pattern, m.group(0)):
                     continue
@@ -55,10 +61,7 @@ class PatternEngine:
         """Scan text with line/column information."""
         matches: list[PatternMatch] = []
         for line_num, line in enumerate(text.split("\n"), start=1):
-            for pattern in self._patterns:
-                compiled = self._compile(pattern.regex)
-                if compiled is None:
-                    continue
+            for pattern, compiled in self._compiled:
                 for m in compiled.finditer(line):
                     if self._is_false_positive(pattern, m.group(0)):
                         continue
@@ -74,10 +77,7 @@ class PatternEngine:
     def redact_text(self, text: str) -> str:
         """Replace all pattern matches in *text* with redacted versions."""
         result = text
-        for pattern in self._patterns:
-            compiled = self._compile(pattern.regex)
-            if compiled is None:
-                continue
+        for pattern, compiled in self._compiled:
             result = compiled.sub(
                 lambda m, p=pattern: m.group(0) if self._is_false_positive(p, m.group(0)) else self._redact(m.group(0)),
                 result,
@@ -105,7 +105,7 @@ class PatternEngine:
         return False
 
     @staticmethod
-    def _compile(regex_str: str) -> re.Pattern | None:
+    def _compile(regex_str: str) -> re.Pattern[str] | None:
         flags = 0
         pattern = regex_str
         if pattern.startswith("(?i)"):
@@ -114,6 +114,8 @@ class PatternEngine:
         try:
             return re.compile(pattern, flags)
         except re.error:
+            # Skip malformed patterns rather than crashing the engine
+            print(f"Invalid regex pattern: {regex_str}", file=sys.stderr)
             return None
 
     @staticmethod


### PR DESCRIPTION
## Summary

\`PatternEngine\` (both implementations) was calling \`new RegExp()\` / \`re.compile()\` per file × per pattern. With 21 default patterns × 100 files that's 2100 compilations per scan, ~100–500ms recoverable.

### Fix

Constructor-once: each pattern's regex is compiled in the engine constructor and reused across every \`scan\` / \`scan_with_position\` / \`redact_text\` call.

| File | Approach |
|---|---|
| \`node/src/core/pattern-engine.ts\` | New \`this.compiled\` array of \`CompiledPattern\` (pattern + RegExp). Hot loops in \`scan\`, \`scanWithPosition\`, \`redactText\` reset \`regex.lastIndex\` before each scan (required because the same RegExp is reused with \`exec\` / \`replace\`). |
| \`python/rafter_cli/core/pattern_engine.py\` | New \`self._compiled\` list of \`(Pattern, re.Pattern)\` tuples. Same three methods iterate the cached compiles. |

### Behavior preserved

- \`(?i)\` inline-flag extraction kept verbatim (Node: append \`\"i\"\` to flags; Python: \`|= re.IGNORECASE\`).
- Node retains the global \`\"g\"\` flag.
- Malformed regex still skipped at construction. Node logs \`console.error\` as before; Python now also logs to stderr (previously silent), which is the right Node/Python parity behavior.
- Public API unchanged. Existing tests don't touch the private \`createRegex\` / \`_compile\` methods.

### Why constructor-once, not lazy cache

PatternEngine instances are short-lived per scan invocation. Lazy compile would add per-method branching with no payoff; constructor-once is simpler and surfaces malformed patterns in one deterministic place.

### Test plan

- [x] \`pnpm exec tsc -p tsconfig.json --noEmit\` clean
- [x] \`python3 -c \"import ast; ast.parse(...)\"\` clean on the modified Python file
- [x] Agent verified compile-count, match output, position info, redaction format, and false-positive filtering are unchanged via a manual import smoke
- [ ] vitest / pytest blocked by host load. The existing pattern-engine + scan tests exercise the hot paths; behavior is unchanged.

Target: \`maylist\`.

Closes sable-6y0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>