### PR TITLE
fix(sable-wxe): convert remaining static-string execSync sites to execFileSync (Node-only sweep follow-up)

### DIFF
--- a/node/src/commands/agent/exec.ts
+++ b/node/src/commands/agent/exec.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { CommandInterceptor } from "../../core/command-interceptor.js";
 import { RegexScanner } from "../../scanners/regex-scanner.js";
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import readline from "readline";
 import { fmt } from "../../utils/formatter.js";
 
@@ -69,6 +69,14 @@ export function createExecCommand(): Command {
       }
 
       // Step 5: Execute command
+      // NOTE: `command` is intentionally executed as a shell string here — this
+      // entire command is `rafter agent exec <command>`, where the user explicitly
+      // asked us to run a shell command on their behalf. The risk classifier and
+      // approval flow above (steps 1, 2, 4) gate this call: by the time we reach
+      // execSync, the command has been evaluated and either auto-allowed,
+      // explicitly approved by the user, or overridden via --force. Converting
+      // to array-form would break shell features (pipes, redirects, globbing)
+      // that users legitimately expect.
       try {
         const output = execSync(command, {
           stdio: "inherit",
@@ -92,7 +100,7 @@ function isGitCommand(command: string): boolean {
 async function scanStagedFiles(): Promise<{ secretsFound: boolean; count: number; files: number }> {
   try {
     // Get staged files
-    const stagedFiles = execSync("git diff --cached --name-only", {
+    const stagedFiles = execFileSync("git", ["diff", "--cached", "--name-only"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "ignore"]
     })

--- a/node/src/commands/agent/init-project.ts
+++ b/node/src/commands/agent/init-project.ts
@@ -4,12 +4,12 @@ import { injectInstructionFile } from "./instruction-block.js";
 import { fmt } from "../../utils/formatter.js";
 import fs from "fs";
 import path from "path";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 /** Find the git root directory, or null if not in a git repo */
 function findGitRoot(): string | null {
   try {
-    return execSync("git rev-parse --show-toplevel", {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
       encoding: "utf-8",
       timeout: 5000,
       stdio: ["pipe", "pipe", "ignore"],

--- a/node/src/commands/agent/scan.ts
+++ b/node/src/commands/agent/scan.ts
@@ -11,7 +11,7 @@ import {
   policyIgnoreToSuppressions,
 } from "../../core/custom-patterns.js";
 import type { ScanIgnoreRule } from "../../core/config-schema.js";
-import { execSync, execFileSync } from "child_process";
+import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";

--- a/node/src/commands/hook/pretool.ts
+++ b/node/src/commands/hook/pretool.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { CommandInterceptor, CommandEvaluation } from "../../core/command-interceptor.js";
 import { RegexScanner } from "../../scanners/regex-scanner.js";
 import { AuditLogger } from "../../core/audit-logger.js";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 type HookFormat = "claude" | "cursor" | "gemini" | "windsurf";
 
@@ -209,7 +209,7 @@ function evaluateWrite(toolInput: Record<string, any>): HookDecision {
 
 function scanStagedFiles(): { secretsFound: boolean; count: number; files: number } {
   try {
-    const stagedOutput = execSync("git diff --cached --name-only --diff-filter=ACM", {
+    const stagedOutput = execFileSync("git", ["diff", "--cached", "--name-only", "--diff-filter=ACM"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "ignore"],
     }).trim();

--- a/node/src/core/docs-loader.ts
+++ b/node/src/core/docs-loader.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { loadPolicy, PolicyDocEntry } from "./policy-loader.js";
 import { getRafterDir } from "./config-defaults.js";
 
@@ -73,7 +73,7 @@ function resolvePolicyPath(relative: string): string {
   if (path.isAbsolute(relative)) return relative;
   let root: string;
   try {
-    root = execSync("git rev-parse --show-toplevel", {
+    root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "ignore"],
     }).trim();

--- a/node/src/core/policy-loader.ts
+++ b/node/src/core/policy-loader.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import yaml from "js-yaml";
 
 export interface PolicyCustomPattern {
@@ -363,7 +363,7 @@ function validatePolicy(policy: PolicyFile, raw: Record<string, any>): PolicyFil
 
 function getGitRoot(): string | null {
   try {
-    return execSync("git rev-parse --show-toplevel", {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "ignore"],
     }).trim();

--- a/node/src/utils/binary-manager.ts
+++ b/node/src/utils/binary-manager.ts
@@ -3,7 +3,7 @@ import os from "os";
 import path from "path";
 import crypto from "crypto";
 import https from "https";
-import { exec, execSync } from "child_process";
+import { exec, execFileSync } from "child_process";
 import { promisify } from "util";
 import { getBinDir } from "../core/config-defaults.js";
 import * as tar from "tar";
@@ -92,9 +92,9 @@ export class BinaryManager {
    * (Homebrew etc.), then ~/.rafter/bin/gitleaks. Read-only — never executes.
    */
   findLegacyGitleaks(): string | null {
-    const cmd = process.platform === "win32" ? "where gitleaks" : "which gitleaks";
+    const finder = process.platform === "win32" ? "where" : "which";
     try {
-      const result = execSync(cmd, { timeout: 5000, encoding: "utf-8" });
+      const result = execFileSync(finder, ["gitleaks"], { timeout: 5000, encoding: "utf-8" });
       const found = result.trim().split("\n")[0].trim();
       if (found) return found;
     } catch { /* not on PATH */ }
@@ -107,9 +107,9 @@ export class BinaryManager {
    * Find betterleaks on system PATH
    */
   findBetterleaksOnPath(): string | null {
-    const cmd = process.platform === "win32" ? "where betterleaks" : "which betterleaks";
+    const finder = process.platform === "win32" ? "where" : "which";
     try {
-      const result = execSync(cmd, { timeout: 5000, encoding: "utf-8" });
+      const result = execFileSync(finder, ["betterleaks"], { timeout: 5000, encoding: "utf-8" });
       const found = result.trim().split("\n")[0].trim();
       return found || null;
     } catch {


### PR DESCRIPTION
## Summary

Final pass on the execSync→execFileSync sweep started in sable-am4 (PR #121) and continued through sable-16b/sable-k7g (PR #124). After this PR, the only execSync call site in \`node/src/\` is the intentional one in \`agent exec\`, which IS supposed to interpret a shell command and is gated by the command-interceptor.

### Sites converted

| Site | Class | Action |
|---|---|---|
| \`agent/exec.ts:73\` | DYNAMIC (user-supplied) | **Kept as \`execSync(string)\`** with clarifying comment. Intentional shell exec for pipes/redirects/globs. Risk classifier verified wired BEFORE call. |
| \`agent/exec.ts:95\` | STATIC \`git diff --cached --name-only\` | Converted |
| \`utils/binary-manager.ts:97\` | STATIC ternary of \`where\` / \`which\` + literal \`gitleaks\` | Converted to \`execFileSync(finder, ["gitleaks"], ...)\` |
| \`utils/binary-manager.ts:112\` | Same ternary + literal \`betterleaks\` | Converted |
| \`core/docs-loader.ts:76\` | STATIC \`git rev-parse --show-toplevel\` | Converted |
| \`commands/agent/init-project.ts:12\` | Same | Converted |
| \`commands/hook/pretool.ts:212\` | STATIC \`git diff --cached --name-only --diff-filter=ACM\` | Converted |
| \`core/policy-loader.ts:366\` | STATIC | Converted |
| \`commands/agent/scan.ts:14\` | Dead import | Removed |

### Headline: \`agent/exec.ts:73\` is correctly gated

Audit trail (\`agent/exec.ts\` line numbers pre-this-PR):
- L15: \`const interceptor = new CommandInterceptor();\`
- L18: \`const evaluation = interceptor.evaluate(command);\`
- L21-29: \`block\` → \`process.exit(1)\` before any shell call
- L45-66: \`requires_approval\` → interactive prompt; \`process.exit(1)\` on cancel; \`--force\` logs the override
- L68: auto-allowed path logged
- L73 (now line 81 after the comment): \`execSync(command, ...)\` — reachable only after one of {allowed, overridden, approved}

No finding to file. The string-form call is intentional, gated, and audit-logged.

### Total remaining

One \`execSync\` call site in \`node/src/\` after this PR: the intentional \`agent/exec.ts\` site above. Python parity was already array-form throughout.

Target: \`maylist\`.

Closes sable-wxe.

## Test plan

- [x] \`pnpm exec tsc -p tsconfig.json --noEmit\` clean
- [x] Behavior preserved on every conversion (same options carried over)
- [x] \`agent/exec.ts:73\` deliberate exception documented inline
- [ ] vitest blocked by host load — existing hook/scan/init-project tests exercise these paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>