### PR TITLE
docs(sable-jqo): scratch-dir quickstart + pre-commit install decision tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ See what Rafter does before reading another word.
 **1. Scan a directory for leaked credentials**
 
 ```sh
-# Drop a .env file with a fake AWS key in a test repo
+# Drop into a scratch directory so this demo doesn't touch your real repo
+cd "$(mktemp -d)" && git init -q
 echo "AWS_ACCESS_KEY_ID=AKIA${SAMPLE_AWS_TAIL}" > .env  # e.g. AKIA followed by IOSFODNN7EXAMPLE
 
 rafter secrets .
@@ -60,6 +61,8 @@ rafter agent audit --last 3
 ```
 
 That's the core loop: scan → protect → audit. Everything works offline, no API key needed.
+
+When you're done, exit the scratch dir and clean it up: `SCRATCH="$PWD" && cd - && rm -rf "$SCRATCH"`.
 
 ## What's Free?
 

--- a/docs/local-toolkit.md
+++ b/docs/local-toolkit.md
@@ -100,6 +100,8 @@ rafter agent install-hook --push    # install pre-push hook instead of pre-commi
 
 Blocks commits when secrets are detected. Bypass with `git commit --no-verify` (not recommended).
 
+Not sure which path is right (native vs. pre-commit framework, in-repo vs. global)? See the [decision tree in `recipes/pre-commit.md`](../recipes/pre-commit.md#which-install-path-should-i-use).
+
 ### pre-commit framework
 
 Rafter works as a [pre-commit](https://pre-commit.com) hook. Add to your `.pre-commit-config.yaml`:

--- a/recipes/pre-commit.md
+++ b/recipes/pre-commit.md
@@ -2,6 +2,18 @@
 
 Block secrets from entering version control. Rafter scans staged files before every commit and rejects any that contain hardcoded credentials. 21+ built-in credential patterns plus optional Betterleaks integration (the gitleaks successor) for higher-recall detection. Deterministic results, exit code 1 on findings.
 
+## Which install path should I use?
+
+Rafter ships three pre-commit install paths. Use this decision tree to pick one:
+
+- **Do you already use the [pre-commit](https://pre-commit.com) framework?** (i.e. `.pre-commit-config.yaml` lives in your repo)
+  - **Yes** → use the [pre-commit framework](#pre-commit-framework) section below. Add the `rafter-scan-node` (or `-python`) entry to `.pre-commit-config.yaml`. The framework manages the hook for you alongside your other linters.
+  - **No** → do you want the hook in just this repo, or in every repo on this machine?
+    - **Just this repo** → `rafter agent install-hook` (writes `.git/hooks/pre-commit`).
+    - **Every repo on this machine** → `rafter agent install-hook --global` (sets `core.hooksPath`).
+
+Rule of thumb: if your team already standardises on pre-commit, stay in that ecosystem. If not, the native one-command install is the lowest-friction option and works out of the box.
+
 ## Pre-commit framework
 
 If you use the [pre-commit](https://pre-commit.com) framework, add this to `.pre-commit-config.yaml`:


### PR DESCRIPTION
## Summary

Two quickstart-UX improvements landing together:

### 1. Scratch-dir wrap for the 90-second quickstart

The \`README.md\` Step 1 now opens a \`mktemp -d\` scratch dir + \`git init\` before writing the demo \`.env\`. Previously, copy-pasting the quickstart into a real project would write \`.env\` into the user's cwd — destructive if they're in their actual repo.

The existing \`AKIA\${SAMPLE_AWS_TAIL}\` obfuscation is preserved (matches the rest of the README, dodges our own pre-commit scanner). A closing one-liner reminds the user to exit the scratch dir when done.

### 2. Pre-commit install decision tree

\`recipes/pre-commit.md\` (which already documents all three install paths) gains a "Which install path should I use?" decision tree above the path-by-path docs. Three branches:

- pre-commit framework user → add a rafter entry to \`.pre-commit-config.yaml\`
- native, this repo only → \`rafter agent install-hook\`
- native, all repos on this machine → \`rafter agent install-hook --global\`

\`docs/local-toolkit.md\` gets a one-line pointer to the new section (single source of truth — no duplication).

### Why \`recipes/pre-commit.md\` for the tree

That file already enumerates all three install paths, so the choice is most actionable adjacent to the description of each. \`docs/local-toolkit.md\` is the high-level "what is the local toolkit" page; cross-linking keeps it slim.

### Stats

- \`README.md\`: 115 → 118 lines (under the 130 ceiling from PR #123)
- \`recipes/pre-commit.md\`: +12 lines (new decision-tree section)
- \`docs/local-toolkit.md\`: +2 lines (cross-link)
- No runtime code changed

Target: \`maylist\`.

Closes sable-jqo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>