### PR TITLE
docs(sable-5u7): fix llms.txt typo + correct platform skill counts (B8)

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -13,7 +13,7 @@ Founded by Rome Thorstenson. Source: [github.com/Raftersecurity/rafter-cli](http
 - **Local (free, offline, no key).** Secret scanning, command interception, policy, hooks, audit log, MCP server, extension/skill review.
 - **Remote — Rafter Code Security Engine (requires `RAFTER_API_KEY`).** Agentic SAST + SCA + secret detection against a GitHub repo, returning a prioritized, fix-oriented report. Triggered by `rafter run` (alias: `rafter scan`).
 
-The two surfaces never overlap. `rafter secrets` is local-only; `rafter run` is remote-only (ode is immediately after analysis). Pick by the task, not by the name.
+The two surfaces never overlap. `rafter secrets` is local-only; `rafter run` is remote-only (code is deleted immediately after analysis). Pick by the task, not by the name.
 
 ## Install
 
@@ -109,9 +109,9 @@ Full schema: [docs.rafter.so/policy](https://docs.rafter.so/policy) (or see `sha
 
 | Platform     | Flag                  | What's installed                    |
 |--------------|-----------------------|-------------------------------------|
-| Claude Code  | `--with-claude-code`  | Pre/PostToolUse hooks + 2 skills    |
-| Codex CLI    | `--with-codex`        | 2 security skills                   |
-| OpenClaw     | `--with-openclaw`     | 1 security skill                    |
+| Claude Code  | `--with-claude-code`  | Pre/PostToolUse hooks + 3 skills    |
+| Codex CLI    | `--with-codex`        | 3 security skills                   |
+| OpenClaw     | `--with-openclaw`     | Rafter Security skill (ClawHub)     |
 | Cursor       | `--with-cursor`       | MCP server + global instructions    |
 | Gemini CLI   | `--with-gemini`       | MCP server config                   |
 | Windsurf     | `--with-windsurf`     | MCP server config                   |


### PR DESCRIPTION
## Summary

Two corrections found while cross-reading our \`llms.txt\` against \`docs.rafter.so/llms.txt\` and verifying against the current \`AGENT_SKILLS\` source.

### Typo fix

Line 16 had a truncated sentence:

> The two surfaces never overlap. \`rafter secrets\` is local-only; \`rafter run\` is remote-only **(ode is immediately after analysis)**. Pick by the task, not by the name.

Looks like a partial edit artifact — the line at L139 in the same file uses the correct phrasing:

> Remote scans send code to the Rafter backend solely for analysis; **code is deleted immediately after**. Secrets are never logged or returned in cleartext.

Aligned L16 to that wording.

### Skill-count fix

The "Supported Agent Platforms" table understated skill counts:

| Platform | Before | After |
|---|---|---|
| Claude Code | "Pre/PostToolUse hooks + 2 skills" | "Pre/PostToolUse hooks + 3 skills" |
| Codex CLI | "2 security skills" | "3 security skills" |
| OpenClaw | "1 security skill" | "Rafter Security skill (ClawHub)" |

Verified against \`node/src/commands/agent/init.ts:27 AGENT_SKILLS\`, which lists three: \`rafter\`, \`rafter-secure-design\`, \`rafter-code-review\`. The fourth skill (\`rafter-skill-review\`, tightened in PR #126) is NOT in \`AGENT_SKILLS\` and so doesn't ship to platforms — separate question whether it should (filing as follow-up).

OpenClaw uses a different shape — the canonical ClawHub install at \`~/.openclaw/workspace/skills/rafter-security/SKILL.md\` (single SKILL.md, not the multi-skill tree).

### Out of scope

- The two llms.txt files (\`docs.rafter.so/llms.txt\` and ours) are intentionally different — they cover different audiences (docs site vs. CLI package). Their overall framing is consistent (agent-first security primitive, free local + paid remote, MIT, no telemetry). Only factual claims need to agree; those are now aligned.
- Cross-rig coordination on the sibling llms.txt (held by the secbolt rig per maylist B8) is being nudged separately to juno.

Target: \`maylist\`.

Closes sable-5u7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>