### PR TITLE
docs(sable-2vz): platform parity re-audit at v0.8.1 (B10)

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -2,33 +2,45 @@
 
 [← Back to README](../README.md)
 
-| Platform | Integration | Detection | Config installed to |
-|----------|-------------|-----------|---------------------|
-| Claude Code | Hooks + Skills | `~/.claude` | `~/.claude/skills/rafter/` and `rafter-agent-security/` |
-| Codex CLI | Skills | `~/.codex` | `~/.agents/skills/rafter/` and `rafter-agent-security/` |
-| OpenClaw | Skills | `~/.openclaw` | `~/.openclaw/skills/rafter-security.md` |
-| Gemini CLI | MCP server | `~/.gemini` | `~/.gemini/settings.json` |
-| Cursor | MCP server | `~/.cursor` | `~/.cursor/mcp.json` |
-| Windsurf | MCP server | `~/.codeium/windsurf` | `~/.codeium/windsurf/mcp_config.json` |
-| Continue.dev | MCP server | `~/.continue` | `~/.continue/config.json` |
-| Aider | MCP server | `~/.aider.conf.yml` | `~/.aider.conf.yml` |
+| Platform     | Integration surface                                             | Detection                    | Primary install paths |
+|--------------|-----------------------------------------------------------------|------------------------------|------------------------|
+| Claude Code  | Skills + sub-agent + hooks + MCP + CLAUDE.md                    | `~/.claude`                  | `~/.claude/skills/<skill>/SKILL.md`, `~/.claude/agents/rafter.md`, `~/.claude/settings.json`, `.mcp.json` (project) |
+| Codex CLI    | Skills + hooks + AGENTS.md                                      | `~/.codex`                   | `~/.agents/skills/<skill>/SKILL.md`, `~/.codex/hooks.json`, `AGENTS.md` |
+| Gemini CLI   | Skills + hooks + MCP + GEMINI.md                                | `~/.gemini`                  | `~/.agents/skills/<skill>/SKILL.md` (+ `gemini skills link`), `~/.gemini/settings.json`, `GEMINI.md` |
+| Cursor       | Per-skill rules + sub-agent + hooks + MCP                       | `~/.cursor`                  | `~/.cursor/rules/<skill>.mdc`, `~/.cursor/agents/rafter.md`, `~/.cursor/hooks.json`, `~/.cursor/mcp.json` |
+| Windsurf     | Per-skill rules + AGENTS.md + MCP                               | `~/.codeium/windsurf`        | `<project>/.windsurf/rules/<skill>.md`, `<project>/AGENTS.md`, `~/.codeium/windsurf/mcp_config.json` |
+| Continue.dev | Per-skill rules + MCP                                           | `~/.continue`                | `<project>/.continue/rules/<skill>.md`, `~/.continue/config.json` |
+| Aider        | Read-only context (`RAFTER.md` injected via `.aider.conf.yml`)  | `~/.aider.conf.yml` or local | `<root>/RAFTER.md`, `<root>/.aider.conf.yml` (`read:` entry) |
+| OpenClaw     | ClawHub skill                                                   | `~/.openclaw`                | `~/.openclaw/workspace/skills/rafter-security/SKILL.md` |
 
-`rafter agent init` auto-detects which platforms are installed. Use `--with-*` flags or `--all` to install integrations.
+`rafter agent init` auto-detects installed platforms. Use `--with-<platform>` flags, `--all`, or `--local` for project-scope installs (Claude Code, Codex, Gemini, Cursor, Windsurf, Continue.dev, and Aider support project-local installs; OpenClaw is user-scope only).
 
-## Skill-based platforms
+## Skills, rules, and the four shipped templates
 
-Claude Code, Codex, and OpenClaw get the full Rafter skill set:
+The same four `resources/skills/<name>/SKILL.md` templates drive every platform's
+"skill-like" surface:
 
 - **`rafter`** — CYOA router for detection (remote + local scanning, audit log, policy).
 - **`rafter-code-review`** — Structured OWASP / MITRE / ASVS walkthrough during PR review or refactoring.
 - **`rafter-secure-design`** — Shift-left threat modeling at feature kickoff (auth, data, API, ingestion, deployment, dependencies).
 - **`rafter-skill-review`** — Guided review of third-party skills before install.
 
-Install, remove, or audit them at any time with `rafter skill list/install/uninstall/review`.
+Platforms with a native SKILL.md primitive (Claude Code, Codex, Gemini, OpenClaw)
+install the templates verbatim. Platforms with a rules primitive (Cursor,
+Windsurf, Continue.dev) ship per-skill rule files generated from
+`resources/<platform>-rules/`. Aider injects `RAFTER.md` via the `.aider.conf.yml`
+`read:` list — there's no skill primitive in Aider.
 
-## MCP-based platforms
+Install, remove, or audit individual skill files at any time with `rafter skill list/install/uninstall/review`. For per-component lifecycle (hooks, MCP, rules, sub-agents, instruction files) use `rafter agent list / enable <id> / disable <id>`.
 
-Gemini, Cursor, Windsurf, Continue.dev, and Aider connect to the Rafter MCP server (`rafter mcp serve`), which exposes `scan_secrets`, `evaluate_command`, `read_audit_log`, and `get_config` tools. See individual setup recipes in [`recipes/`](../recipes/).
+## MCP server
+
+Claude Code, Cursor, Windsurf, Continue.dev, and Gemini connect to the Rafter
+MCP server (`rafter mcp serve`), which exposes `scan_secrets`,
+`evaluate_command`, `read_audit_log`, and `get_config` tools plus
+`rafter://config` and `rafter://policy` resources over stdio. Codex, Aider, and
+OpenClaw do not have native MCP support — they rely on the other surfaces
+listed above.
 
 ## See also
 
@@ -36,3 +48,4 @@ Gemini, Cursor, Windsurf, Continue.dev, and Aider connect to the Rafter MCP serv
 - [docs/local-toolkit.md](local-toolkit.md) — setup walkthrough and skill management
 - [docs/adding-a-platform.md](adding-a-platform.md) — contract for adding a new agent IDE
 - [`recipes/`](../recipes/) — per-platform copy-paste setup recipes
+- [`shared-docs/PLATFORM_PARITY_AUDIT.md`](../shared-docs/PLATFORM_PARITY_AUDIT.md) — full parity matrix and gap log

--- a/shared-docs/PLATFORM_PARITY_AUDIT.md
+++ b/shared-docs/PLATFORM_PARITY_AUDIT.md
@@ -7,6 +7,168 @@
 >
 > Re-audited 2026-04-30 by raftercli/polecats/obsidian against `origin/main`
 > (commit `e366778`, v0.7.7). See "Re-audit (2026-04-30)" section below.
+>
+> Re-audited 2026-05-19 by sable polecat (sable-2vz / B10 follow-up) against
+> `origin/maylist` HEAD `d2d9f6a`, v0.8.1. See "Re-audit (2026-05-19) at v0.8.1"
+> section below. The earlier sections are preserved as history.
+
+## Re-audit (2026-05-19) at v0.8.1
+
+Re-run after the v0.7.7 → v0.8.1 window. Pinned at `origin/maylist` `d2d9f6a`
+(node/package.json v0.8.1, python/pyproject.toml v0.8.1). Host overloaded — no
+test run; audit is code-walk only against `node/src/commands/agent/init.ts`,
+`verify.ts`, `components.ts`, and Python mirrors at `python/rafter_cli/commands/agent.py`.
+
+### Updated state matrix (v0.8.1)
+
+Columns: `Skills` (count of SKILL.md files installed by the init path, of 4
+shipped templates) / `MCP` / `Hooks` / `Instruction file` / `Per-skill rules`
+/ `Sub-agent` / `Verify` (`agent verify` covers it) / `Uninstall` (`agent
+disable`/`uninstall` cleanly tears down).
+
+| Platform     | Skills (init) | MCP                                      | Hooks                                                    | Instruction file               | Per-skill rules                  | Sub-agent                                  | Verify                  | Uninstall (components.ts)       |
+|--------------|---------------|------------------------------------------|----------------------------------------------------------|--------------------------------|----------------------------------|--------------------------------------------|-------------------------|---------------------------------|
+| Claude Code  | **3 of 4**    | yes (`.mcp.json` project / settings user) | yes (`PreToolUse` + `PostToolUse`)                        | CLAUDE.md                      | n/a (uses skills)                | yes (`.claude/agents/rafter.md`)            | yes (file + `--probe`)  | hooks, instructions, skills, mcp |
+| Codex        | **3 of 4**    | n/a (no MCP in Codex)                    | yes (`PreToolUse: Bash\|apply_patch` + `PostToolUse`)     | AGENTS.md                      | n/a                              | n/a (no first-class primitive)              | yes (skills only)        | hooks, skills (no instructions)  |
+| Gemini       | **3 of 4**    | yes (`.gemini/settings.json`)            | yes (`BeforeTool` regex + `AfterTool`)                    | GEMINI.md                      | n/a                              | n/a                                        | yes (MCP only)          | hooks, mcp (no skills, no instructions) |
+| Cursor       | n/a (rules)   | yes (`.cursor/mcp.json`)                 | yes (`preToolUse` + `postToolUse` + `beforeShellExecution`) | per-skill rules (see col)     | **4 of 4** in `.cursor/rules/`   | yes (`.cursor/agents/rafter.md`)            | yes (MCP only)          | hooks, instructions (rules+sub-agent), mcp |
+| Windsurf     | n/a (rules)   | yes (`~/.codeium/windsurf/mcp_config.json`) | none (no hook surface; intentionally not installed)     | inherits root `AGENTS.md`      | **4 of 4** in `.windsurf/rules/` | n/a                                        | yes (MCP only)          | rules, mcp (no AGENTS.md teardown) |
+| Continue.dev | n/a (rules)   | yes (`.continue/config.json`)            | none (no hook surface; pruned in rf-cia phase b)         | none                           | **4 of 4** in `.continue/rules/` | n/a                                        | yes (MCP only)          | rules, mcp                       |
+| Aider        | n/a (read)    | n/a (no native MCP; legacy YAML stripped) | n/a (no hook surface)                                   | RAFTER.md via `read:`          | n/a                              | n/a                                        | yes (read-entry + file) | aider.read                       |
+| OpenClaw     | 1 (ClawHub)   | n/a                                      | n/a                                                     | none                           | n/a                              | n/a                                        | yes (file + legacy hint) | openclaw.skills (**wrong path**) |
+
+Notes:
+
+- "Skills (init) = 3 of 4" for Claude Code / Codex / Gemini reflects the
+  current `AGENT_SKILLS` registry in `node/src/commands/agent/init.ts:27-31`
+  (and Python `_AGENT_SKILLS` at `python/rafter_cli/commands/agent.py:118-122`),
+  which omits `rafter-skill-review`. The dry-run plan, the Cursor /
+  Windsurf / Continue rule lists, and the `components.ts` registry's
+  `COMPONENT_SKILL_NAMES` all enumerate 4. The init path therefore disagrees
+  with `rafter agent enable claude-code.skills` (which installs 4). New gap.
+- "Verify (MCP only)" for Gemini / Cursor / Windsurf / Continue means the
+  platform check confirms the MCP server entry but does NOT confirm hooks
+  fired or rules were copied. `--probe` covers Claude Code only.
+- Components registry IDs (Node + Python): `claude-code.hooks`, `.instructions`,
+  `.skills`, `.mcp`; `codex.hooks`, `.skills`; `cursor.hooks`, `.instructions`
+  (rules + sub-agent), `.mcp`; `gemini.hooks`, `.mcp`; `windsurf.rules`, `.mcp`;
+  `continue.rules`, `.mcp`; `aider.read`; `openclaw.skills`. No `gemini.skills`,
+  no `gemini.instructions`, no `codex.instructions`, no `windsurf.instructions`
+  for AGENTS.md.
+
+### What's improved since v0.7.7
+
+- **Cursor deep support shipped** (rf-svn3, PR #81) — full hook coverage
+  (`preToolUse` + `postToolUse` + `beforeShellExecution`), 4 per-skill rules at
+  `.cursor/rules/<skill>.mdc`, and `.cursor/agents/rafter.md` sub-agent.
+- **Windsurf deep support shipped** (rf-0vr3, PR #84) — pruned silent-no-op
+  hooks install; 4 per-skill rules at `.windsurf/rules/<skill>.md`; root
+  `AGENTS.md` written via `installGlobalInstructions` (Windsurf reads it
+  natively). Windsurf also installs at `--local` scope now.
+- **Aider read-only context shipped** (rf-du2o, PR #85) — `RAFTER.md` write +
+  `read: [..., RAFTER.md]` in `.aider.conf.yml`. Legacy
+  `mcp-server-command: rafter mcp serve` line is stripped on reinstall.
+- **Continue.dev per-skill rules shipped** (rf-acz0, PR #86) — 4 rules at
+  `.continue/rules/<skill>.md` with Continue.dev YAML frontmatter. Continue.dev
+  installs at `--local` scope now.
+- **Codex hook matcher widened** (rf-ovql) — `PreToolUse.matcher` now
+  `"Bash|apply_patch"` so file edits via `apply_patch` actually trigger pretool.
+- **Gemini hook matcher tightened** (rf-044o, PR #87) — `BeforeTool.matcher`
+  now `"run_shell_command|write_file|replace|edit"` matching current Gemini
+  docs verbatim.
+- **`rafter agent verify` overhauled** (rf-65zg, PR #88) — Python now covers
+  all 8 platforms (parity with Node). Both add Continue.dev + Aider checks.
+  New `--json` flag and `--probe` flag (runtime probe for Claude Code).
+- **Onboarding contract published** (rf-o329, PR #89) —
+  `docs/adding-a-platform.md` is the contract any new agent platform
+  integration follows.
+- **OpenClaw rebuilt as a ClawHub skill** (rf-zgwj) — install moved to
+  `~/.openclaw/workspace/skills/rafter-security/SKILL.md` (the canonical
+  ClawHub-discovered path). Returned to `--all`. Legacy `~/.openclaw/skills/
+  rafter-security.md` stripped on reinstall.
+- **Betterleaks migration shipped** (v0.8.0) — gitleaks → betterleaks. Legacy
+  `~/.rafter/bin/gitleaks` is detected by `agent verify` / `status` with an
+  upgrade hint; the `--with-gitleaks` / `--engine gitleaks` / `update-gitleaks`
+  CLI flags have been removed.
+- **Dry-run plan shipped** (rf-hrtd) — `rafter agent init --dry-run` enumerates
+  every file path the install would touch without writing anything.
+- **Component-granular install** — `rafter agent enable/disable <id>` for 17
+  components across all 8 platforms.
+
+### Gaps remaining (file as new beads, `discovered-from:sable-2vz`)
+
+1. **Init path installs 3 skills instead of 4 for Claude Code / Codex / Gemini.**
+   `AGENT_SKILLS` in `node/src/commands/agent/init.ts:27-31` omits
+   `rafter-skill-review`; Python `_AGENT_SKILLS` at `agent.py:118-122` same
+   miss. The dry-run printout, the Cursor / Windsurf / Continue rule lists,
+   and `components.ts:COMPONENT_SKILL_NAMES` all list 4. Result: `rafter
+   agent init --with-claude-code` ships 3 skills but `rafter agent enable
+   claude-code.skills` ships 4. Same divergence for `codex.skills`. Add
+   `rafter-skill-review` to `AGENT_SKILLS` / `_AGENT_SKILLS`.
+
+2. **`openclaw.skills` component points at the legacy path.** `components.ts:976-998`
+   manages `~/.openclaw/skills/rafter-security.md` while the init path
+   (rf-zgwj) ships at `~/.openclaw/workspace/skills/rafter-security/SKILL.md`.
+   `rafter agent disable openclaw.skills` and `agent enable openclaw.skills`
+   operate on the wrong file — disable is a no-op against current installs.
+   Update the component spec to the ClawHub path; mirror in Python.
+
+3. **No component spec for AGENTS.md / GEMINI.md instruction files.** Codex
+   and Gemini write AGENTS.md / GEMINI.md respectively in
+   `installGlobalInstructions`, but `components.ts` has no
+   `codex.instructions` or `gemini.instructions`. `agent disable
+   codex.instructions` is not callable; AGENTS.md is orphaned after Codex
+   teardown. Same for Windsurf which inherits root `AGENTS.md`.
+
+4. **No component spec for Gemini skills.** Gemini install writes 3 skills to
+   `.agents/skills/<name>/SKILL.md` and runs `gemini skills link`, but
+   `components.ts` has no `gemini.skills` entry — user can't `agent disable
+   gemini.skills` to roll back the `gemini skills link` registration.
+
+5. **`agent verify` is shallow for the MCP-only platforms.** Cursor /
+   Windsurf / Continue / Gemini checks confirm only the MCP server entry —
+   they don't confirm hooks are present, rules are copied, or sub-agents
+   exist. Cursor in particular ships hooks + rules + sub-agent + MCP and we
+   verify only MCP. Bring each `checkX` to confirm every surface the install
+   writes for that platform.
+
+6. **`agent verify --probe` covers only Claude Code.** Cursor / Codex /
+   Gemini hooks all invoke `rafter hook pretool` with different `--format`
+   flags. The rf-65zg `--probe` synthesizes a Claude-format payload and asserts
+   `audit.jsonl`. Extend `--probe` to fire one synthetic payload per supported
+   hook format (`--format cursor`, `--format codex`, `--format gemini`) so we
+   catch the rf-luk-style "wrote file but never fires" failure for non-Claude
+   platforms.
+
+7. **`docs/supported-platforms.md` is stale.** Still says "MCP server" for
+   Cursor / Windsurf / Continue / Aider and reports skills installed at
+   `~/.claude/skills/rafter/` and `rafter-agent-security/` (the latter name
+   doesn't exist anywhere in the install path). Doesn't mention per-skill
+   rules, sub-agents, AGENTS.md, RAFTER.md, or the ClawHub OpenClaw path.
+   Lists OpenClaw skill install at `~/.openclaw/skills/rafter-security.md`
+   (legacy). Patched in this commit but the underlying skill set listed in
+   the body should be re-checked against the init path after gap #1 lands.
+
+Beads to file (parent agent — do NOT file these from this sub-task):
+
+- Gap 1 → P1 bug, "init path installs 3 of 4 skills for Claude Code / Codex /
+  Gemini; add rafter-skill-review to AGENT_SKILLS"
+- Gap 2 → P1 bug, "openclaw.skills component points at legacy path"
+- Gap 3 → P2 task, "add codex.instructions / gemini.instructions / windsurf.instructions component specs"
+- Gap 4 → P2 task, "add gemini.skills component spec"
+- Gap 5 → P2 task, "broaden agent verify checks for Cursor / Windsurf / Continue / Gemini beyond MCP entry"
+- Gap 6 → P2 task, "extend agent verify --probe to Cursor / Codex / Gemini hook formats"
+- Gap 7 → P3 docs, "docs/supported-platforms.md content re-check after gap 1 fix"
+
+### Findings unchanged since 2026-04-30
+
+- AGENTS.md as cross-platform context standard (Codex + Windsurf): unchanged
+  and realized at workspace root.
+- `.claude/agents/` is multi-platform (Cursor reads it too): unchanged.
+- Onboarding contract: now shipped at `docs/adding-a-platform.md` (gap closed).
+- All 8 platforms covered by `agent verify` in both Node and Python (gap closed).
+
+
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Maylist B10: re-run the platform parity audit at v0.8.1 (last run was v0.7.7, PR #61).

### Files

- \`shared-docs/PLATFORM_PARITY_AUDIT.md\` (+162) — new "Re-audit (2026-05-19) at v0.8.1" section appended at top. Historical sections preserved.
- \`docs/supported-platforms.md\` (+29 / -16) — refreshed to reflect rules / sub-agents / AGENTS.md / RAFTER.md / ClawHub paths. Dropped stale "MCP server" descriptions and the bogus \`rafter-agent-security/\` skill name.

### Current matrix (v0.8.1)

| Platform | Skills (init) | MCP | Hooks | Instruction file | Per-skill rules | Sub-agent | Verify | Uninstall |
|---|---|---|---|---|---|---|---|---|
| Claude Code | 3 of 4 | yes | PreToolUse + PostToolUse | CLAUDE.md | n/a | yes | yes + \`--probe\` | full |
| Codex | 3 of 4 | n/a | Bash\|apply_patch + PostToolUse | AGENTS.md | n/a | n/a | skills only | partial |
| Gemini | 3 of 4 | yes | BeforeTool regex + AfterTool | GEMINI.md | n/a | n/a | MCP only | partial |
| Cursor | n/a (rules) | yes | preToolUse + postToolUse + beforeShell | per-skill rules | 4 of 4 | yes | MCP only | full |
| Windsurf | n/a (rules) | yes | none (pruned) | inherits AGENTS.md | 4 of 4 | n/a | MCP only | partial |
| Continue.dev | n/a (rules) | yes | none | none | 4 of 4 | n/a | MCP only | full |
| Aider | n/a (read) | n/a | n/a | RAFTER.md via \`read:\` | n/a | n/a | read-entry + file | full |
| OpenClaw | 1 (ClawHub) | n/a | n/a | none | n/a | n/a | file + legacy hint | wrong path |

### Improved since v0.7.7
- Cursor / Windsurf / Continue / Aider deep support (rf-svn3, rf-0vr3, rf-acz0, rf-du2o)
- Codex \`apply_patch\` matcher + Gemini regex matcher tightening (rf-ovql, rf-044o)
- \`agent verify\` overhaul: Python parity for all 8 platforms + \`--json\` + \`--probe\` (rf-65zg)
- \`docs/adding-a-platform.md\` published (rf-o329)
- OpenClaw rebuilt at ClawHub workspace path (rf-zgwj)
- Betterleaks migration (v0.8.0), dry-run plan (rf-hrtd), component-granular install

### Gaps remaining (each will become a follow-up bead)

1. **P1** — \`AGENT_SKILLS\` (init.ts) and \`_AGENT_SKILLS\` (agent.py) omit \`rafter-skill-review\`, so init ships 3 of 4 skills while \`components.ts\` documents 4. Already tracked: **sable-t6p** (filed during sable-5u7).
2. **P1** — \`openclaw.skills\` component manages the legacy \`~/.openclaw/skills/rafter-security.md\` path; init writes the ClawHub path. \`agent disable openclaw.skills\` is a no-op.
3. **P2** — No component spec for \`codex.instructions\` / \`gemini.instructions\` / \`windsurf.instructions\`. Those instruction files can't be torn down via \`agent disable\`.
4. **P2** — No \`gemini.skills\` component spec — \`gemini skills link\` registration can't be rolled back via components.
5. **P2** — \`agent verify\` checks for Cursor / Windsurf / Continue / Gemini only confirm MCP entry; ignore hooks, rules, sub-agent presence.
6. **P2** — \`agent verify --probe\` covers only Claude Code; Cursor / Codex / Gemini hook formats not probed.
7. **P3** — \`docs/supported-platforms.md\` skill list needs re-check after gap 1 lands.

Target: \`maylist\`.

Closes sable-2vz. Follow-up beads for gaps 2–7 to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>