### PR TITLE
fix(sable-cg1): openclaw.skills component points at ClawHub canonical path; legacy file removed on uninstall

### DIFF
--- a/node/src/commands/agent/components.ts
+++ b/node/src/commands/agent/components.ts
@@ -975,7 +975,13 @@ function aiderRead(): ComponentSpec {
 
 function openclawSkill(): ComponentSpec {
   const home = os.homedir();
-  const skillPath = path.join(home, ".openclaw", "skills", "rafter-security.md");
+  // rf-zgwj moved the install to ClawHub's canonical workspace path so
+  // OpenClaw actually discovers the skill at session start. The legacy
+  // ~/.openclaw/skills/rafter-security.md path was never read by OpenClaw;
+  // we still detect/remove it here as a migration cleanup.
+  const skillDir = path.join(home, ".openclaw", "workspace", "skills", "rafter-security");
+  const skillPath = path.join(skillDir, "SKILL.md");
+  const legacyPath = path.join(home, ".openclaw", "skills", "rafter-security.md");
   return {
     id: "openclaw.skills",
     platform: "openclaw",
@@ -983,10 +989,9 @@ function openclawSkill(): ComponentSpec {
     description: "OpenClaw rafter-security skill",
     detectDir: path.join(home, ".openclaw"),
     path: skillPath,
-    isInstalled: () => fs.existsSync(skillPath),
+    isInstalled: () => fs.existsSync(skillPath) || fs.existsSync(legacyPath),
     install: () => {
-      const dir = path.dirname(skillPath);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      if (!fs.existsSync(skillDir)) fs.mkdirSync(skillDir, { recursive: true });
       const template = skillTemplatePath("rafter");
       if (fs.existsSync(template)) {
         fs.copyFileSync(template, skillPath);
@@ -994,6 +999,16 @@ function openclawSkill(): ComponentSpec {
     },
     uninstall: () => {
       if (fs.existsSync(skillPath)) fs.rmSync(skillPath, { force: true });
+      // Best-effort: drop the now-empty skill dir we created.
+      try {
+        if (fs.existsSync(skillDir) && fs.readdirSync(skillDir).length === 0) {
+          fs.rmdirSync(skillDir);
+        }
+      } catch {
+        /* leave it */
+      }
+      // Migration cleanup: also remove the pre-rf-zgwj legacy file if present.
+      if (fs.existsSync(legacyPath)) fs.rmSync(legacyPath, { force: true });
     },
   };
 }

--- a/python/rafter_cli/commands/agent_components.py
+++ b/python/rafter_cli/commands/agent_components.py
@@ -946,10 +946,16 @@ def _aider_read() -> ComponentSpec:
 def _openclaw_skill() -> ComponentSpec:
     home = Path.home()
     detect_dir = home / ".openclaw"
-    skill_path = detect_dir / "skills" / "rafter-security.md"
+    # rf-zgwj moved the install to ClawHub's canonical workspace path so
+    # OpenClaw actually discovers the skill at session start. The legacy
+    # ~/.openclaw/skills/rafter-security.md path was never read by OpenClaw;
+    # we still detect/remove it here as a migration cleanup.
+    skill_dir = detect_dir / "workspace" / "skills" / "rafter-security"
+    skill_path = skill_dir / "SKILL.md"
+    legacy_path = detect_dir / "skills" / "rafter-security.md"
 
     def install() -> None:
-        skill_path.parent.mkdir(parents=True, exist_ok=True)
+        skill_dir.mkdir(parents=True, exist_ok=True)
         # Try primary skill location, then legacy resource name.
         content = _skill_text("skills", "rafter", "SKILL.md") or _skill_text("rafter-security-skill.md")
         if content is not None:
@@ -958,6 +964,15 @@ def _openclaw_skill() -> ComponentSpec:
     def uninstall() -> None:
         if skill_path.exists():
             skill_path.unlink()
+        # Best-effort: drop the now-empty skill dir we created.
+        try:
+            if skill_dir.exists() and not any(skill_dir.iterdir()):
+                skill_dir.rmdir()
+        except OSError:
+            pass
+        # Migration cleanup: also remove the pre-rf-zgwj legacy file if present.
+        if legacy_path.exists():
+            legacy_path.unlink()
 
     return ComponentSpec(
         id="openclaw.skills",
@@ -966,7 +981,7 @@ def _openclaw_skill() -> ComponentSpec:
         description="OpenClaw rafter-security skill",
         detect_dir=detect_dir,
         path=skill_path,
-        is_installed=lambda: skill_path.exists(),
+        is_installed=lambda: skill_path.exists() or legacy_path.exists(),
         install=install,
         uninstall=uninstall,
     )


### PR DESCRIPTION
## Summary

Gap #2 from the v0.8.1 platform parity audit (sable-2vz / PR #132).

\`openclaw.skills\` \`ComponentSpec\` (in \`components.ts\` + \`agent_components.py\`) was managing the pre-rf-zgwj **legacy** path \`~/.openclaw/skills/rafter-security.md\` — a path OpenClaw never read at runtime. The actual install (\`rafter agent init --with-openclaw\`) writes the **canonical ClawHub** path \`~/.openclaw/workspace/skills/rafter-security/SKILL.md\`.

Consequence: \`rafter agent disable openclaw.skills\` and the new \`rafter agent uninstall\` (PR #116) were **no-ops** against the real install.

### Fix

- \`skillPath\` now points at the canonical ClawHub SKILL.md
- \`isInstalled\` returns true if EITHER the canonical or the legacy file exists (so old installs still register and can be cleaned up)
- \`install()\` creates the \`workspace/skills/rafter-security\` directory + writes SKILL.md there
- \`uninstall()\` removes the canonical SKILL.md, drops the now-empty skill dir, AND removes the legacy \`~/.openclaw/skills/rafter-security.md\` file as a migration cleanup

Node + Python kept symmetric. Verified \`tsc --noEmit\` and \`python3 ast.parse\` are clean.

Target: \`maylist\`.

Closes sable-cg1.

## Test plan

- [x] tsc / ast.parse clean
- [x] isInstalled returns true for both legacy and canonical install state
- [x] uninstall drops both legacy and canonical paths
- [ ] vitest blocked by host load — install → uninstall round-trip test (sable-3ep test suite shape) will exercise this once box recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>