### PR TITLE
fix(sable-1ik): local secrets scanner respects .gitignore by default (user review feedback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Local secrets scanner respects `.gitignore` by default.** `rafter secrets <dir>` (and the deprecated alias `rafter agent scan <dir>`) used to walk every file under the target directory regardless of `.gitignore`, surfacing findings in build outputs, vendored deps, and one-off scratch files that the repo had explicitly excluded. The directory walker now batches the candidate file list through `git check-ignore --stdin --no-index -z` inside the scan root's git work tree, so every gitignore semantic git itself supports — nested `.gitignore`, negations, `.git/info/exclude`, the configured global excludes file, the full pattern grammar — is honored exactly. Zero new dependencies. Scans against directories outside a git work tree (or with git missing) silently fall back to the prior behavior. Opt out with `--no-gitignore`. Honored by `rafter secrets`, `rafter agent scan`, and `rafter agent baseline create`. Betterleaks engine already honors `.gitignore` natively (gitleaks ancestry); this change brings the built-in pattern engine to parity. Node + Python.
+
 ## [0.8.1] - 2026-05-12
 
 ### Fixed

--- a/node/src/commands/agent/scan.ts
+++ b/node/src/commands/agent/scan.ts
@@ -31,6 +31,8 @@ interface ScanOpts {
   baseline?: boolean;
   watch?: boolean;
   history?: boolean;
+  /** Commander maps `--no-gitignore` to `gitignore: false` (default true). */
+  gitignore?: boolean;
 }
 
 interface BaselineEntry {
@@ -81,6 +83,7 @@ export function createScanCommand(): Command {
     .option("--baseline", "Filter findings present in the saved baseline")
     .option("--watch", "Watch for file changes and re-scan on change")
     .option("--history", "Scan git history for secrets (requires betterleaks engine)")
+    .option("--no-gitignore", "Scan files even if .gitignore would exclude them (default: respect .gitignore)")
     .action(async (scanPath, opts: ScanOpts) => {
       // Validate flags before doing any work.
       const validEngines = ["auto", "betterleaks", "patterns"];
@@ -151,7 +154,7 @@ export function createScanCommand(): Command {
         if (!opts.quiet) {
           console.error(`Scanning directory: ${resolvedPath} (${engine})`);
         }
-        results = await scanDirectory(resolvedPath, engine, scanCfg, opts.history);
+        results = await scanDirectory(resolvedPath, engine, scanCfg, opts.history, opts.gitignore);
       } else {
         if (!opts.quiet) {
           console.error(`Scanning file: ${resolvedPath} (${engine})`);
@@ -522,7 +525,11 @@ async function scanDirectory(
   engine: "betterleaks" | "patterns",
   scanCfg?: { excludePaths?: string[]; customPatterns?: Array<{ name: string; regex: string; severity: string }> },
   history?: boolean,
+  respectGitignore?: boolean,
 ): Promise<ScanResult[]> {
+  // respectGitignore default is true. The patterns engine honors it via
+  // RegexScanner.scanDirectory; betterleaks honors it natively (gitleaks
+  // ancestry — reads .gitignore unless --no-git is set).
   if (engine === "betterleaks") {
     try {
       const bl = new BetterleaksScanner();
@@ -530,11 +537,17 @@ async function scanDirectory(
     } catch (e) {
       console.error(fmt.warning("Betterleaks scan failed, falling back to patterns"));
       const scanner = new RegexScanner(scanCfg?.customPatterns);
-      return scanner.scanDirectory(dirPath, { excludePaths: scanCfg?.excludePaths });
+      return scanner.scanDirectory(dirPath, {
+        excludePaths: scanCfg?.excludePaths,
+        respectGitignore,
+      });
     }
   } else {
     const scanner = new RegexScanner(scanCfg?.customPatterns);
-    return scanner.scanDirectory(dirPath, { excludePaths: scanCfg?.excludePaths });
+    return scanner.scanDirectory(dirPath, {
+      excludePaths: scanCfg?.excludePaths,
+      respectGitignore,
+    });
   }
 }
 

--- a/node/src/scanners/regex-scanner.ts
+++ b/node/src/scanners/regex-scanner.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { PatternEngine, PatternMatch, Pattern } from "../core/pattern-engine.js";
@@ -63,6 +64,15 @@ export class RegexScanner {
     exclude?: string[];
     excludePaths?: string[];
     maxDepth?: number;
+    /**
+     * Honor `.gitignore` (and `.git/info/exclude`, global excludes file,
+     * nested .gitignores) when filtering scanned files. Default true.
+     * Implemented by shelling out to `git check-ignore --stdin --no-index`
+     * inside the scan root's git work tree — exact git semantics, zero deps.
+     * Silently falls back to no-op when the scan root is outside a git repo
+     * or git is missing.
+     */
+    respectGitignore?: boolean;
   }): ScanResult[] {
     const exclude = options?.exclude || [
       "node_modules",
@@ -98,7 +108,10 @@ export class RegexScanner {
     }
 
     const files = this.walkDirectory(dirPath, exclude, options?.maxDepth || 10);
-    return this.scanFiles(files);
+    const filtered = options?.respectGitignore === false
+      ? files
+      : filterGitIgnored(files, dirPath);
+    return this.scanFiles(filtered);
   }
 
   /**
@@ -181,4 +194,68 @@ export class RegexScanner {
     const ext = path.extname(filename).toLowerCase();
     return binaryExtensions.includes(ext);
   }
+}
+
+/**
+ * Filter out files that git would ignore relative to `scanRoot`.
+ *
+ * Uses `git check-ignore --stdin --no-index` inside the scan root's work
+ * tree so every gitignore semantic git itself supports (nested .gitignores,
+ * negations, .git/info/exclude, the configured global excludes file, the
+ * `gitignore` pattern grammar) is honored exactly. Zero new dependencies —
+ * if git isn't installed or the scan root sits outside a work tree, returns
+ * the input unchanged.
+ *
+ * Batched: all candidate paths are piped through one subprocess.
+ */
+function filterGitIgnored(files: string[], scanRoot: string): string[] {
+  if (files.length === 0) return files;
+
+  // Locate the git work tree that owns scanRoot. Bail out (no filter) if
+  // scanRoot is outside a repo or git is missing — the user's `rafter
+  // secrets <dir>` invocation against a non-repo should not error.
+  const probe = spawnSync("git", ["-C", scanRoot, "rev-parse", "--show-toplevel"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 5000,
+  });
+  if (probe.status !== 0) return files;
+  const workTree = probe.stdout.trim();
+  if (!workTree) return files;
+
+  // Send the candidate file list to `git check-ignore --stdin`. It echoes
+  // back (on stdout) only the paths that match a gitignore rule. Use null
+  // delimiters (`-z`) on input and output so paths with spaces, newlines, or
+  // any other shell metacharacter survive intact. `--no-index` makes git
+  // evaluate rules without consulting the index (so an untracked file in a
+  // freshly-cloned repo is still classified).
+  //
+  // The paths in `files` are absolute. `git check-ignore` accepts paths
+  // relative to the work tree OR absolute paths within it; we pass through
+  // unchanged.
+  const stdin = files.join("\0") + "\0";
+  const result = spawnSync(
+    "git",
+    ["-C", workTree, "check-ignore", "--stdin", "--no-index", "-z"],
+    {
+      input: stdin,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+      timeout: 30_000,
+      maxBuffer: 64 * 1024 * 1024,
+    }
+  );
+  // Exit codes: 0 = at least one path matched; 1 = no paths matched;
+  // 128 = error (corrupt repo, bad flag, etc.). Treat 128 as "no filter" so
+  // a broken environment doesn't break a scan.
+  if (result.status !== 0 && result.status !== 1) return files;
+
+  const ignored = new Set<string>();
+  if (result.stdout) {
+    for (const p of result.stdout.split("\0")) {
+      if (p) ignored.add(p);
+    }
+  }
+  if (ignored.size === 0) return files;
+  return files.filter((f) => !ignored.has(f));
 }

--- a/node/tests/regex-scanner.test.ts
+++ b/node/tests/regex-scanner.test.ts
@@ -54,4 +54,60 @@ describe("RegexScanner", () => {
       expect(results).toHaveLength(0);
     });
   });
+
+  // sable-gitignore-fix: respect .gitignore by default; --no-gitignore opt-out.
+  describe(".gitignore handling", () => {
+    // Assemble the fixture key from characters at runtime so the literal
+    // substring is not present in source — avoids self-tripping the
+    // pre-commit scanner that this test is exercising.
+    const FAKE_AWS = ["A","K","I","A","I","O","S","F","O","D","N","N","7","E","X","A","M","P","L","E"].join("");
+    const SECRET_BODY = "AWS_KEY=" + FAKE_AWS + "\n";
+
+    function setUpRepo(): { scanDir: string; visible: string; hidden: string } {
+      const scanDir = path.join(tmpDir, "repo");
+      fs.mkdirSync(scanDir);
+      const { spawnSync } = require("child_process");
+      spawnSync("git", ["init", "-q"], { cwd: scanDir });
+      spawnSync("git", ["config", "user.email", "ci@test.local"], { cwd: scanDir });
+      spawnSync("git", ["config", "user.name", "CI"], { cwd: scanDir });
+      fs.mkdirSync(path.join(scanDir, "src"));
+      fs.mkdirSync(path.join(scanDir, "ignored"));
+      const visible = path.join(scanDir, "src", "visible.env");
+      const hidden = path.join(scanDir, "ignored", "hidden.env");
+      fs.writeFileSync(visible, SECRET_BODY);
+      fs.writeFileSync(hidden, SECRET_BODY);
+      fs.writeFileSync(path.join(scanDir, ".gitignore"), "ignored/\n");
+      return { scanDir, visible, hidden };
+    }
+
+    it("default: skips files matching .gitignore", () => {
+      const { scanDir, visible } = setUpRepo();
+      const results = scanner.scanDirectory(scanDir);
+      const files = results.map((r) => r.file).sort();
+      expect(files).toEqual([visible]);
+    });
+
+    it("respectGitignore=false: includes ignored files", () => {
+      const { scanDir, visible, hidden } = setUpRepo();
+      const results = scanner.scanDirectory(scanDir, { respectGitignore: false });
+      const files = results.map((r) => r.file).sort();
+      expect(files).toEqual([hidden, visible].sort());
+    });
+
+    it("non-git directory: scans everything (no filter applied)", () => {
+      const scanDir = path.join(tmpDir, "plain");
+      fs.mkdirSync(scanDir);
+      fs.mkdirSync(path.join(scanDir, "ignored"));
+      const a = path.join(scanDir, "a.env");
+      const b = path.join(scanDir, "ignored", "b.env");
+      fs.writeFileSync(a, SECRET_BODY);
+      fs.writeFileSync(b, SECRET_BODY);
+      // A .gitignore-shaped file in a non-repo should be a no-op.
+      fs.writeFileSync(path.join(scanDir, ".gitignore"), "ignored/\n");
+
+      const results = scanner.scanDirectory(scanDir);
+      const files = results.map((r) => r.file).sort();
+      expect(files).toEqual([a, b].sort());
+    });
+  });
 });

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -1424,7 +1424,14 @@ def _scan_file(file_path: str, engine: str, custom_patterns=None) -> list[ScanRe
         return [r] if r.matches else []
 
 
-def _scan_directory(dir_path: str, engine: str, scan_cfg=None, *, history: bool = False) -> list[ScanResult]:
+def _scan_directory(
+    dir_path: str,
+    engine: str,
+    scan_cfg=None,
+    *,
+    history: bool = False,
+    respect_gitignore: bool = True,
+) -> list[ScanResult]:
     custom = None
     exclude = None
     if scan_cfg:
@@ -1438,10 +1445,10 @@ def _scan_directory(dir_path: str, engine: str, scan_cfg=None, *, history: bool 
             return [ScanResult(file=r.file, matches=r.matches) for r in results]
         except Exception:
             scanner = RegexScanner(custom)
-            return scanner.scan_directory(dir_path, exclude_paths=exclude)
+            return scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
     else:
         scanner = RegexScanner(custom)
-        return scanner.scan_directory(dir_path, exclude_paths=exclude)
+        return scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
 
 
 def _output_scan_results(
@@ -1674,6 +1681,7 @@ def scan(
     baseline: bool = typer.Option(False, "--baseline", help="Filter findings present in the saved baseline"),
     watch: bool = typer.Option(False, "--watch", help="Watch for file changes and re-scan on change"),
     history: bool = typer.Option(False, "--history", help="Scan git history for secrets (requires betterleaks engine)"),
+    gitignore: bool = typer.Option(True, "--gitignore/--no-gitignore", help="Respect .gitignore when walking the scan target (default: on)"),
 ):
     """Scan files or directories for secrets. [deprecated: use 'rafter secrets' instead]"""
     print(
@@ -1771,7 +1779,7 @@ def scan(
     if os.path.isdir(resolved_path):
         if not quiet:
             print(f"Scanning directory: {resolved_path} ({eng})", file=sys.stderr)
-        results = _scan_directory(resolved_path, eng, scan_cfg, history=history)
+        results = _scan_directory(resolved_path, eng, scan_cfg, history=history, respect_gitignore=gitignore)
     else:
         if not quiet:
             print(f"Scanning file: {resolved_path} ({eng})", file=sys.stderr)

--- a/python/rafter_cli/commands/scan.py
+++ b/python/rafter_cli/commands/scan.py
@@ -96,6 +96,7 @@ def scan_local(
     baseline: bool = typer.Option(False, "--baseline", help="Filter findings present in the saved baseline"),
     watch: bool = typer.Option(False, "--watch", help="Watch for file changes and re-scan on change"),
     history: bool = typer.Option(False, "--history", help="Scan git history for secrets (requires betterleaks engine)"),
+    gitignore: bool = typer.Option(True, "--gitignore/--no-gitignore", help="Respect .gitignore when walking the scan target (default: on)"),
 ):
     """(deprecated alias for 'rafter secrets')."""
     from .agent import (
@@ -220,7 +221,7 @@ def scan_local(
     if os.path.isdir(resolved_path):
         if not quiet:
             print(f"Scanning directory: {resolved_path} ({eng})", file=sys.stderr)
-        results = _scan_directory(resolved_path, eng, scan_cfg, history=history)
+        results = _scan_directory(resolved_path, eng, scan_cfg, history=history, respect_gitignore=gitignore)
     else:
         if not quiet:
             print(f"Scanning file: {resolved_path} ({eng})", file=sys.stderr)
@@ -256,6 +257,7 @@ def secrets(
     baseline: bool = typer.Option(False, "--baseline", help="Filter findings present in the saved baseline"),
     watch: bool = typer.Option(False, "--watch", help="Watch for file changes and re-scan on change"),
     history: bool = typer.Option(False, "--history", help="Scan git history for secrets (requires betterleaks engine)"),
+    gitignore: bool = typer.Option(True, "--gitignore/--no-gitignore", help="Respect .gitignore when walking the scan target (default: on)"),
 ):
     """Scan files/directories for hardcoded secrets."""
     return scan_local(
@@ -269,4 +271,5 @@ def secrets(
         baseline=baseline,
         watch=watch,
         history=history,
+        gitignore=gitignore,
     )

--- a/python/rafter_cli/scanners/regex_scanner.py
+++ b/python/rafter_cli/scanners/regex_scanner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -67,6 +68,7 @@ class RegexScanner:
         dir_path: str,
         exclude_paths: list[str] | None = None,
         max_depth: int = 10,
+        respect_gitignore: bool = True,
     ) -> list[ScanResult]:
         exclude = list(DEFAULT_EXCLUDE)
         if exclude_paths:
@@ -76,6 +78,8 @@ class RegexScanner:
                     exclude.append(cleaned)
 
         files = self._walk(dir_path, exclude, max_depth)
+        if respect_gitignore:
+            files = _filter_gitignored(files, dir_path)
         return self.scan_files(files)
 
     def scan_text(self, text: str) -> list[PatternMatch]:
@@ -110,3 +114,53 @@ class RegexScanner:
         except PermissionError:
             pass
         return files
+
+
+def _filter_gitignored(files: list[str], scan_root: str) -> list[str]:
+    """Drop files git would ignore relative to ``scan_root``.
+
+    Shells out to ``git check-ignore --stdin --no-index -z`` inside the scan
+    root's work tree so every gitignore semantic git supports (nested
+    .gitignores, negations, .git/info/exclude, the configured global excludes
+    file, the full pattern grammar) is honored exactly. Zero new
+    dependencies. Bails out silently — returning the input unchanged — when
+    git is missing or the scan root sits outside a work tree.
+    """
+    if not files:
+        return files
+    # Locate the work tree that owns scan_root.
+    try:
+        probe = subprocess.run(
+            ["git", "-C", scan_root, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return files
+    if probe.returncode != 0:
+        return files
+    work_tree = probe.stdout.strip()
+    if not work_tree:
+        return files
+
+    # Batch every candidate through one `git check-ignore --stdin` call.
+    # Null-delimited I/O preserves paths containing newlines / spaces.
+    stdin = ("\0".join(files) + "\0").encode("utf-8")
+    try:
+        result = subprocess.run(
+            ["git", "-C", work_tree, "check-ignore", "--stdin", "--no-index", "-z"],
+            input=stdin,
+            capture_output=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return files
+    # Exit codes: 0 = at least one path ignored; 1 = none; 128 = error.
+    # Anything else => abandon the filter rather than break the scan.
+    if result.returncode not in (0, 1):
+        return files
+    ignored = {p.decode("utf-8") for p in result.stdout.split(b"\0") if p}
+    if not ignored:
+        return files
+    return [f for f in files if f not in ignored]

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -303,6 +303,7 @@ The `secrets` spelling is preferred because it makes the scope explicit; `scan l
 - `--baseline` — filter findings present in the saved baseline (see `rafter agent baseline`)
 - `--watch` — watch path for file changes and re-scan on each change; Ctrl+C exits
 - `--history` — scan the full git history for previously-committed secrets (requires `--engine betterleaks`; invokes `betterleaks git` against the repo history)
+- `--gitignore` / `--no-gitignore` — when scanning a directory, honor `.gitignore` rules (default: on). Implemented via `git check-ignore --stdin --no-index -z` against the scan root's git work tree; honors nested `.gitignore`, negations, `.git/info/exclude`, and the configured global excludes file. Silently falls back to no-op when the scan target is outside any git work tree.
 
 Exit codes: 0 = clean, 1 = secrets found, 2 = runtime error.
 


### PR DESCRIPTION
## Summary

Real user-facing bug from a public review: \`rafter secrets <dir>\` walked every file regardless of \`.gitignore\`, surfacing findings in build outputs, vendored deps, and scratch files the repo had explicitly excluded. Fix lands directly on \`main\` per user direction.

## Approach

After the directory walker collects candidate files, batch them through:

\`\`\`
git check-ignore --stdin --no-index -z
\`\`\`

…inside the scan root's git work tree. That command IS git itself — every gitignore semantic git supports is honored exactly:

- nested \`.gitignore\` files
- negations (\`!pattern\`)
- \`.git/info/exclude\`
- the configured global excludes file (\`core.excludesFile\`)
- the full \`gitignore\` pattern grammar (\`**\`, character classes, directory-vs-file)

**Zero new dependencies.** Null-delimited I/O (\`-z\` on stdin + stdout) so paths containing spaces, newlines, or shell metacharacters survive intact.

**Outside-git is a silent no-op.** If \`git rev-parse --show-toplevel\` against the scan root fails (target is outside any work tree, or git is missing) the filter is skipped — scanning a plain directory works exactly as before.

## CLI surface

| Flag | Behavior |
|---|---|
| (default) | Respects \`.gitignore\` |
| \`--no-gitignore\` | Scan everything, ignore the repo's \`.gitignore\` |

Honored by:
- \`rafter secrets\` (top-level alias)
- \`rafter agent scan\` (deprecated alias, kept in lockstep)
- \`rafter agent baseline create\` (uses the default; baseline of ignored files would create false-positive churn)

The **betterleaks engine** already honored \`.gitignore\` natively (gitleaks ancestry — runs \`betterleaks dir\` which reads \`.gitignore\`). This change brings the built-in pattern engine to parity.

## Test plan

- [x] \`pnpm exec tsc -p tsconfig.json --noEmit\` clean
- [x] \`python3 ast.parse\` clean on the 3 modified Python files
- [x] **End-to-end smoke**: built CLI, set up a temp git repo with \`ignored/\` in \`.gitignore\`, planted the same fake AWS key in \`src/visible.env\` and \`ignored/hidden.env\`. Default scan: only \`src/visible.env\` reported. \`--no-gitignore\`: both files reported. Confirmed.
- [x] **vitest**: 5/5 in \`regex-scanner.test.ts\` pass (2 existing symlink + 3 new \`.gitignore\` cases — default skips, opt-out includes, non-git is a no-op). 47/47 across scanner-adjacent suites (regex-scanner + secret-scanning-e2e + scan-sarif + snapshot-scan).

## Security review (rafter-code-review pass)

Diff touches shell exec + file paths. Walked CWE-Top-25:

- **CWE-78 command injection**: \`spawnSync\`/\`subprocess.run\` use **array form** — paths and the scan-root cwd flow as discrete args (\`["-C", scanRoot, "rev-parse", ...]\`), never interpolated into a shell command.
- **CWE-22 path traversal**: paths sent over stdin to \`git check-ignore\` are the same paths the walker already produced; null-delimited (\`-z\`) so they can't be smuggled across delimiters.
- **CWE-400 resource exhaustion**: 5 s timeout on the toplevel probe, 30 s on the batch, \`maxBuffer = 64 MB\` (Node). Exit status 128 / other errors fall back to no-filter rather than break the scan.
- **Default-secure regression check**: \`respectGitignore\` defaults to \`true\` (Python keyword default; Node \`opts?.respectGitignore === false\` opt-out). A user with \`AKIA…\` in a tracked file still gets flagged.

Closes sable-1ik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>