### PR TITLE
chore(release): bump to v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-05-26
+
 ### Changed
 - **Local secrets scanner respects `.gitignore` by default.** `rafter secrets <dir>` (and the deprecated alias `rafter agent scan <dir>`) used to walk every file under the target directory regardless of `.gitignore`, surfacing findings in build outputs, vendored deps, and one-off scratch files that the repo had explicitly excluded. The directory walker now batches the candidate file list through `git check-ignore --stdin --no-index -z` inside the scan root's git work tree, so every gitignore semantic git itself supports — nested `.gitignore`, negations, `.git/info/exclude`, the configured global excludes file, the full pattern grammar — is honored exactly. Zero new dependencies. Scans against directories outside a git work tree (or with git missing) silently fall back to the prior behavior. Opt out with `--no-gitignore`. Honored by `rafter secrets`, `rafter agent scan`, and `rafter agent baseline create`. Betterleaks engine already honors `.gitignore` natively (gitleaks ancestry); this change brings the built-in pattern engine to parity. Node + Python.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Rafter works as a [pre-commit](https://pre-commit.com) hook. Add to your `.pre-c
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.7.9
+    rev: v0.8.2
     hooks:
       - id: rafter-scan-node
 ```
@@ -430,7 +430,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.7.9
+    rev: v0.8.2
     hooks:
       - id: rafter-scan-node      # auto-installs via npm
       # - id: rafter-scan-python  # auto-installs via pip

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.1
+version: 0.8.2
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.8.1"
+version = "0.8.2"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.1
+version: 0.8.2
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/recipes/homebrew-formula.rb
+++ b/recipes/homebrew-formula.rb
@@ -13,7 +13,7 @@
 class Rafter < Formula
   desc "Security toolkit for developers — secret scanning, policy enforcement, audit logging"
   homepage "https://rafter.so"
-  url "https://registry.npmjs.org/@rafter-security/cli/-/cli-0.6.5.tgz"
+  url "https://registry.npmjs.org/@rafter-security/cli/-/cli-0.8.2.tgz"
   sha256 :no_check # Replace with actual SHA256 from npm registry
   license "MIT"
 

--- a/recipes/pre-commit.md
+++ b/recipes/pre-commit.md
@@ -9,7 +9,7 @@ If you use the [pre-commit](https://pre-commit.com) framework, add this to `.pre
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.6.5
+    rev: v0.8.2
     hooks:
       - id: rafter-scan-node   # auto-installs via npm, no global install needed
 ```

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -1027,7 +1027,7 @@ Integration with [pre-commit](https://pre-commit.com/):
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.5.6
+    rev: v0.8.2
     hooks:
       - id: rafter-scan           # Node.js
       # - id: rafter-scan-python  # Python alternative


### PR DESCRIPTION
Version bump for v0.8.2. Single user-facing change since v0.8.1: local secrets scanner respects \`.gitignore\` by default (#139, sable-1ik). JSON contract unchanged, exit codes unchanged — patch bump.

Mirrors the version-bump-then-promote pattern from PR #102 (v0.8.1 bump) → PR #103 (v0.8.1 promote).

After this merges to main, I'll open the main → prod release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>