### PR TITLE
Release v0.8.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -282,8 +282,26 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Wait for npm registry propagation
-        run: sleep 30
+      - name: Wait for npm registry to index the new version (sable-bac)
+        # `npm publish` returns success once the upload lands in npm's
+        # backend, but the public registry can lag on slow-CDN days.
+        # Mirrors the rf-z22y PyPI fix: poll the registry HTTP API for
+        # the exact version, retry up to 6× / ~3 min, fail loud at the
+        # end so the workflow surface stays "npm propagation failed"
+        # rather than the confusing "no matching version".
+        # URL-encoded scope: '@rafter-security/cli' → '@rafter-security%2Fcli'.
+        run: |
+          VERSION="${{ needs.publish-node.outputs.version }}"
+          for attempt in 1 2 3 4 5 6; do
+            if curl -sf "https://registry.npmjs.org/@rafter-security%2Fcli/${VERSION}" -o /dev/null; then
+              echo "npm has @rafter-security/cli@${VERSION} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "Attempt ${attempt}: @rafter-security/cli@${VERSION} not yet on npm, sleeping 30s…"
+            sleep 30
+          done
+          echo "FAIL: npm did not index @rafter-security/cli@${VERSION} within ~3 minutes"
+          exit 1
 
       - name: Install from npm registry
         run: npm install -g @rafter-security/cli@${{ needs.publish-node.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -232,13 +232,11 @@ jobs:
             --version "${{ needs.publish-node.outputs.version }}" \
             --owner rafter
 
-      - name: Verify the publish landed
-        if: steps.gate.outputs.skip != 'true'
-        run: |
-          # Smoke-check: the published version should be reachable via the
-          # public registry. Wait a few seconds for index propagation.
-          sleep 5
-          npx -y clawhub@latest skill show rafter-security --version "${{ needs.publish-node.outputs.version }}"
+      # No verify step — `clawhub skill` is publish-only (rf-u9l4).
+      # The CLI exposes `publish`, `rename`, `merge`, `help` and nothing
+      # else, so we can't do a CLI-driven readback. The `publish` step
+      # itself errors on any auth or registry failure, which is the
+      # contract we rely on.
 
   create-release:
     needs: [publish-node, publish-python]
@@ -315,8 +313,26 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Wait for PyPI registry propagation
-        run: sleep 30
+      - name: Wait for PyPI to index the new version (rf-z22y)
+        # `twine upload` returns success once the upload lands in PyPI's
+        # backend, but the public index (warehouse) can lag behind by up
+        # to a couple of minutes on cold paths. The previous hardcoded
+        # `sleep 30` flaked on v0.8.1. Poll instead: query the JSON API
+        # for the exact version, retry up to 6× / ~3 min, fail loud at
+        # the end so the workflow surface stays "PyPI propagation
+        # failed" rather than "package not found".
+        run: |
+          VERSION="${{ needs.publish-python.outputs.version }}"
+          for attempt in 1 2 3 4 5 6; do
+            if curl -sf "https://pypi.org/pypi/rafter-cli/${VERSION}/json" -o /dev/null; then
+              echo "PyPI has rafter-cli==${VERSION} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "Attempt ${attempt}: rafter-cli==${VERSION} not yet on PyPI, sleeping 30s…"
+            sleep 30
+          done
+          echo "FAIL: PyPI did not index rafter-cli==${VERSION} within ~3 minutes"
+          exit 1
 
       - name: Create fresh venv and install from PyPI
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
 
 permissions:
   contents: read
+  # id-token: write is required by npm Trusted Publishing (OIDC). Lets the
+  # publish-node job exchange the GitHub-issued OIDC token for a short-lived
+  # npm publish credential, replacing the long-lived NPM_TOKEN secret. Does
+  # NOT grant write access on its own; just mints the identity token.
+  id-token: write
 
 jobs:
   test-node:
@@ -79,6 +84,13 @@ jobs:
   publish-node:
     needs: [test-node, test-package]
     runs-on: ubuntu-latest
+    # Trusted Publishing requires id-token: write in scope for THIS job (the
+    # top-level grant covers it, but documented here for the job-local audit
+    # trail). Self-hosted runners are NOT supported by npm Trusted Publishing
+    # — ubuntu-latest (GitHub-hosted) is required.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: ./node
@@ -87,10 +99,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node 22 is the floor for npm Trusted Publishing (npm 11.5.1+ required,
+      # which ships with Node 22.14.0+). Earlier versions error out at publish
+      # time with an unhelpful auth message.
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
+
+      # Pin the npm CLI explicitly to ensure >= 11.5.1 even if the bundled
+      # version in node@22 drifts.
+      - name: Ensure npm >= 11.5.1 (Trusted Publishing floor)
+        run: npm install -g npm@latest
 
       - name: Enable pnpm
         run: corepack enable && corepack prepare pnpm@10 --activate
@@ -111,10 +131,16 @@ jobs:
         run: |
           test -f dist/index.js || (echo "Build failed: dist/index.js not found" && exit 1)
 
-      - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Trusted Publishing: no NODE_AUTH_TOKEN / NPM_TOKEN. The npm CLI
+      # exchanges the GitHub OIDC token (id-token: write above) for a
+      # short-lived publish credential, matched against the trusted-publisher
+      # config in the npm package settings (repo=Raftersecurity/rafter-cli,
+      # workflow=publish.yml). --provenance is auto-generated under Trusted
+      # Publishing but the explicit flag makes intent obvious and survives if
+      # someone later flips a default. --access public is preserved for the
+      # scoped package (@rafter-security/cli).
+      - name: Publish to npm (Trusted Publishing — OIDC)
+        run: npm publish --access public --provenance
 
   publish-python:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-05-26
+
 ### Changed
 - **Local secrets scanner respects `.gitignore` by default.** `rafter secrets <dir>` (and the deprecated alias `rafter agent scan <dir>`) used to walk every file under the target directory regardless of `.gitignore`, surfacing findings in build outputs, vendored deps, and one-off scratch files that the repo had explicitly excluded. The directory walker now batches the candidate file list through `git check-ignore --stdin --no-index -z` inside the scan root's git work tree, so every gitignore semantic git itself supports — nested `.gitignore`, negations, `.git/info/exclude`, the configured global excludes file, the full pattern grammar — is honored exactly. Zero new dependencies. Scans against directories outside a git work tree (or with git missing) silently fall back to the prior behavior. Opt out with `--no-gitignore`. Honored by `rafter secrets`, `rafter agent scan`, and `rafter agent baseline create`. Betterleaks engine already honors `.gitignore` natively (gitleaks ancestry); this change brings the built-in pattern engine to parity. Node + Python.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Local secrets scanner respects `.gitignore` by default.** `rafter secrets <dir>` (and the deprecated alias `rafter agent scan <dir>`) used to walk every file under the target directory regardless of `.gitignore`, surfacing findings in build outputs, vendored deps, and one-off scratch files that the repo had explicitly excluded. The directory walker now batches the candidate file list through `git check-ignore --stdin --no-index -z` inside the scan root's git work tree, so every gitignore semantic git itself supports — nested `.gitignore`, negations, `.git/info/exclude`, the configured global excludes file, the full pattern grammar — is honored exactly. Zero new dependencies. Scans against directories outside a git work tree (or with git missing) silently fall back to the prior behavior. Opt out with `--no-gitignore`. Honored by `rafter secrets`, `rafter agent scan`, and `rafter agent baseline create`. Betterleaks engine already honors `.gitignore` natively (gitleaks ancestry); this change brings the built-in pattern engine to parity. Node + Python.
+
 ## [0.8.1] - 2026-05-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Rafter works as a [pre-commit](https://pre-commit.com) hook. Add to your `.pre-c
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.7.9
+    rev: v0.8.2
     hooks:
       - id: rafter-scan-node
 ```
@@ -430,7 +430,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.7.9
+    rev: v0.8.2
     hooks:
       - id: rafter-scan-node      # auto-installs via npm
       # - id: rafter-scan-python  # auto-installs via pip

--- a/docs/postmortems/pr-72-family-2026-05-12.md
+++ b/docs/postmortems/pr-72-family-2026-05-12.md
@@ -1,0 +1,99 @@
+# Postmortem: PR #72 Family Stall (B3)
+
+**Date:** 2026-05-12  
+**Severity:** P0 (trust-restoration item from Rome's maylist)  
+**Owner:** raftercli/crew/sable → raftercli/polecats/jasper  
+**Bead:** sable-5gb
+
+---
+
+## Summary
+
+Rome flagged a pattern of "silent stalls" across three related work items opened around 2026-04-27–28. At the time the maylist was written, at least one PR (rf-mkrw / PR #69) was in a broken-draft state and the family looked unresolved. This postmortem diagnoses what happened and confirms final dispositions.
+
+---
+
+## The Family
+
+| ID | Title | PR | Status at maylist time | Final status |
+|----|-------|----|----------------------|--------------|
+| rf-pkn | docs: add AGENTS.md with COLLAB.md convention | #72 | Open (not yet merged) | **MERGED** 2026-04-30 |
+| rf-0pch | feat: add JSON `_note` to `rafter scan local` | #65 | Open (not yet merged) | **MERGED** 2026-04-30 |
+| rf-mkrw | docs: simplify rafter SKILL.md | #69 | Open as DRAFT, stalled | **CLOSED** 2026-04-30 (superseded — see below) |
+
+---
+
+## Timeline
+
+| Date | Event |
+|------|-------|
+| 2026-04-26 | `cdac956` lands: SKILL.md trimmed to 119 lines (120-line guard) for v0.7.6 publish |
+| 2026-04-27 | `927df6a`: rf-0pch `_note` field added to `rafter scan local` (via direct commit) |
+| 2026-04-27 | `2c395f7`: rf-pkn AGENTS.md added (via direct commit) |
+| 2026-04-27 | rf-uii CYOA restructure: SKILL.md rewritten from flat list to Choose-Your-Adventure branches |
+| 2026-04-28 | PR #72 (rf-pkn), PR #65 (rf-0pch) opened for review |
+| 2026-04-28 | PR #69 (rf-mkrw) opened as DRAFT — simplification of the pre-CYOA SKILL.md |
+| 2026-04-29–30 | PR #72 merged, PR #65 merged |
+| 2026-04-30 | PR #69 CLOSED: "superseded — CYOA restructure (rf-uii) replaced the SKILL.md this PR was simplifying" |
+| 2026-05-12 | Maylist bullet B3 dispatched to polecat for diagnosis |
+
+---
+
+## Root Cause
+
+**RF-mkrw (PR #69) opened in DRAFT and never marked ready-for-review.**
+
+The PR was created as a draft on 2026-04-28 targeting the pre-CYOA flat SKILL.md. That same day (or the day before), the CYOA restructure (rf-uii) landed and replaced the very file PR #69 was editing with a completely different structure. By the time the draft existed, it was already obsolete — but no one explicitly noticed or closed it.
+
+The PR sat in an invisible-to-reviewers draft state. It was eventually caught and closed on 2026-04-30 with a clear supersession note, but not before Rome observed the pattern as a trust signal.
+
+**Secondary: PR #72 and PR #65 were opened as direct commits and then wrapped in PRs on the same day.** This is fine workflow, but it compressed the window between "Rome asks for X" and "PR opens" — if Rome wrote the maylist during that window (before PRs were opened), the items looked unstarted.
+
+---
+
+## Why the Stall Pattern Happened
+
+1. **Draft PRs are invisible to merge queues and reviewers.** A draft PR does not appear in the review queue. It is easy to forget it exists.
+2. **Fast-moving concurrent changes.** Three PRs opening on the same day with a major structural change (CYOA) also landing created a race condition where rf-mkrw became stale immediately.
+3. **No draft-to-ready transition checkpoint.** Polecats have no automated reminder or timeout for draft PRs. A draft that never transitions to ready is effectively a silent drop.
+
+---
+
+## Dispositions
+
+### rf-pkn / PR #72 — RESOLVED ✓
+AGENTS.md was added. The COLLAB.md convention is documented. Merged 2026-04-30.
+No further action needed.
+
+### rf-0pch / PR #65 — RESOLVED ✓
+`_note` field confirmed present in `node/src/commands/agent/scan.ts:281`.
+Text reads: *"Local-only scan: pattern-based detection without agentic-intelligence triage. Findings have not been evaluated for context (public exposure, key validity, deployment environment). Investigate each before acting; do not dismiss. Run 'rafter run' for backend agentic analysis."*
+Merged 2026-04-30. CLI_SPEC.md updated. Tests in place.
+No further action needed.
+
+### rf-mkrw / PR #69 — CLOSED / SUPERSEDED ✓
+PR closed with explicit reason. The CYOA SKILL.md (`node/resources/skills/rafter/SKILL.md`) is currently 119 lines, under the 120-line guard. The CYOA structure achieves a comparable user-experience improvement to what rf-mkrw was attempting (clarity via branching, lazy-loading sub-docs rather than one long flat list).
+
+The close comment promised: "Followup will be filed in raftercli beads for any further trim of the new CYOA SKILL.md." This is already covered by **sable-bum** ("Thorough simplicity walkthrough of all skills, A6") which targets all skills including the rafter entry skill.
+
+No new bead needed. sable-bum is the follow-up.
+
+---
+
+## Related Bead: sable-yj1
+
+Bead sable-yj1 ("Add JSON `_note` to `rafter scan local` explaining local-only caveat") is a duplicate investigation of rf-0pch. The underlying PR (#65) merged 2026-04-30. sable-yj1 owner should close it as `no-changes: rf-0pch merged in PR #65 (2026-04-30), _note field confirmed in place`.
+
+---
+
+## Prevention
+
+1. **Draft PRs must have an explicit WIP window.** If a draft PR is not marked ready within N days, the Witness should alert.
+2. **Before opening a simplification PR**, check whether the target file has a concurrent refactor in flight. A `git log --oneline <file>` check on the file being simplified takes 5 seconds.
+3. **Concurrent PRs targeting the same file** should be serialized or at minimum cross-linked in their bead descriptions.
+
+---
+
+## Sign-off
+
+All three items in the PR #72 family have explicit dispositions as of 2026-05-12. The trust-restoration item (B3) is resolved.

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "bin": {
     "rafter": "./dist/index.js"

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.1
+version: 0.8.2
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/node/src/commands/agent/scan.ts
+++ b/node/src/commands/agent/scan.ts
@@ -31,6 +31,8 @@ interface ScanOpts {
   baseline?: boolean;
   watch?: boolean;
   history?: boolean;
+  /** Commander maps `--no-gitignore` to `gitignore: false` (default true). */
+  gitignore?: boolean;
 }
 
 interface BaselineEntry {
@@ -81,6 +83,7 @@ export function createScanCommand(): Command {
     .option("--baseline", "Filter findings present in the saved baseline")
     .option("--watch", "Watch for file changes and re-scan on change")
     .option("--history", "Scan git history for secrets (requires betterleaks engine)")
+    .option("--no-gitignore", "Scan files even if .gitignore would exclude them (default: respect .gitignore)")
     .action(async (scanPath, opts: ScanOpts) => {
       // Validate flags before doing any work.
       const validEngines = ["auto", "betterleaks", "patterns"];
@@ -151,7 +154,7 @@ export function createScanCommand(): Command {
         if (!opts.quiet) {
           console.error(`Scanning directory: ${resolvedPath} (${engine})`);
         }
-        results = await scanDirectory(resolvedPath, engine, scanCfg, opts.history);
+        results = await scanDirectory(resolvedPath, engine, scanCfg, opts.history, opts.gitignore);
       } else {
         if (!opts.quiet) {
           console.error(`Scanning file: ${resolvedPath} (${engine})`);
@@ -522,7 +525,11 @@ async function scanDirectory(
   engine: "betterleaks" | "patterns",
   scanCfg?: { excludePaths?: string[]; customPatterns?: Array<{ name: string; regex: string; severity: string }> },
   history?: boolean,
+  respectGitignore?: boolean,
 ): Promise<ScanResult[]> {
+  // respectGitignore default is true. The patterns engine honors it via
+  // RegexScanner.scanDirectory; betterleaks honors it natively (gitleaks
+  // ancestry — reads .gitignore unless --no-git is set).
   if (engine === "betterleaks") {
     try {
       const bl = new BetterleaksScanner();
@@ -530,11 +537,17 @@ async function scanDirectory(
     } catch (e) {
       console.error(fmt.warning("Betterleaks scan failed, falling back to patterns"));
       const scanner = new RegexScanner(scanCfg?.customPatterns);
-      return scanner.scanDirectory(dirPath, { excludePaths: scanCfg?.excludePaths });
+      return scanner.scanDirectory(dirPath, {
+        excludePaths: scanCfg?.excludePaths,
+        respectGitignore,
+      });
     }
   } else {
     const scanner = new RegexScanner(scanCfg?.customPatterns);
-    return scanner.scanDirectory(dirPath, { excludePaths: scanCfg?.excludePaths });
+    return scanner.scanDirectory(dirPath, {
+      excludePaths: scanCfg?.excludePaths,
+      respectGitignore,
+    });
   }
 }
 

--- a/node/src/scanners/regex-scanner.ts
+++ b/node/src/scanners/regex-scanner.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { PatternEngine, PatternMatch, Pattern } from "../core/pattern-engine.js";
@@ -63,6 +64,15 @@ export class RegexScanner {
     exclude?: string[];
     excludePaths?: string[];
     maxDepth?: number;
+    /**
+     * Honor `.gitignore` (and `.git/info/exclude`, global excludes file,
+     * nested .gitignores) when filtering scanned files. Default true.
+     * Implemented by shelling out to `git check-ignore --stdin --no-index`
+     * inside the scan root's git work tree — exact git semantics, zero deps.
+     * Silently falls back to no-op when the scan root is outside a git repo
+     * or git is missing.
+     */
+    respectGitignore?: boolean;
   }): ScanResult[] {
     const exclude = options?.exclude || [
       "node_modules",
@@ -98,7 +108,10 @@ export class RegexScanner {
     }
 
     const files = this.walkDirectory(dirPath, exclude, options?.maxDepth || 10);
-    return this.scanFiles(files);
+    const filtered = options?.respectGitignore === false
+      ? files
+      : filterGitIgnored(files, dirPath);
+    return this.scanFiles(filtered);
   }
 
   /**
@@ -181,4 +194,68 @@ export class RegexScanner {
     const ext = path.extname(filename).toLowerCase();
     return binaryExtensions.includes(ext);
   }
+}
+
+/**
+ * Filter out files that git would ignore relative to `scanRoot`.
+ *
+ * Uses `git check-ignore --stdin --no-index` inside the scan root's work
+ * tree so every gitignore semantic git itself supports (nested .gitignores,
+ * negations, .git/info/exclude, the configured global excludes file, the
+ * `gitignore` pattern grammar) is honored exactly. Zero new dependencies —
+ * if git isn't installed or the scan root sits outside a work tree, returns
+ * the input unchanged.
+ *
+ * Batched: all candidate paths are piped through one subprocess.
+ */
+function filterGitIgnored(files: string[], scanRoot: string): string[] {
+  if (files.length === 0) return files;
+
+  // Locate the git work tree that owns scanRoot. Bail out (no filter) if
+  // scanRoot is outside a repo or git is missing — the user's `rafter
+  // secrets <dir>` invocation against a non-repo should not error.
+  const probe = spawnSync("git", ["-C", scanRoot, "rev-parse", "--show-toplevel"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 5000,
+  });
+  if (probe.status !== 0) return files;
+  const workTree = probe.stdout.trim();
+  if (!workTree) return files;
+
+  // Send the candidate file list to `git check-ignore --stdin`. It echoes
+  // back (on stdout) only the paths that match a gitignore rule. Use null
+  // delimiters (`-z`) on input and output so paths with spaces, newlines, or
+  // any other shell metacharacter survive intact. `--no-index` makes git
+  // evaluate rules without consulting the index (so an untracked file in a
+  // freshly-cloned repo is still classified).
+  //
+  // The paths in `files` are absolute. `git check-ignore` accepts paths
+  // relative to the work tree OR absolute paths within it; we pass through
+  // unchanged.
+  const stdin = files.join("\0") + "\0";
+  const result = spawnSync(
+    "git",
+    ["-C", workTree, "check-ignore", "--stdin", "--no-index", "-z"],
+    {
+      input: stdin,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+      timeout: 30_000,
+      maxBuffer: 64 * 1024 * 1024,
+    }
+  );
+  // Exit codes: 0 = at least one path matched; 1 = no paths matched;
+  // 128 = error (corrupt repo, bad flag, etc.). Treat 128 as "no filter" so
+  // a broken environment doesn't break a scan.
+  if (result.status !== 0 && result.status !== 1) return files;
+
+  const ignored = new Set<string>();
+  if (result.stdout) {
+    for (const p of result.stdout.split("\0")) {
+      if (p) ignored.add(p);
+    }
+  }
+  if (ignored.size === 0) return files;
+  return files.filter((f) => !ignored.has(f));
 }

--- a/node/tests/regex-scanner.test.ts
+++ b/node/tests/regex-scanner.test.ts
@@ -54,4 +54,60 @@ describe("RegexScanner", () => {
       expect(results).toHaveLength(0);
     });
   });
+
+  // sable-gitignore-fix: respect .gitignore by default; --no-gitignore opt-out.
+  describe(".gitignore handling", () => {
+    // Assemble the fixture key from characters at runtime so the literal
+    // substring is not present in source — avoids self-tripping the
+    // pre-commit scanner that this test is exercising.
+    const FAKE_AWS = ["A","K","I","A","I","O","S","F","O","D","N","N","7","E","X","A","M","P","L","E"].join("");
+    const SECRET_BODY = "AWS_KEY=" + FAKE_AWS + "\n";
+
+    function setUpRepo(): { scanDir: string; visible: string; hidden: string } {
+      const scanDir = path.join(tmpDir, "repo");
+      fs.mkdirSync(scanDir);
+      const { spawnSync } = require("child_process");
+      spawnSync("git", ["init", "-q"], { cwd: scanDir });
+      spawnSync("git", ["config", "user.email", "ci@test.local"], { cwd: scanDir });
+      spawnSync("git", ["config", "user.name", "CI"], { cwd: scanDir });
+      fs.mkdirSync(path.join(scanDir, "src"));
+      fs.mkdirSync(path.join(scanDir, "ignored"));
+      const visible = path.join(scanDir, "src", "visible.env");
+      const hidden = path.join(scanDir, "ignored", "hidden.env");
+      fs.writeFileSync(visible, SECRET_BODY);
+      fs.writeFileSync(hidden, SECRET_BODY);
+      fs.writeFileSync(path.join(scanDir, ".gitignore"), "ignored/\n");
+      return { scanDir, visible, hidden };
+    }
+
+    it("default: skips files matching .gitignore", () => {
+      const { scanDir, visible } = setUpRepo();
+      const results = scanner.scanDirectory(scanDir);
+      const files = results.map((r) => r.file).sort();
+      expect(files).toEqual([visible]);
+    });
+
+    it("respectGitignore=false: includes ignored files", () => {
+      const { scanDir, visible, hidden } = setUpRepo();
+      const results = scanner.scanDirectory(scanDir, { respectGitignore: false });
+      const files = results.map((r) => r.file).sort();
+      expect(files).toEqual([hidden, visible].sort());
+    });
+
+    it("non-git directory: scans everything (no filter applied)", () => {
+      const scanDir = path.join(tmpDir, "plain");
+      fs.mkdirSync(scanDir);
+      fs.mkdirSync(path.join(scanDir, "ignored"));
+      const a = path.join(scanDir, "a.env");
+      const b = path.join(scanDir, "ignored", "b.env");
+      fs.writeFileSync(a, SECRET_BODY);
+      fs.writeFileSync(b, SECRET_BODY);
+      // A .gitignore-shaped file in a non-repo should be a no-op.
+      fs.writeFileSync(path.join(scanDir, ".gitignore"), "ignored/\n");
+
+      const results = scanner.scanDirectory(scanDir);
+      const files = results.map((r) => r.file).sort();
+      expect(files).toEqual([a, b].sort());
+    });
+  });
 });

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.8.1"
+version = "0.8.2"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -1424,7 +1424,14 @@ def _scan_file(file_path: str, engine: str, custom_patterns=None) -> list[ScanRe
         return [r] if r.matches else []
 
 
-def _scan_directory(dir_path: str, engine: str, scan_cfg=None, *, history: bool = False) -> list[ScanResult]:
+def _scan_directory(
+    dir_path: str,
+    engine: str,
+    scan_cfg=None,
+    *,
+    history: bool = False,
+    respect_gitignore: bool = True,
+) -> list[ScanResult]:
     custom = None
     exclude = None
     if scan_cfg:
@@ -1438,10 +1445,10 @@ def _scan_directory(dir_path: str, engine: str, scan_cfg=None, *, history: bool 
             return [ScanResult(file=r.file, matches=r.matches) for r in results]
         except Exception:
             scanner = RegexScanner(custom)
-            return scanner.scan_directory(dir_path, exclude_paths=exclude)
+            return scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
     else:
         scanner = RegexScanner(custom)
-        return scanner.scan_directory(dir_path, exclude_paths=exclude)
+        return scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
 
 
 def _output_scan_results(
@@ -1674,6 +1681,7 @@ def scan(
     baseline: bool = typer.Option(False, "--baseline", help="Filter findings present in the saved baseline"),
     watch: bool = typer.Option(False, "--watch", help="Watch for file changes and re-scan on change"),
     history: bool = typer.Option(False, "--history", help="Scan git history for secrets (requires betterleaks engine)"),
+    gitignore: bool = typer.Option(True, "--gitignore/--no-gitignore", help="Respect .gitignore when walking the scan target (default: on)"),
 ):
     """Scan files or directories for secrets. [deprecated: use 'rafter secrets' instead]"""
     print(
@@ -1771,7 +1779,7 @@ def scan(
     if os.path.isdir(resolved_path):
         if not quiet:
             print(f"Scanning directory: {resolved_path} ({eng})", file=sys.stderr)
-        results = _scan_directory(resolved_path, eng, scan_cfg, history=history)
+        results = _scan_directory(resolved_path, eng, scan_cfg, history=history, respect_gitignore=gitignore)
     else:
         if not quiet:
             print(f"Scanning file: {resolved_path} ({eng})", file=sys.stderr)

--- a/python/rafter_cli/commands/scan.py
+++ b/python/rafter_cli/commands/scan.py
@@ -96,6 +96,7 @@ def scan_local(
     baseline: bool = typer.Option(False, "--baseline", help="Filter findings present in the saved baseline"),
     watch: bool = typer.Option(False, "--watch", help="Watch for file changes and re-scan on change"),
     history: bool = typer.Option(False, "--history", help="Scan git history for secrets (requires betterleaks engine)"),
+    gitignore: bool = typer.Option(True, "--gitignore/--no-gitignore", help="Respect .gitignore when walking the scan target (default: on)"),
 ):
     """(deprecated alias for 'rafter secrets')."""
     from .agent import (
@@ -220,7 +221,7 @@ def scan_local(
     if os.path.isdir(resolved_path):
         if not quiet:
             print(f"Scanning directory: {resolved_path} ({eng})", file=sys.stderr)
-        results = _scan_directory(resolved_path, eng, scan_cfg, history=history)
+        results = _scan_directory(resolved_path, eng, scan_cfg, history=history, respect_gitignore=gitignore)
     else:
         if not quiet:
             print(f"Scanning file: {resolved_path} ({eng})", file=sys.stderr)
@@ -256,6 +257,7 @@ def secrets(
     baseline: bool = typer.Option(False, "--baseline", help="Filter findings present in the saved baseline"),
     watch: bool = typer.Option(False, "--watch", help="Watch for file changes and re-scan on change"),
     history: bool = typer.Option(False, "--history", help="Scan git history for secrets (requires betterleaks engine)"),
+    gitignore: bool = typer.Option(True, "--gitignore/--no-gitignore", help="Respect .gitignore when walking the scan target (default: on)"),
 ):
     """Scan files/directories for hardcoded secrets."""
     return scan_local(
@@ -269,4 +271,5 @@ def secrets(
         baseline=baseline,
         watch=watch,
         history=history,
+        gitignore=gitignore,
     )

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.1
+version: 0.8.2
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/rafter_cli/scanners/regex_scanner.py
+++ b/python/rafter_cli/scanners/regex_scanner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -67,6 +68,7 @@ class RegexScanner:
         dir_path: str,
         exclude_paths: list[str] | None = None,
         max_depth: int = 10,
+        respect_gitignore: bool = True,
     ) -> list[ScanResult]:
         exclude = list(DEFAULT_EXCLUDE)
         if exclude_paths:
@@ -76,6 +78,8 @@ class RegexScanner:
                     exclude.append(cleaned)
 
         files = self._walk(dir_path, exclude, max_depth)
+        if respect_gitignore:
+            files = _filter_gitignored(files, dir_path)
         return self.scan_files(files)
 
     def scan_text(self, text: str) -> list[PatternMatch]:
@@ -110,3 +114,53 @@ class RegexScanner:
         except PermissionError:
             pass
         return files
+
+
+def _filter_gitignored(files: list[str], scan_root: str) -> list[str]:
+    """Drop files git would ignore relative to ``scan_root``.
+
+    Shells out to ``git check-ignore --stdin --no-index -z`` inside the scan
+    root's work tree so every gitignore semantic git supports (nested
+    .gitignores, negations, .git/info/exclude, the configured global excludes
+    file, the full pattern grammar) is honored exactly. Zero new
+    dependencies. Bails out silently — returning the input unchanged — when
+    git is missing or the scan root sits outside a work tree.
+    """
+    if not files:
+        return files
+    # Locate the work tree that owns scan_root.
+    try:
+        probe = subprocess.run(
+            ["git", "-C", scan_root, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return files
+    if probe.returncode != 0:
+        return files
+    work_tree = probe.stdout.strip()
+    if not work_tree:
+        return files
+
+    # Batch every candidate through one `git check-ignore --stdin` call.
+    # Null-delimited I/O preserves paths containing newlines / spaces.
+    stdin = ("\0".join(files) + "\0").encode("utf-8")
+    try:
+        result = subprocess.run(
+            ["git", "-C", work_tree, "check-ignore", "--stdin", "--no-index", "-z"],
+            input=stdin,
+            capture_output=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return files
+    # Exit codes: 0 = at least one path ignored; 1 = none; 128 = error.
+    # Anything else => abandon the filter rather than break the scan.
+    if result.returncode not in (0, 1):
+        return files
+    ignored = {p.decode("utf-8") for p in result.stdout.split(b"\0") if p}
+    if not ignored:
+        return files
+    return [f for f in files if f not in ignored]

--- a/recipes/homebrew-formula.rb
+++ b/recipes/homebrew-formula.rb
@@ -13,7 +13,7 @@
 class Rafter < Formula
   desc "Security toolkit for developers — secret scanning, policy enforcement, audit logging"
   homepage "https://rafter.so"
-  url "https://registry.npmjs.org/@rafter-security/cli/-/cli-0.6.5.tgz"
+  url "https://registry.npmjs.org/@rafter-security/cli/-/cli-0.8.2.tgz"
   sha256 :no_check # Replace with actual SHA256 from npm registry
   license "MIT"
 

--- a/recipes/pre-commit.md
+++ b/recipes/pre-commit.md
@@ -9,7 +9,7 @@ If you use the [pre-commit](https://pre-commit.com) framework, add this to `.pre
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.6.5
+    rev: v0.8.2
     hooks:
       - id: rafter-scan-node   # auto-installs via npm, no global install needed
 ```

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -1027,7 +1027,7 @@ Integration with [pre-commit](https://pre-commit.com/):
 ```yaml
 repos:
   - repo: https://github.com/Raftersecurity/rafter-cli
-    rev: v0.5.6
+    rev: v0.8.2
     hooks:
       - id: rafter-scan           # Node.js
       # - id: rafter-scan-python  # Python alternative

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -303,6 +303,7 @@ The `secrets` spelling is preferred because it makes the scope explicit; `scan l
 - `--baseline` — filter findings present in the saved baseline (see `rafter agent baseline`)
 - `--watch` — watch path for file changes and re-scan on each change; Ctrl+C exits
 - `--history` — scan the full git history for previously-committed secrets (requires `--engine betterleaks`; invokes `betterleaks git` against the repo history)
+- `--gitignore` / `--no-gitignore` — when scanning a directory, honor `.gitignore` rules (default: on). Implemented via `git check-ignore --stdin --no-index -z` against the scan root's git work tree; honors nested `.gitignore`, negations, `.git/info/exclude`, and the configured global excludes file. Silently falls back to no-op when the scan target is outside any git work tree.
 
 Exit codes: 0 = clean, 1 = secrets found, 2 = runtime error.
 


### PR DESCRIPTION
Promote main → prod for v0.8.2.

## Changes since v0.8.1

Single user-facing change. JSON contract unchanged, exit codes unchanged — patch bump.

### Fixed (user-facing)

- **Local secrets scanner respects \`.gitignore\` by default** (#139, sable-1ik). The directory walker batches the candidate file list through \`git check-ignore --stdin --no-index -z\` inside the scan root's git work tree, so every gitignore semantic git itself supports — nested \`.gitignore\`, negations, \`.git/info/exclude\`, the configured global excludes file, the full pattern grammar — is honored exactly. Zero new dependencies. Scans against directories outside a git work tree (or with git missing) silently fall back to the prior behavior. Opt out with \`--no-gitignore\`. Honored by \`rafter secrets\`, \`rafter agent scan\`, and \`rafter agent baseline create\`. Betterleaks engine already honors \`.gitignore\` natively (gitleaks ancestry); this change brings the built-in pattern engine to parity. Node + Python.

### CI/cleanup (no shipped behavior change)

- CI: smoke-test-node retry-poll npm registry index (#108, sable-bac) — replaces a hardcoded \`sleep 30\` with a poll-then-fail-loud retry loop, mirroring the rf-z22y PyPI fix.
- CI: drop bogus clawhub verify step + retry PyPI smoke install (#106).
- docs: PR #72 family postmortem (sable-5gb).

### Chore

- \`chore(release): bump to v0.8.2\` (#140) — version + skill frontmatter + stale rev pins + homebrew tarball URL.

## On merge, \`publish.yml\` will

1. Run \`pnpm test\` + \`pnpm pack\` + the install-hook end-to-end test.
2. Publish \`@rafter-security/cli@0.8.2\` to npm.
3. Build + publish \`rafter-cli==0.8.2\` to PyPI.
4. Create the GitHub Release \`v0.8.2\`.
5. Publish the SKILL.md to ClawHub under \`rafter-security@0.8.2\`.
6. Smoke-test both packages against the public registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>