### PR TITLE
ci(sable-ibd): migrate npm publish to GitHub Actions OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
 
 permissions:
   contents: read
+  # id-token: write is required by npm Trusted Publishing (OIDC). Lets the
+  # publish-node job exchange the GitHub-issued OIDC token for a short-lived
+  # npm publish credential, replacing the long-lived NPM_TOKEN secret. Does
+  # NOT grant write access on its own; just mints the identity token.
+  id-token: write
 
 jobs:
   test-node:
@@ -79,6 +84,13 @@ jobs:
   publish-node:
     needs: [test-node, test-package]
     runs-on: ubuntu-latest
+    # Trusted Publishing requires id-token: write in scope for THIS job (the
+    # top-level grant covers it, but documented here for the job-local audit
+    # trail). Self-hosted runners are NOT supported by npm Trusted Publishing
+    # — ubuntu-latest (GitHub-hosted) is required.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: ./node
@@ -87,10 +99,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node 22 is the floor for npm Trusted Publishing (npm 11.5.1+ required,
+      # which ships with Node 22.14.0+). Earlier versions error out at publish
+      # time with an unhelpful auth message.
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
+
+      # Pin the npm CLI explicitly to ensure >= 11.5.1 even if the bundled
+      # version in node@22 drifts.
+      - name: Ensure npm >= 11.5.1 (Trusted Publishing floor)
+        run: npm install -g npm@latest
 
       - name: Enable pnpm
         run: corepack enable && corepack prepare pnpm@10 --activate
@@ -111,10 +131,16 @@ jobs:
         run: |
           test -f dist/index.js || (echo "Build failed: dist/index.js not found" && exit 1)
 
-      - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Trusted Publishing: no NODE_AUTH_TOKEN / NPM_TOKEN. The npm CLI
+      # exchanges the GitHub OIDC token (id-token: write above) for a
+      # short-lived publish credential, matched against the trusted-publisher
+      # config in the npm package settings (repo=Raftersecurity/rafter-cli,
+      # workflow=publish.yml). --provenance is auto-generated under Trusted
+      # Publishing but the explicit flag makes intent obvious and survives if
+      # someone later flips a default. --access public is preserved for the
+      # scoped package (@rafter-security/cli).
+      - name: Publish to npm (Trusted Publishing — OIDC)
+        run: npm publish --access public --provenance
 
   publish-python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Replace the long-lived \`NPM_TOKEN\` secret in the \`publish-node\` job with npm's OIDC-based Trusted Publishing flow. Rome has the npm-side trusted-publisher config in place (\`repo=Raftersecurity/rafter-cli, workflow=publish.yml\`), so this PR is the workflow half of the migration.

**Merge this BEFORE PR #141 (Release v0.8.2)** so v0.8.2 is the first OIDC-published release.

## Workflow changes

| Before | After |
|---|---|
| Top-level \`permissions: contents: read\` | + \`id-token: write\` (workflow-wide, also repeated job-local on publish-node) |
| \`setup-node@v4\` node-version \`"20"\` in publish-node | \`"22"\` (Trusted Publishing requires Node 22.14.0+ / npm 11.5.1+) |
| (none) | New step: \`npm install -g npm@latest\` — guarantees CLI ≥ 11.5.1 |
| \`env: NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` | Removed. OIDC handles auth. |
| \`npm publish --access public\` | \`npm publish --access public --provenance\` |

Other jobs (\`test-node\`, \`test-package\`, \`smoke-test-node\`) **kept on node-version "20"** — they don't publish, so they don't need the Trusted Publishing floor.

## Post-merge cleanup (NOT in this PR)

After a successful first OIDC publish:
- Delete \`NPM_TOKEN\` from GitHub repo secrets.
- Revoke the old npm automation token.
- Flip the npm package to "require 2FA, disallow tokens".

## What's out of scope

- **PyPI publish-python**: PyPI Trusted Publishing is a separate configuration (different action: \`pypa/gh-action-pypi-publish\` with \`trusted-publishing: true\`, and a corresponding pending-publisher setup on PyPI). Filed as a future follow-up if you want it.
- **Trigger model**: kept \`push: branches: [prod]\`. The Trusted Publishing docs recommend tag/release-triggered publishes + an environment with manual approval as a tighter pattern, but that's a separate decision and out of scope here.

## Risk

- Self-hosted runners are NOT supported by Trusted Publishing. We use \`ubuntu-latest\` (GitHub-hosted) — fine.
- First-publish failure modes per npm docs: trusted-publisher config mismatch (404), missing \`id-token: write\` permission (auth error). Both verified above.
- The package is already published on npm, so the first-publish-needs-2FA workaround for fresh packages doesn't apply here.

Closes sable-ibd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>