### PR TITLE
fix(publish): rename publish.yml → publish.yaml; --skip-existing on PyPI upload

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -135,7 +135,7 @@ jobs:
       # exchanges the GitHub OIDC token (id-token: write above) for a
       # short-lived publish credential, matched against the trusted-publisher
       # config in the npm package settings (repo=Raftersecurity/rafter-cli,
-      # workflow=publish.yml). --provenance is auto-generated under Trusted
+      # workflow=publish.yaml). --provenance is auto-generated under Trusted
       # Publishing but the explicit flag makes intent obvious and survives if
       # someone later flips a default. --access public is preserved for the
       # scoped package (@rafter-security/cli).
@@ -174,11 +174,18 @@ jobs:
           ls dist/*.whl >/dev/null 2>&1 || (echo "Build failed: wheel not found" && exit 1)
           ls dist/*.tar.gz >/dev/null 2>&1 || (echo "Build failed: sdist not found" && exit 1)
 
+      # Idempotency: if this version is already on PyPI, skip the upload so
+      # a retry of a partially-failed release (e.g. the publish-node Trusted
+      # Publishing filename mismatch that 404'd v0.8.2's npm publish AFTER
+      # publish-python had already succeeded) doesn't fail with a 400 on
+      # "File already exists". `twine upload --skip-existing` is the
+      # standard idiom for this — succeeds whether or not the version is
+      # new on the index.
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: python -m twine upload dist/*
+        run: python -m twine upload --skip-existing dist/*
 
   publish-clawhub:
     # Publishes the rafter-security skill to ClawHub

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Ensure ClawHub skill version matches package version
         # rf-zgwj — the SKILL.md frontmatter version is what ClawHub publishes
         # under. Drift here would silently ship a stale version on the next
-        # `clawhub skill publish` (publish.yml). Both the Node and Python
+        # `clawhub skill publish` (publish.yaml). Both the Node and Python
         # resource copies must match the package version exactly.
         run: |
           PACKAGE_VERSION="${{ steps.node-version.outputs.VERSION }}"

--- a/node/tests/github-action.test.ts
+++ b/node/tests/github-action.test.ts
@@ -379,14 +379,14 @@ describe("test-comprehensive.yml — CI matrix", () => {
   });
 });
 
-// ── publish.yml — release pipeline validation ──────────────────────────
+// ── publish.yaml — release pipeline validation ──────────────────────────
 
-describe("publish.yml — release pipeline", () => {
+describe("publish.yaml — release pipeline", () => {
   let workflow: any;
 
   beforeAll(() => {
     workflow = yaml.load(
-      fs.readFileSync(path.join(WORKFLOWS_DIR, "publish.yml"), "utf-8"),
+      fs.readFileSync(path.join(WORKFLOWS_DIR, "publish.yaml"), "utf-8"),
     );
   });
 


### PR DESCRIPTION
## Why

The v0.8.2 publish run on prod **failed at \`publish-node\`** with:

\`\`\`
npm error 404 Not Found - PUT https://registry.npmjs.org/@rafter-security%2fcli
\`\`\`

…even though the OIDC exchange succeeded and a provenance statement was signed to Sigstore. Root cause confirmed: the **npm Trusted Publisher config on \`@rafter-security/cli\` records the workflow filename as \`publish.yaml\`**, but our file was \`publish.yml\`. The OIDC token's \`workflow\` claim therefore doesn't match the configured trusted-publisher entry, and npm returns 404 — exactly the failure mode the docs call out.

Partial-release state captured before this PR:

| Job | Result | Effect |
|---|---|---|
| \`publish-python\` | success | \`rafter-cli==0.8.2\` ships to PyPI |
| \`publish-node\` | failure | \`@rafter-security/cli@0.8.2\` NOT on npm |
| \`publish-clawhub\` | skipped | needs publish-node |
| \`create-release\` | skipped | needs publish-node + publish-python |
| \`smoke-test-node\` | skipped | needs publish-node + create-release |
| \`smoke-test-python\` | skipped | needs publish-python + create-release |

## What changed

1. **Renamed \`.github/workflows/publish.yml\` → \`.github/workflows/publish.yaml\`** via \`git mv\` so history follows. Workflow path now matches the npm trusted-publisher config exactly. The other workflows in \`.github/workflows/\` keep the \`.yml\` convention — this one is intentionally \`.yaml\` to match the npm-side configuration. (Alternative was for you to edit the npm UI to \`publish.yml\` — went with the code-side fix since it's faster.)

2. **\`--skip-existing\` on the \`twine upload\` command in \`publish-python\`**. v0.8.2 already shipped to PyPI in the partial release. Without this flag, the retry would hit HTTP 400 "File already exists" and skip every downstream job again. \`--skip-existing\` is the standard idempotency idiom for twine — succeeds whether or not the version is new on the index.

3. **Adjacent doc/test refs updated**:
   - \`node/tests/github-action.test.ts\` reads the workflow by path — bumped \`publish.yml\` → \`publish.yaml\`. **76/76 tests pass.**
   - One comment in \`validate-release.yml\` and one in the renamed workflow file updated.

## Merge sequence + expected outcome

1. **Merge this PR into \`main\`.**
2. **Merge \`main\` into \`prod\`** (a fresh main → prod PR; reuse the same Release v0.8.2 framing if you want, or simpler "release: retry v0.8.2 publish").
3. The push to prod triggers \`publish.yaml\`:
   - \`publish-node\` → OIDC publish succeeds, \`@rafter-security/cli@0.8.2\` lands on npm with provenance.
   - \`publish-python\` → \`twine upload --skip-existing\` no-ops on v0.8.2.
   - \`create-release\`, \`publish-clawhub\`, \`smoke-test-node\`, \`smoke-test-python\` all run.

> **Re-running the failed job on the existing run won't help** — it'd execute the OLD workflow definition (still \`publish.yml\`, no \`--skip-existing\`). The fix has to ship via a fresh push to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>