### PR TITLE
release: retry v0.8.2 publish (publish.yaml rename + PyPI idempotency)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -135,7 +135,7 @@ jobs:
       # exchanges the GitHub OIDC token (id-token: write above) for a
       # short-lived publish credential, matched against the trusted-publisher
       # config in the npm package settings (repo=Raftersecurity/rafter-cli,
-      # workflow=publish.yml). --provenance is auto-generated under Trusted
+      # workflow=publish.yaml). --provenance is auto-generated under Trusted
       # Publishing but the explicit flag makes intent obvious and survives if
       # someone later flips a default. --access public is preserved for the
       # scoped package (@rafter-security/cli).
@@ -174,11 +174,18 @@ jobs:
           ls dist/*.whl >/dev/null 2>&1 || (echo "Build failed: wheel not found" && exit 1)
           ls dist/*.tar.gz >/dev/null 2>&1 || (echo "Build failed: sdist not found" && exit 1)
 
+      # Idempotency: if this version is already on PyPI, skip the upload so
+      # a retry of a partially-failed release (e.g. the publish-node Trusted
+      # Publishing filename mismatch that 404'd v0.8.2's npm publish AFTER
+      # publish-python had already succeeded) doesn't fail with a 400 on
+      # "File already exists". `twine upload --skip-existing` is the
+      # standard idiom for this — succeeds whether or not the version is
+      # new on the index.
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: python -m twine upload dist/*
+        run: python -m twine upload --skip-existing dist/*
 
   publish-clawhub:
     # Publishes the rafter-security skill to ClawHub

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Ensure ClawHub skill version matches package version
         # rf-zgwj — the SKILL.md frontmatter version is what ClawHub publishes
         # under. Drift here would silently ship a stale version on the next
-        # `clawhub skill publish` (publish.yml). Both the Node and Python
+        # `clawhub skill publish` (publish.yaml). Both the Node and Python
         # resource copies must match the package version exactly.
         run: |
           PACKAGE_VERSION="${{ steps.node-version.outputs.VERSION }}"

--- a/node/tests/github-action.test.ts
+++ b/node/tests/github-action.test.ts
@@ -379,14 +379,14 @@ describe("test-comprehensive.yml — CI matrix", () => {
   });
 });
 
-// ── publish.yml — release pipeline validation ──────────────────────────
+// ── publish.yaml — release pipeline validation ──────────────────────────
 
-describe("publish.yml — release pipeline", () => {
+describe("publish.yaml — release pipeline", () => {
   let workflow: any;
 
   beforeAll(() => {
     workflow = yaml.load(
-      fs.readFileSync(path.join(WORKFLOWS_DIR, "publish.yml"), "utf-8"),
+      fs.readFileSync(path.join(WORKFLOWS_DIR, "publish.yaml"), "utf-8"),
     );
   });
 


### PR DESCRIPTION
Retry of the v0.8.2 release. The first attempt via PR #141 failed at \`publish-node\` with an npm \`E404\` because the workflow filename in the OIDC token (\`publish.yml\`) didn't match the npm Trusted Publisher config (\`publish.yaml\`). Prod was rolled back to v0.8.1. PyPI publish for v0.8.2 had already landed before publish-node failed, so PyPI carries v0.8.2 and npm does not.

## Fixes in main since the failed v0.8.2 attempt

- **#142** — migrate npm publish to GitHub Actions OIDC Trusted Publishing. \`id-token: write\` permission, node-version 22, npm CLI bump, drop \`NPM_TOKEN\` env, \`--provenance\` flag.
- **#143** — rename \`.github/workflows/publish.yml\` → \`publish.yaml\` so the OIDC workflow claim matches the trusted-publisher config; add \`--skip-existing\` to the \`twine upload\` so the v0.8.2-on-PyPI no-op doesn't break the retry.

## Other changes since v0.8.1 (same as the original PR #141 body)

- **#139** sable-1ik — local secrets scanner respects \`.gitignore\` by default. New \`--no-gitignore\` flag.
- **#108** sable-bac — CI: retry-poll npm registry index in smoke-test-node.
- **#106, #107**, ddceda0 — CI cleanup + PR #72 family postmortem (docs).
- **#140** — \`chore(release): bump to v0.8.2\` — versions, skill frontmatters, stale rev pins, homebrew tarball URL.

## On merge, \`publish.yaml\` will

1. Run \`pnpm test\` + \`pnpm pack\` + the install-hook end-to-end test.
2. **OIDC publish** \`@rafter-security/cli@0.8.2\` to npm with provenance — workflow filename now matches the trusted-publisher config.
3. \`twine upload --skip-existing dist/*\` — no-op for the already-shipped \`rafter-cli==0.8.2\`.
4. \`create-release\` → GitHub Release \`v0.8.2\` tag.
5. \`publish-clawhub\` → \`rafter-security@0.8.2\` to ClawHub.
6. Smoke tests against the public registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>