### PR TITLE
fix(publish): add repository/homepage/bugs/license/author metadata to node/package.json

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -2,6 +2,17 @@
   "name": "@rafter-security/cli",
   "version": "0.8.2",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Raftersecurity/rafter-cli.git"
+  },
+  "homepage": "https://rafter.so",
+  "bugs": {
+    "url": "https://github.com/Raftersecurity/rafter-cli/issues"
+  },
+  "license": "MIT",
+  "author": "Rafter Security",
+  "description": "Rafter CLI — the default security agent for AI coding workflows. Free for individuals and open source.",
   "bin": {
     "rafter": "./dist/index.js"
   },
@@ -18,7 +29,6 @@
   "engines": {
     "node": ">=18"
   },
-  "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "axios": "^1.13.5",


### PR DESCRIPTION
## Why

The v0.8.2 publish retry got past the \`publish.yaml\` filename mismatch (PR #143 + #144) but failed at the next provenance gate with:

\`\`\`
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@rafter-security%2fcli
npm error Error verifying sigstore provenance bundle: Failed to validate repository information:
npm error package.json: "repository.url" is "", expected to match
npm error "https://github.com/Raftersecurity/rafter-cli" from provenance
\`\`\`

npm's Trusted Publishing provenance verifier cross-checks \`package.json\`'s \`repository.url\` against the GitHub repo claim in the OIDC token. Our \`node/package.json\` had no \`repository\` field at all, so the comparison failed. Token-based publishes (v0.8.1 and earlier) bypassed this entirely because they didn't sign provenance.

## What changed

Standard npm package metadata block added right after \`version\` / \`type\` in \`node/package.json\`:

\`\`\`json
"repository": { "type": "git", "url": "git+https://github.com/Raftersecurity/rafter-cli.git" },
"homepage": "https://rafter.so",
"bugs": { "url": "https://github.com/Raftersecurity/rafter-cli/issues" },
"license": "MIT",
"author": "Rafter Security",
"description": "Rafter CLI — the default security agent for AI coding workflows. Free for individuals and open source."
\`\`\`

The \`git+https://...git\` URL form is what npm + sigstore-js normalize to \`https://github.com/Raftersecurity/rafter-cli\` before comparing against the provenance bundle. Throwing in the adjacent canonical fields (\`homepage\`, \`bugs\`, \`license\`, \`author\`, \`description\`) so npmjs.com renders a clean package page on the v0.8.2 publish.

## Merge sequence

1. **Merge this PR → \`main\`.**
2. The open release PR **#144** (main → prod) auto-picks up this commit.
3. Re-merge main → prod (or just merge #144) — push triggers \`publish.yaml\` → publish-node OIDC publish now satisfies the provenance verifier → \`@rafter-security/cli@0.8.2\` lands on npm with provenance.
4. \`twine upload --skip-existing\` still no-ops on the existing PyPI v0.8.2. ClawHub / GitHub release / smokes run.

## Tests

- \`pnpm exec tsc -p tsconfig.json --noEmit\` clean.
- \`pnpm exec vitest run tests/github-action.test.ts\` — 76/76 pass. (No tests directly assert on the new package.json keys; they assert workflow shape.)
- \`python3 -c "import json; json.load(open('node/package.json'))"\` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>