### PR TITLE
release: retry v0.8.2 publish (3rd attempt — package.json repository field)

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -2,6 +2,17 @@
   "name": "@rafter-security/cli",
   "version": "0.8.2",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Raftersecurity/rafter-cli.git"
+  },
+  "homepage": "https://rafter.so",
+  "bugs": {
+    "url": "https://github.com/Raftersecurity/rafter-cli/issues"
+  },
+  "license": "MIT",
+  "author": "Rafter Security",
+  "description": "Rafter CLI — the default security agent for AI coding workflows. Free for individuals and open source.",
   "bin": {
     "rafter": "./dist/index.js"
   },
@@ -18,7 +29,6 @@
   "engines": {
     "node": ">=18"
   },
-  "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "axios": "^1.13.5",


### PR DESCRIPTION
Third attempt at v0.8.2 release. Each prior attempt advanced one gate further; this one fixes the next gate.

| Attempt | Failure | Fix |
|---|---|---|
| **1st (#141)** | npm \`E404\` — OIDC token workflow filename \`publish.yml\` didn't match trusted-publisher config \`publish.yaml\` | #143: rename workflow to \`publish.yaml\` |
| **2nd (#144)** | npm \`E422\` — provenance verifier rejected because \`package.json\` had no \`repository.url\` to compare against the OIDC token's repo claim | #145: add \`repository\` + sibling metadata to \`node/package.json\` |
| **3rd (this PR)** | — | — |

PyPI v0.8.2 already shipped on attempt 1; \`twine upload --skip-existing\` (PR #143) handles the no-op on retry.

## Commits ahead of prod

- **#145** — add \`repository\` (\`git+https://github.com/Raftersecurity/rafter-cli.git\`), \`homepage\`, \`bugs\`, \`license\`, \`author\`, \`description\` to \`node/package.json\` so the npm Trusted Publishing provenance verifier finds the repo URL it expects.
- **#143** — rename \`publish.yml → publish.yaml\` + \`twine upload --skip-existing\`.
- **#142** — Trusted Publishing migration (id-token: write, node 22, npm CLI bump, drop NPM_TOKEN, --provenance).
- **#140** — \`chore(release): bump to v0.8.2\`.
- **#139** — local secrets scanner respects \`.gitignore\` by default (sable-1ik).
- **#108, #107, #106**, ddceda0 — CI cleanup + postmortem.

## On merge

1. \`publish-node\` — OIDC publish satisfies both the workflow-filename match AND the provenance \`repository.url\` check → \`@rafter-security/cli@0.8.2\` lands on npm.
2. \`publish-python\` — \`twine upload --skip-existing\` no-ops (PyPI v0.8.2 already there).
3. \`create-release\`, \`publish-clawhub\`, smokes all run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>