### PR TITLE
docs(sable-jnd+dfu): rafter SKILL Setup section + Cursor recipe leads with --local

### DIFF
--- a/node/resources/skills/rafter/SKILL.md
+++ b/node/resources/skills/rafter/SKILL.md
@@ -114,5 +114,5 @@ export RAFTER_API_KEY="..."        # or put it in .env
 
 Without a key, only `rafter secrets` works — that's secret-hygiene, not code review. If security matters for the task, flag the missing key to the user rather than silently accepting the narrower scan.
 
-## Strengthen the Project
-Not wired in yet? `rafter agent install-hook` (pre-commit), `rafter ci init` (CI workflow), `.rafter.yml` (policy). Per-platform setup: `rafter brief setup/<platform>`.
+## Setup
+Not installed? `npm i -g @rafter-security/cli` (Node) or `pip install rafter-cli` (Python). `npx` form is `npx @rafter-security/cli` — the bare `npx rafter-cli` resolves to an unrelated package. Inside Cursor's sandbox or any session where writing `~/.rafter` triggers a prompt, prefer `rafter agent init --local --with-<platform>` — writes `./.rafter/` + `./.<platform>/` instead of `$HOME`. Not wired yet? `rafter agent install-hook` (pre-commit), `rafter ci init` (CI), `.rafter.yml` (policy). Per-platform: `rafter brief setup/<platform>`.

--- a/python/rafter_cli/resources/skills/rafter/SKILL.md
+++ b/python/rafter_cli/resources/skills/rafter/SKILL.md
@@ -114,5 +114,5 @@ export RAFTER_API_KEY="..."        # or put it in .env
 
 Without a key, only `rafter secrets` works — that's secret-hygiene, not code review. If security matters for the task, flag the missing key to the user rather than silently accepting the narrower scan.
 
-## Strengthen the Project
-Not wired in yet? `rafter agent install-hook` (pre-commit), `rafter ci init` (CI workflow), `.rafter.yml` (policy). Per-platform setup: `rafter brief setup/<platform>`.
+## Setup
+Not installed? `npm i -g @rafter-security/cli` (Node) or `pip install rafter-cli` (Python). `npx` form is `npx @rafter-security/cli` — the bare `npx rafter-cli` resolves to an unrelated package. Inside Cursor's sandbox or any session where writing `~/.rafter` triggers a prompt, prefer `rafter agent init --local --with-<platform>` — writes `./.rafter/` + `./.<platform>/` instead of `$HOME`. Not wired yet? `rafter agent install-hook` (pre-commit), `rafter ci init` (CI), `.rafter.yml` (policy). Per-platform: `rafter brief setup/<platform>`.

--- a/recipes/cursor.md
+++ b/recipes/cursor.md
@@ -1,20 +1,40 @@
 # Cursor Setup
 
-Rafter integrates with Cursor through an **MCP server** that exposes scanning and auditing tools.
+Rafter's Cursor integration covers an MCP server + Cursor-native hooks (`preToolUse` / `postToolUse` / `beforeShellExecution`) + per-skill rules + a Cursor sub-agent. See [`shared-docs/PLATFORM_PARITY_AUDIT.md`](../shared-docs/PLATFORM_PARITY_AUDIT.md) for the full surface matrix.
+
+## Install the CLI first
+
+```sh
+npm install -g @rafter-security/cli   # Node
+# or:
+pip install rafter-cli                 # Python
+```
+
+> Using `npx`? The canonical form is `npx @rafter-security/cli` — the bare `npx rafter-cli` resolves to an **unrelated** package on npm.
 
 ## Automatic setup
+
+### Driven by the Cursor agent itself (recommended for first-run)
+
+```sh
+rafter agent init --local --with-cursor
+```
+
+Writes to `./.rafter/` and `./.cursor/` instead of `$HOME` — sidesteps Cursor's sandbox prompt for writing under your home directory and scopes the install to this project. Run it from inside the repo you're working in.
+
+### Global install (one-time, applies to every project)
 
 ```sh
 rafter agent init --with-cursor
 ```
 
-This auto-detects `~/.cursor` and installs the MCP server config. Done.
+Auto-detects `~/.cursor` and installs at user scope. Requires elevated permissions if Cursor's sandbox is locked down — the agent will prompt for them.
 
 ## Manual setup
 
 ### 1. MCP server
 
-Add to your `~/.cursor/mcp.json`:
+Add to `~/.cursor/mcp.json` (or `./.cursor/mcp.json` for per-project):
 
 ```json
 {


### PR DESCRIPTION
## Why

Real Cursor user report 2026-05-27 surfaced two install-time friction points the rafter SKILL.md and the Cursor recipe were silent on:

1. The Cursor agent **hallucinated \`npx rafter-cli agent init --all\`**. \`rafter-cli\` (bare) on npm resolves to an **unrelated** package; ours is \`@rafter-security/cli\`. The SKILL.md had no Install / bootstrap section, so when an agent didn't find \`rafter\` on PATH it had to guess — and guessed wrong.
2. The same agent **hit a Cursor sandbox prompt for writing \`~/.rafter\`** and had to retry with elevated permissions. \`rafter agent init --local --with-cursor\` writes to \`./.rafter/\` + \`./.cursor/\` instead of \`$HOME\` and sidesteps the prompt entirely.

## Changes

- **rafter SKILL.md** (Node + Python — verified byte-identical post-edit) — replaces the bare \`## Strengthen the Project\` block with a denser \`## Setup\` block that:
  - Names the canonical install commands (\`npm i -g @rafter-security/cli\`, \`pip install rafter-cli\`).
  - Warns off \`npx rafter-cli\` — recommends the scoped form \`npx @rafter-security/cli\`.
  - Leads with \`rafter agent init --local --with-<platform>\` for sandboxed sessions (Cursor and friends).
  - Preserves the prior install-hook / ci init / .rafter.yml / per-platform pointers.

  Single-paragraph form keeps the file at **118 lines** (under the 120-line guard enforced by \`node/tests/brief.test.ts:152\`). 28/28 brief tests pass.

- **\`recipes/cursor.md\`** — rebuilt. Now opens with the **surface matrix** (MCP + hooks + per-skill rules + sub-agent — was previously presented as "MCP server only", understating what \`--with-cursor\` actually installs), then leads with \`rafter agent init --local --with-cursor\` as the recommended first-run for agent-driven setup. Global-scope form documented as the explicit alternative. The install-prerequisite block + the \`npx rafter-cli\` warning are at the top.

A parallel docs-site PR will follow on \`Rome-1/docs\` for the matching prose in \`quickstart.mdx\` (which has the literal hallucinated \`npx rafter-cli\` line that the Cursor agent was reading) and \`guides/agent-security/mcp-integration.mdx\`.

Closes sable-jnd and sable-dfu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>