### PR TITLE
feat(github-action): default severity-threshold to none (report-only)

### DIFF
--- a/github-action/README.md
+++ b/github-action/README.md
@@ -9,7 +9,7 @@ Run [Rafter](https://rafter.so) security scans on your GitHub repositories. Find
 - Scans on push and pull request events
 - Posts findings as PR comments with severity breakdown
 - Uploads SARIF to GitHub Code Scanning (appears in Security tab)
-- Configurable severity thresholds for CI gating
+- Report-only by default — opt into CI gating with `severity-threshold`
 - Fast and Plus scan modes
 
 ## Quick Start
@@ -42,7 +42,7 @@ jobs:
 |-------|-------------|---------|
 | `api-key` | Your Rafter API key (required) | — |
 | `scan-mode` | `fast` or `plus` | `fast` |
-| `severity-threshold` | Fail if findings at this level or above: `critical`, `high`, `medium`, `low`, `none` | `high` |
+| `severity-threshold` | Fail if findings at this level or above: `critical`, `high`, `medium`, `low`, `none`. Default `none` so first installs don't break builds — set to `high` once the baseline is triaged. | `none` |
 | `comment-on-pr` | Post results as PR comment | `true` |
 | `upload-sarif` | Upload SARIF to GitHub Code Scanning | `true` |
 | `timeout-minutes` | Max wait time for scan completion | `10` |
@@ -61,6 +61,17 @@ jobs:
 | `status` | Scan status |
 
 ## Examples
+
+### Enforce in CI (recommended after first scan)
+
+The default install is report-only — findings show up in PR comments and the Security tab but won't fail the check. Once you've triaged the baseline, opt into blocking:
+
+```yaml
+- uses: Raftersecurity/rafter-cli/github-action@main
+  with:
+    api-key: ${{ secrets.RAFTER_API_KEY }}
+    severity-threshold: high      # fail on critical/high
+```
 
 ### Block PRs with critical findings only
 
@@ -88,7 +99,6 @@ jobs:
   id: rafter
   with:
     api-key: ${{ secrets.RAFTER_API_KEY }}
-    severity-threshold: none  # Don't fail, just report
 
 - run: echo "Found ${{ steps.rafter.outputs.findings-count }} issues"
 ```

--- a/github-action/action.yml
+++ b/github-action/action.yml
@@ -15,9 +15,9 @@ inputs:
     required: false
     default: 'fast'
   severity-threshold:
-    description: 'Fail the check if findings at this severity or above are found. Options: critical, high, medium, low, none'
+    description: 'Fail the check if findings at this severity or above are found. Options: critical, high, medium, low, none. Default "none" so first-install never breaks a build; once you''ve triaged the baseline, set to "high" to enforce.'
     required: false
-    default: 'high'
+    default: 'none'
   comment-on-pr:
     description: 'Post scan results as a PR comment'
     required: false
@@ -239,6 +239,7 @@ runs:
         HIGH_COUNT: ${{ steps.results.outputs.high_count }}
         MEDIUM_COUNT: ${{ steps.results.outputs.medium_count }}
         LOW_COUNT: ${{ steps.results.outputs.low_count }}
+        SEVERITY_THRESHOLD: ${{ inputs.severity-threshold }}
       run: |
         MD_REPORT=$(jq -r '.markdown // empty' "${{ runner.temp }}/rafter-results.md" 2>/dev/null || cat "${{ runner.temp }}/rafter-results.md")
 
@@ -278,6 +279,10 @@ runs:
           echo ""
           echo "</details>"
           echo ""
+          if [ "$FINDINGS_COUNT" -gt 0 ] && [ "$SEVERITY_THRESHOLD" = "none" ]; then
+            echo "> :information_source: This run is report-only. To fail the build on critical/high findings, set \`severity-threshold: high\` in your workflow."
+            echo ""
+          fi
           echo "---"
           echo "<sub>Scan ID: ${SCAN_ID} | Powered by [Rafter](https://rafter.so)</sub>"
         } >> "$COMMENT_FILE"


### PR DESCRIPTION
## Summary

- Flips the GitHub Action's `severity-threshold` default from `high` to `none` so a first install scans, comments, and uploads SARIF but never fails the build.
- Adds a one-line tip to the PR comment when findings exist under the report-only default, pointing users to `severity-threshold: high` for opt-in enforcement.
- README updated: features list now says "report-only by default", input table reflects the new default with guidance, and a new "Enforce in CI (recommended after first scan)" example block leads the examples.

## Why

Rafter spans SAST + SCA + secrets where false positives are common. The previous default (`high`) meant any first install on a real repo would likely fail CI on day one — the worst possible first impression, and one that gets the action removed before users see the value. This aligns with how Snyk, CodeQL, and Semgrep default: surface findings through PR comments + the Security tab, and let teams opt into blocking once they've triaged the baseline.

## Behavior change for existing users

- **Users who set `severity-threshold` explicitly in their workflow**: unaffected.
- **Users who relied on the implicit `high` default**: their builds will stop failing on critical/high findings. They'll see the new tip in the PR comment and can restore prior behavior with `severity-threshold: high`.

## Test plan

- [ ] Workflow consumer with no `severity-threshold` set → scan completes, PR comment includes the tip when findings exist, build does not fail.
- [ ] Workflow consumer with `severity-threshold: high` set → fail-on-high behavior preserved.
- [ ] Workflow consumer with `severity-threshold: critical` set → fail-on-critical behavior preserved.
- [ ] SARIF still uploads to the Security tab in all cases.

## Security review

`rafter` agent reviewed the diff — verdict GO, no findings. The new `SEVERITY_THRESHOLD` env var passthrough uses the GitHub-recommended `env:` block pattern (not template interpolation into the script body); the new echo line is a static string; the `none` branch of the threshold-evaluation step already no-ops, so the default change has no logic regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)