### PR TITLE
fix(scan): honor .rafter.yml scan.exclude_paths on both engines (sable-yz0)

### DIFF
--- a/node/src/commands/agent/scan.ts
+++ b/node/src/commands/agent/scan.ts
@@ -17,6 +17,7 @@ import os from "os";
 import path from "path";
 import { fmt } from "../../utils/formatter.js";
 import { createRequire } from "module";
+import { minimatch } from "minimatch";
 
 const _require = createRequire(import.meta.url);
 const { version: CLI_VERSION } = _require("../../../package.json");
@@ -50,6 +51,70 @@ function loadBaselineEntries(): BaselineEntry[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Does `relPath` (forward-slash relative path) match an `exclude_paths`
+ * entry from `.rafter.yml`?
+ *
+ * sable-yz0 — single source of truth for `scan.exclude_paths` semantics
+ * across both scan engines and the staged / diff modes. Rules (any one
+ * matches → exclude):
+ *
+ *   1. Exact match: `relPath === pattern` (the pattern is the full file path)
+ *   2. Directory-prefix: `relPath` starts with `pattern + "/"` (the pattern
+ *      is a directory; everything under it is excluded). Trailing "/" on
+ *      the pattern is ignored — `scripts/` and `scripts` mean the same.
+ *   3. Dir-name anywhere: any segment of `relPath` equals `pattern` (preserves
+ *      the historical RegexScanner walker behavior — `node_modules` skips
+ *      `pkg/foo/node_modules/...` too).
+ *   4. Glob: if `pattern` contains `* ? [`, run it through minimatch with
+ *      `dot:true, matchBase:true`. Same defaults as `policyIgnoreToSuppressions`.
+ */
+function pathMatchesExcludePattern(relPath: string, pattern: string): boolean {
+  const rel = relPath.replace(/\\/g, "/");
+  const p = pattern.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (!p) return false;
+  if (rel === p) return true;
+  if (rel.startsWith(p + "/")) return true;
+  if (rel.split("/").includes(p)) return true;
+  if (/[*?[]/.test(p)) {
+    if (minimatch(rel, p, { dot: true, matchBase: true })) return true;
+    // Auto-anchor relative globs so `foo/**` matches anywhere in the tree.
+    if (!p.startsWith("/") && !p.startsWith("**")) {
+      if (minimatch(rel, "**/" + p, { dot: true })) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Strip findings whose file path matches any `scan.exclude_paths` entry.
+ * Called at the `scanDirectory` chokepoint so both the betterleaks and
+ * patterns engines get the same filter (and the same semantics).
+ *
+ * `scanRoot` is the absolute directory the scan was rooted at; finding
+ * paths are converted to scan-root-relative before matching, so users
+ * write `components/common/Mermaid.tsx` in their `.rafter.yml`, not the
+ * absolute path on the CI runner.
+ */
+function applyExcludePaths(
+  results: ScanResult[],
+  excludePaths: string[] | undefined,
+  scanRoot: string,
+): ScanResult[] {
+  if (!excludePaths || excludePaths.length === 0) return results;
+  const root = path.resolve(scanRoot).replace(/\\/g, "/");
+  return results.filter((r) => {
+    const abs = path.resolve(r.file).replace(/\\/g, "/");
+    let rel = abs;
+    if (abs === root) {
+      rel = "";
+    } else if (abs.startsWith(root + "/")) {
+      rel = abs.slice(root.length + 1);
+    }
+    return !excludePaths.some((pat) => pathMatchesExcludePattern(rel, pat));
+  });
 }
 
 function applyBaseline(results: ScanResult[], entries: BaselineEntry[]): ScanResult[] {
@@ -391,7 +456,11 @@ async function scanDiffFiles(
       allResults.push(...results);
     }
 
-    outputScanResults(applyBaseline(allResults, baselineEntries), opts, `files changed since ${ref}`, true, suppressions);
+    // sable-yz0 — honor scan.exclude_paths in --diff mode too (was previously
+    // dropped). Use the repo root as scanRoot so user-relative paths in
+    // .rafter.yml resolve consistently with the directory-scan behavior.
+    const filteredDiff = applyExcludePaths(allResults, scanCfg?.excludePaths, repoRoot);
+    outputScanResults(applyBaseline(filteredDiff, baselineEntries), opts, `files changed since ${ref}`, true, suppressions);
   } catch (error: any) {
     if (error.status === 128) {
       console.error("Error: Not in a git repository or invalid ref");
@@ -449,7 +518,9 @@ async function scanStagedFiles(
       allResults.push(...results);
     }
 
-    outputScanResults(applyBaseline(allResults, baselineEntries), opts, "staged files", true, suppressions);
+    // sable-yz0 — honor scan.exclude_paths in --staged mode too.
+    const filteredStaged = applyExcludePaths(allResults, scanCfg?.excludePaths, repoRoot);
+    outputScanResults(applyBaseline(filteredStaged, baselineEntries), opts, "staged files", true, suppressions);
   } catch (error: any) {
     if (error.status === 128) {
       console.error("Error: Not in a git repository");
@@ -530,25 +601,40 @@ async function scanDirectory(
   // respectGitignore default is true. The patterns engine honors it via
   // RegexScanner.scanDirectory; betterleaks honors it natively (gitleaks
   // ancestry — reads .gitignore unless --no-git is set).
+  let results: ScanResult[];
   if (engine === "betterleaks") {
     try {
       const bl = new BetterleaksScanner();
-      return await bl.scanDirectory(dirPath, { useGit: history ?? false });
+      results = await bl.scanDirectory(dirPath, { useGit: history ?? false });
     } catch (e) {
       console.error(fmt.warning("Betterleaks scan failed, falling back to patterns"));
       const scanner = new RegexScanner(scanCfg?.customPatterns);
-      return scanner.scanDirectory(dirPath, {
+      results = scanner.scanDirectory(dirPath, {
         excludePaths: scanCfg?.excludePaths,
         respectGitignore,
       });
     }
   } else {
     const scanner = new RegexScanner(scanCfg?.customPatterns);
-    return scanner.scanDirectory(dirPath, {
+    results = scanner.scanDirectory(dirPath, {
       excludePaths: scanCfg?.excludePaths,
       respectGitignore,
     });
   }
+  // sable-yz0 — post-filter by `.rafter.yml scan.exclude_paths`. Two bugs
+  // motivated this chokepoint:
+  //   1. The betterleaks happy-path above never received excludePaths,
+  //      so `auto`-engine scans (the default when betterleaks is on disk)
+  //      silently ignored user policy.
+  //   2. The patterns engine's walker only matches `excludePaths` entries
+  //      against single directory NAMES (`entry.name`), so a customer
+  //      writing `components/common/Mermaid.tsx` (file path) or
+  //      `supabase/migrations/foo.sql` (multi-segment path) got no
+  //      filtering at all.
+  // The post-filter applies the same path-aware semantics to BOTH engines
+  // (exact path, directory-prefix, dir-name-anywhere, glob via minimatch),
+  // catching whatever leaks through the walker-level optimization.
+  return applyExcludePaths(results, scanCfg?.excludePaths, dirPath);
 }
 
 /**

--- a/node/tests/scan-exclude-paths.test.ts
+++ b/node/tests/scan-exclude-paths.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for sable-yz0 — `rafter secrets` must honor
+ * `.rafter.yml scan.exclude_paths` on both the betterleaks and patterns
+ * engines, and across all entry shapes (bare dir name, dir with trailing
+ * slash, full file path, glob).
+ *
+ * Mirrors the customer's exact repro: plant a fake Stripe key in three
+ * excluded paths AND one non-excluded path, expect only the non-excluded
+ * one to fire (exit 1, single finding).
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { execSync, spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { randomBytes } from "crypto";
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const CLI_DIST = path.join(PROJECT_ROOT, "dist", "index.js");
+
+// Stripe-style key, split so this file doesn't trip its own scanner.
+const FAKE_STRIPE = "sk" + "_live_" + "1234567890abcdefghijklmn";
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI_DIST)) {
+    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "inherit" });
+  }
+});
+
+function setupRepro(): string {
+  const dir = path.join(
+    os.tmpdir(),
+    `rafter-exclude-test-${Date.now()}-${randomBytes(4).toString("hex")}`,
+  );
+  fs.mkdirSync(dir, { recursive: true });
+  execSync("git init -q", { cwd: dir });
+  fs.mkdirSync(path.join(dir, "scripts"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "components", "common"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "supabase", "migrations"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "safe"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "scripts", "dev.ts"), `// ${FAKE_STRIPE}\n`);
+  fs.writeFileSync(path.join(dir, "components", "common", "Mermaid.tsx"), `// ${FAKE_STRIPE}\n`);
+  fs.writeFileSync(
+    path.join(dir, "supabase", "migrations", "20250215000000_resend_setup.sql"),
+    `-- ${FAKE_STRIPE}\n`,
+  );
+  fs.writeFileSync(path.join(dir, "safe", "leaky.ts"), `// ${FAKE_STRIPE}\n`);
+  fs.writeFileSync(
+    path.join(dir, ".rafter.yml"),
+    [
+      "scan:",
+      "  exclude_paths:",
+      "    - scripts/",
+      "    - components/common/Mermaid.tsx",
+      "    - supabase/migrations/20250215000000_resend_setup.sql",
+      "",
+    ].join("\n"),
+  );
+  return dir;
+}
+
+function runCli(args: string[], cwd: string, homeDir: string) {
+  const r = spawnSync(process.execPath, [CLI_DIST, ...args], {
+    cwd,
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, HOME: homeDir, XDG_CONFIG_HOME: path.join(homeDir, ".config"), CI: "1" },
+  });
+  return { stdout: r.stdout || "", stderr: r.stderr || "", exitCode: r.status ?? 1 };
+}
+
+describe("rafter secrets — scan.exclude_paths (sable-yz0)", () => {
+  let repo: string;
+  let home: string;
+
+  beforeEach(() => {
+    repo = setupRepro();
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "rafter-exclude-home-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("patterns engine flags only the non-excluded path (the customer's repro)", () => {
+    const r = runCli(["secrets", ".", "--engine", "patterns", "--format", "json"], repo, home);
+    expect(r.exitCode).toBe(1);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file).sort();
+    // Exactly one file fires — safe/leaky.ts. None of the excluded paths.
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/safe\/leaky\.ts$/);
+    expect(files.some((f: string) => f.includes("scripts/dev.ts"))).toBe(false);
+    expect(files.some((f: string) => f.includes("Mermaid.tsx"))).toBe(false);
+    expect(files.some((f: string) => f.includes("resend_setup.sql"))).toBe(false);
+  });
+
+  it("auto engine matches patterns-engine output (regardless of which engine wins)", () => {
+    const r = runCli(["secrets", ".", "--format", "json"], repo, home);
+    expect(r.exitCode).toBe(1);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file).sort();
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/safe\/leaky\.ts$/);
+  });
+
+  it("dropping the exclude_paths block re-surfaces all four findings", () => {
+    fs.writeFileSync(path.join(repo, ".rafter.yml"), "");
+    const r = runCli(["secrets", ".", "--engine", "patterns", "--format", "json"], repo, home);
+    expect(r.exitCode).toBe(1);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file).sort();
+    expect(files).toHaveLength(4);
+  });
+
+  it("dir-name-anywhere semantics: bare `node_modules` excludes nested copies", () => {
+    fs.mkdirSync(path.join(repo, "pkg", "node_modules", "foo"), { recursive: true });
+    fs.writeFileSync(path.join(repo, "pkg", "node_modules", "foo", "leak.ts"), `// ${FAKE_STRIPE}\n`);
+    fs.writeFileSync(
+      path.join(repo, ".rafter.yml"),
+      "scan:\n  exclude_paths:\n    - node_modules\n",
+    );
+
+    const r = runCli(["secrets", ".", "--engine", "patterns", "--format", "json"], repo, home);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file);
+    expect(files.some((f: string) => f.includes("node_modules"))).toBe(false);
+    // safe/leaky.ts still fires since exclude_paths only has node_modules now
+    expect(files.some((f: string) => f.includes("safe/leaky.ts"))).toBe(true);
+  });
+
+  it("glob semantics: `**/*.sql` excludes every SQL file at any depth", () => {
+    fs.writeFileSync(
+      path.join(repo, ".rafter.yml"),
+      "scan:\n  exclude_paths:\n    - '**/*.sql'\n",
+    );
+    const r = runCli(["secrets", ".", "--engine", "patterns", "--format", "json"], repo, home);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file);
+    expect(files.some((f: string) => f.endsWith(".sql"))).toBe(false);
+  });
+});

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -1493,6 +1493,68 @@ def _scan_file(file_path: str, engine: str, custom_patterns=None) -> list[ScanRe
         return [r] if r.matches else []
 
 
+def _path_matches_exclude_pattern(rel_path: str, pattern: str) -> bool:
+    """Mirror of Node ``pathMatchesExcludePattern`` (sable-yz0).
+
+    Rules (any one matches → exclude):
+      1. Exact match: ``rel_path == pattern``.
+      2. Directory-prefix: ``rel_path`` starts with ``pattern + "/"``.
+         Trailing ``/`` on the pattern is ignored.
+      3. Dir-name anywhere: any segment of ``rel_path`` equals ``pattern``.
+         Preserves the RegexScanner walker's existing dir-name behavior.
+      4. Glob: if pattern has ``* ? [``, use fnmatch with auto-anchor
+         (try ``pattern`` and ``**/pattern``) — mirrors Node ``matchGlob``.
+    """
+    import fnmatch as _fnmatch
+    rel = rel_path.replace("\\", "/")
+    p = pattern.replace("\\", "/").rstrip("/")
+    if not p:
+        return False
+    if rel == p:
+        return True
+    if rel.startswith(p + "/"):
+        return True
+    if p in rel.split("/"):
+        return True
+    if any(c in p for c in "*?["):
+        if _fnmatch.fnmatch(rel, p):
+            return True
+        if not p.startswith("/") and not p.startswith("**"):
+            if _fnmatch.fnmatch(rel, "**/" + p) or _fnmatch.fnmatch(rel, "*/" + p):
+                return True
+    return False
+
+
+def _apply_exclude_paths(
+    results: list[ScanResult],
+    exclude_paths: list[str] | None,
+    scan_root: str,
+) -> list[ScanResult]:
+    """Strip findings whose path matches any ``scan.exclude_paths`` entry.
+
+    Chokepoint that fixes sable-yz0 across both scan engines AND the staged
+    / diff modes. See the Node ``applyExcludePaths`` docstring for the full
+    rationale — both engines previously bypassed the policy on the
+    happy-path, and the existing walker-level filter only matched
+    directory NAMES, missing every multi-segment path users wrote.
+    """
+    if not exclude_paths:
+        return results
+    root = os.path.abspath(scan_root).replace("\\", "/")
+    kept: list[ScanResult] = []
+    for r in results:
+        abs_p = os.path.abspath(r.file).replace("\\", "/")
+        if abs_p == root:
+            rel = ""
+        elif abs_p.startswith(root + "/"):
+            rel = abs_p[len(root) + 1 :]
+        else:
+            rel = abs_p
+        if not any(_path_matches_exclude_pattern(rel, pat) for pat in exclude_paths):
+            kept.append(r)
+    return kept
+
+
 def _scan_directory(
     dir_path: str,
     engine: str,
@@ -1511,13 +1573,15 @@ def _scan_directory(
         try:
             bl = BetterleaksScanner()
             results = bl.scan_directory(dir_path, use_git=history)
-            return [ScanResult(file=r.file, matches=r.matches) for r in results]
+            results = [ScanResult(file=r.file, matches=r.matches) for r in results]
         except Exception:
             scanner = RegexScanner(custom)
-            return scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
+            results = scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
     else:
         scanner = RegexScanner(custom)
-        return scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
+        results = scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
+    # sable-yz0 — post-filter chokepoint. See _apply_exclude_paths docstring.
+    return _apply_exclude_paths(results, exclude, dir_path)
 
 
 def _output_scan_results(

--- a/python/rafter_cli/commands/scan.py
+++ b/python/rafter_cli/commands/scan.py
@@ -107,6 +107,7 @@ def scan_local(
         _output_sarif,
         _watch_and_scan,
         _apply_baseline,
+        _apply_exclude_paths,
         _load_baseline_entries,
     )
     from ..core.config_manager import ConfigManager
@@ -164,6 +165,9 @@ def scan_local(
             resolved = os.path.join(repo_root, f)
             if os.path.isfile(resolved):
                 all_results.extend(_scan_file(resolved, eng, custom_patterns))
+        # sable-yz0 — honor scan.exclude_paths in --diff mode too.
+        exclude = scan_cfg.exclude_paths if scan_cfg else None
+        all_results = _apply_exclude_paths(all_results, exclude, repo_root)
         filtered = _apply_baseline(all_results, baseline_entries)
         _output_scan_results(filtered, json_output, quiet, f"files changed since {diff}", format=format, suppressions=suppressions)
         return
@@ -201,6 +205,9 @@ def scan_local(
             resolved = os.path.join(repo_root, f)
             if os.path.isfile(resolved):
                 all_results.extend(_scan_file(resolved, eng, custom_patterns))
+        # sable-yz0 — honor scan.exclude_paths in --staged mode too.
+        exclude = scan_cfg.exclude_paths if scan_cfg else None
+        all_results = _apply_exclude_paths(all_results, exclude, repo_root)
         filtered = _apply_baseline(all_results, baseline_entries)
         _output_scan_results(filtered, json_output, quiet, "staged files", format=format, suppressions=suppressions)
         return

--- a/python/tests/test_scan_exclude_paths.py
+++ b/python/tests/test_scan_exclude_paths.py
@@ -1,0 +1,146 @@
+"""Regression tests for sable-yz0 (Python parity).
+
+Three layers of coverage:
+
+1. ``_path_matches_exclude_pattern`` — the pure matching function.
+   Same semantics as Node ``pathMatchesExcludePattern``.
+2. ``_apply_exclude_paths`` — the chokepoint that turns a list of
+   ``ScanResult`` into a filtered list. This is what plugs into the
+   betterleaks + patterns engines and the staged / diff modes.
+3. ``_scan_directory`` end-to-end via the in-repo RegexScanner — proves
+   the chokepoint catches what the walker-level filter missed.
+
+We test the helpers directly (mirroring ``test_agent_init.py``) rather
+than subprocessing the CLI, so the suite runs in any environment that
+can import the package — CI installs the package via ``pip install -e``;
+local dev may not.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from rafter_cli.commands.agent import (
+    _apply_exclude_paths,
+    _path_matches_exclude_pattern,
+    _scan_directory,
+)
+from rafter_cli.core.pattern_engine import PatternMatch
+from rafter_cli.scanners.regex_scanner import ScanResult
+
+# Stripe-style key, split so this file doesn't trip its own scanner.
+FAKE_STRIPE = "sk" + "_live_" + "1234567890abcdefghijklmn"
+
+
+def _make_result(file_path: str) -> ScanResult:
+    """Build a minimal ScanResult with one fake match for filtering tests."""
+    from rafter_cli.core.pattern_engine import Pattern
+    p = Pattern(name="Test", regex="x", severity="high", description="t")
+    m = PatternMatch(pattern=p, match="x", line=1, column=1, redacted="x")
+    return ScanResult(file=file_path, matches=[m])
+
+
+class TestPathMatchesExcludePattern:
+    def test_exact_match(self):
+        assert _path_matches_exclude_pattern("components/common/Mermaid.tsx", "components/common/Mermaid.tsx")
+        assert not _path_matches_exclude_pattern("components/common/Other.tsx", "components/common/Mermaid.tsx")
+
+    def test_directory_prefix_no_slash(self):
+        assert _path_matches_exclude_pattern("scripts/dev.ts", "scripts")
+        assert _path_matches_exclude_pattern("scripts/sub/foo.ts", "scripts")
+        assert not _path_matches_exclude_pattern("scripted/foo.ts", "scripts")
+
+    def test_directory_prefix_trailing_slash(self):
+        assert _path_matches_exclude_pattern("scripts/dev.ts", "scripts/")
+        assert _path_matches_exclude_pattern("scripts/sub/foo.ts", "scripts/")
+
+    def test_dirname_anywhere(self):
+        """Bare name matches a dir at any depth — preserves the prior
+        RegexScanner walker behavior so users with `node_modules` keep
+        working for nested copies."""
+        assert _path_matches_exclude_pattern("pkg/node_modules/foo.ts", "node_modules")
+        assert not _path_matches_exclude_pattern("pkg/notnode_modules/foo.ts", "node_modules")
+
+    def test_glob_with_recursion(self):
+        assert _path_matches_exclude_pattern("supabase/migrations/foo.sql", "**/*.sql")
+        assert not _path_matches_exclude_pattern("supabase/migrations/foo.json", "**/*.sql")
+
+    def test_glob_extension_anywhere(self):
+        assert _path_matches_exclude_pattern("a/b/c/foo.snap", "*.snap")
+        assert _path_matches_exclude_pattern("foo.snap", "*.snap")
+
+    def test_empty_pattern_never_matches(self):
+        assert not _path_matches_exclude_pattern("anything", "")
+        assert not _path_matches_exclude_pattern("anything", "/")
+
+
+class TestApplyExcludePaths:
+    """Chokepoint filter — what plugs into both scan engines."""
+
+    def test_no_excludes_returns_unchanged(self):
+        results = [_make_result("/repo/a.ts"), _make_result("/repo/b.ts")]
+        assert _apply_exclude_paths(results, None, "/repo") == results
+        assert _apply_exclude_paths(results, [], "/repo") == results
+
+    def test_customer_repro(self, tmp_path):
+        """User's exact .rafter.yml — three excludes, one safe path."""
+        results = [
+            _make_result(str(tmp_path / "scripts" / "dev.ts")),
+            _make_result(str(tmp_path / "components" / "common" / "Mermaid.tsx")),
+            _make_result(str(tmp_path / "supabase" / "migrations" / "20250215000000_resend_setup.sql")),
+            _make_result(str(tmp_path / "safe" / "leaky.ts")),
+        ]
+        excludes = [
+            "scripts/",
+            "components/common/Mermaid.tsx",
+            "supabase/migrations/20250215000000_resend_setup.sql",
+        ]
+        kept = _apply_exclude_paths(results, excludes, str(tmp_path))
+        assert len(kept) == 1
+        assert kept[0].file.endswith("safe/leaky.ts")
+
+    def test_filter_resolves_relative_to_scan_root(self, tmp_path):
+        """A multi-segment exclude must match against the path relative
+        to scan_root, not the absolute path."""
+        results = [_make_result(str(tmp_path / "components" / "common" / "Mermaid.tsx"))]
+        assert _apply_exclude_paths(results, ["components/common/Mermaid.tsx"], str(tmp_path)) == []
+
+    def test_glob(self, tmp_path):
+        results = [
+            _make_result(str(tmp_path / "supabase" / "migrations" / "x.sql")),
+            _make_result(str(tmp_path / "safe.ts")),
+        ]
+        kept = _apply_exclude_paths(results, ["**/*.sql"], str(tmp_path))
+        assert len(kept) == 1
+        assert kept[0].file.endswith("safe.ts")
+
+
+class TestScanDirectoryEndToEnd:
+    """Plant real fake secrets, run _scan_directory, assert chokepoint filtered."""
+
+    def test_full_repro(self, tmp_path):
+        from rafter_cli.core.config_schema import ScanConfig
+
+        for sub in ("scripts", "components/common", "supabase/migrations", "safe"):
+            (tmp_path / sub).mkdir(parents=True)
+        (tmp_path / "scripts" / "dev.ts").write_text(f"// {FAKE_STRIPE}\n")
+        (tmp_path / "components" / "common" / "Mermaid.tsx").write_text(f"// {FAKE_STRIPE}\n")
+        (tmp_path / "supabase" / "migrations" / "20250215000000_resend_setup.sql").write_text(f"-- {FAKE_STRIPE}\n")
+        (tmp_path / "safe" / "leaky.ts").write_text(f"// {FAKE_STRIPE}\n")
+
+        scan_cfg = ScanConfig(
+            exclude_paths=[
+                "scripts/",
+                "components/common/Mermaid.tsx",
+                "supabase/migrations/20250215000000_resend_setup.sql",
+            ],
+            custom_patterns=[],
+            ignore=[],
+        )
+
+        results = _scan_directory(str(tmp_path), engine="patterns", scan_cfg=scan_cfg, respect_gitignore=False)
+        files = sorted(r.file for r in results)
+        assert len(files) == 1, f"expected only safe/leaky.ts, got: {files}"
+        assert files[0].endswith("safe/leaky.ts")


### PR DESCRIPTION
## Summary

Customer planted fake Stripe keys in three `scan.exclude_paths` entries AND a non-excluded path → all three got flagged. `exclude_paths` was silently dropped. Fix the two root causes in v0.8.3:

1. **`BetterleaksScanner.scanDirectory()` never received `excludePaths`** — only the patterns engine got it, and `auto` (the default) picks betterleaks when the binary is on disk.
2. **The patterns engine's walker only matched `excludePaths` entries against single directory NAMES** (`entry.name`) — multi-segment paths like `components/common/Mermaid.tsx` and `supabase/migrations/foo.sql` got no filtering.

Solution: a single `applyExcludePaths` / `_apply_exclude_paths` chokepoint after both engines (and the `--staged` / `--diff` modes), with path-aware semantics:

| Pattern form | Matches |
|---|---|
| `scripts/` or `scripts` | the `scripts` dir at root + everything under it; also any segment named `scripts` anywhere (preserves the historical dir-name-anywhere behavior so existing `node_modules` policies still cover nested copies) |
| `components/common/Mermaid.tsx` | exact file at that relative path |
| `**/*.sql` (any glob char) | minimatch (Node) / fnmatch (Python), with auto-anchor for relative globs |

## Customer's exact repro

```yaml
# .rafter.yml
scan:
  exclude_paths:
    - scripts/
    - components/common/Mermaid.tsx
    - supabase/migrations/20250215000000_resend_setup.sql
```

Plant a fake Stripe key in each excluded path + `safe/leaky.ts`. Run `rafter secrets .` on either engine. **Before:** all 4 flagged. **After:** only `safe/leaky.ts`. Verified locally on both `--engine patterns` and `--engine auto` (betterleaks).

## Tests

| Suite | Cases | Status |
|---|---|---|
| `node/tests/scan-exclude-paths.test.ts` (subprocess end-to-end) | 5 | Pass |
| `python/tests/test_scan_exclude_paths.py` (helpers + chokepoint + `_scan_directory` E2E) | 12 | Pass |
| `python/tests/test_agent_scan_history.py` + `test_agent_baseline.py` (regression) | 23 | Pass |
| `node/tests/baseline.test.ts` (regression) | 12 | Pass |

## Security review

`rafter` agent review — **PASS for merge, no critical/high findings.**

Two low-severity defense-in-depth observations tracked as the follow-up bead `sable-aem` (P3): cap pattern length at 512 chars in `policy-loader` to neutralize pathological minimatch/fnmatch input. Attacker model is local-only (need write access to `.rafter.yml`, at which point scanning is already neuterable), so impact is low and out of scope for this PR.

Two info-level notes:
- **Dir-name-anywhere is broad by design.** Bare entries like `src` or `tmp` drop findings under any matching segment in the tree — documented and intentional (back-compat with the historical `RegexScanner` walker). Worth surfacing in user-facing docs in a follow-up.
- **Findings outside `scanRoot` keep the absolute path.** Theoretical edge case — scanners produce in-root paths today; `path.resolve` canonicalizes `..` before the prefix check, so traversal can't sneak under `scanRoot`.

## Tracking

- Bead: `sable-yz0` (P0 bug, claimed by me)
- Sibling beads from the same customer triage:
  - `sable-s2t` (P1) — PR-comment formatter shows hashed `R-XXXXX` rule IDs instead of scanner-native names
  - `sable-5vo` (P1) — verify remote scanner (`rafter run` / `/api/static/scan`) honors `.rafter.yml scan.exclude_paths`
- Follow-up from rafter review: `sable-aem` (P3) — pattern-length cap

## What's still customer-blocking after this lands

- They need to **upgrade past v0.7.9** (currently ~2 weeks behind master). Patching to v0.8.4 (which will include this fix) unblocks the local-scan case.
- The remote-scan case still isn't tested; `sable-5vo` covers the verification path. If `rafter run` doesn't honor `.rafter.yml` either, the fallback is `rafter agent baseline` and we'll document it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)