### PR TITLE
feat: add JSON output for agent status

### DIFF
--- a/docs/proposals/auto-registration-presence-signaling.md
+++ b/docs/proposals/auto-registration-presence-signaling.md
@@ -157,7 +157,7 @@ at session start:
   "initialized": true,
   "risk_level": "moderate",
   "command_policy": "approve-dangerous",
-  "gitleaks_available": true,
+  "betterleaks_available": true,
   "hooks_installed": { "pre_tool_use": true, "post_tool_use": true },
   "project_policy": ".rafter.yml found",
   "last_scan": "2026-03-05T10:00:00Z",

--- a/node/src/commands/agent/status.ts
+++ b/node/src/commands/agent/status.ts
@@ -3,24 +3,41 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { execSync } from "child_process";
+import { fileURLToPath } from "url";
 import { getRafterDir, getAuditLogPath, getBinDir } from "../../core/config-defaults.js";
 import { AuditLogger } from "../../core/audit-logger.js";
 import { ConfigManager } from "../../core/config-manager.js";
 import { BinaryManager } from "../../utils/binary-manager.js";
 
+interface AgentStatusJson {
+  installed: boolean;
+  version: string;
+  agents_detected: string[];
+  hooks_installed: string[];
+  gitleaks_available: boolean;
+  config_path: string;
+  audit_log_path: string;
+}
+
 export function createStatusCommand(): Command {
   return new Command("status")
     .description("Show agent security status dashboard")
-    .action(async () => {
+    .option("--json", "Output status as JSON")
+    .action(async (opts: { json?: boolean }) => {
       const rafterDir = getRafterDir();
       const auditPath = getAuditLogPath();
       const home = os.homedir();
+      const configPath = path.join(rafterDir, "config.json");
+
+      if (opts.json) {
+        console.log(JSON.stringify(buildStatusJson(home, configPath, auditPath), null, 2));
+        return;
+      }
 
       console.log("Rafter Agent Status");
       console.log("=".repeat(50));
 
       // --- Config ---
-      const configPath = path.join(rafterDir, "config.json");
       if (fs.existsSync(configPath)) {
         try {
           const cfg = new ConfigManager().load();
@@ -179,4 +196,111 @@ export function createStatusCommand(): Command {
 
       console.log();
     });
+}
+
+function buildStatusJson(home: string, configPath: string, auditPath: string): AgentStatusJson {
+  return {
+    installed: fs.existsSync(configPath),
+    version: getPkgVersion(),
+    agents_detected: detectAgents(home),
+    hooks_installed: detectGitHooks(home),
+    gitleaks_available: isBetterleaksAvailable(),
+    config_path: formatHomePath(configPath, home),
+    audit_log_path: formatHomePath(auditPath, home),
+  };
+}
+
+function detectAgents(home: string): string[] {
+  const candidates: Array<[string, string]> = [
+    ["claude-code", path.join(home, ".claude")],
+    ["openclaw", path.join(home, ".openclaw")],
+    ["codex", path.join(home, ".codex")],
+    ["gemini", path.join(home, ".gemini")],
+    ["cursor", path.join(home, ".cursor")],
+    ["windsurf", path.join(home, ".codeium", "windsurf")],
+    ["continue", path.join(home, ".continue")],
+    ["aider", path.join(home, ".aider.conf.yml")],
+  ];
+  return candidates
+    .filter(([, p]) => fs.existsSync(p))
+    .map(([name]) => name);
+}
+
+function detectGitHooks(home: string): string[] {
+  const hooks = new Set<string>();
+  const specs: Array<[string, string]> = [
+    ["pre-commit", "Rafter Security Pre-Commit Hook"],
+    ["pre-push", "Rafter Security Pre-Push Hook"],
+  ];
+
+  for (const [hookName, marker] of specs) {
+    const globalHook = path.join(home, ".rafter", "git-hooks", hookName);
+    if (fileContains(globalHook, marker)) hooks.add(hookName);
+  }
+
+  try {
+    const gitDir = execSync("git rev-parse --git-dir", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+      timeout: 5000,
+    }).trim();
+    const hooksDir = path.resolve(gitDir, "hooks");
+    for (const [hookName, marker] of specs) {
+      if (fileContains(path.join(hooksDir, hookName), marker)) hooks.add(hookName);
+    }
+  } catch {
+    // Not in a git repository, or git unavailable.
+  }
+
+  return [...hooks].sort();
+}
+
+function isBetterleaksAvailable(): boolean {
+  const exeExt = process.platform === "win32" ? ".exe" : "";
+  const localBetterleaks = path.join(getBinDir(), `betterleaks${exeExt}`);
+  try {
+    execSync("betterleaks version", {
+      timeout: 5000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    if (fs.existsSync(localBetterleaks)) return true;
+    return Boolean(new BinaryManager().findLegacyGitleaks());
+  }
+}
+
+function fileContains(filePath: string, needle: string): boolean {
+  try {
+    return fs.readFileSync(filePath, "utf-8").includes(needle);
+  } catch {
+    return false;
+  }
+}
+
+function formatHomePath(filePath: string, home: string): string {
+  const relative = path.relative(home, filePath);
+  if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+    return path.join("~", relative).replace(/\\/g, "/");
+  }
+  return filePath;
+}
+
+function getPkgVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    let dir = path.dirname(__filename);
+    for (let i = 0; i < 6; i++) {
+      const candidate = path.join(dir, "package.json");
+      if (fs.existsSync(candidate)) {
+        const pkg = JSON.parse(fs.readFileSync(candidate, "utf-8"));
+        if (pkg.version) return pkg.version;
+      }
+      dir = path.dirname(dir);
+    }
+  } catch {
+    // fall through
+  }
+  return "unknown";
 }

--- a/node/src/commands/agent/status.ts
+++ b/node/src/commands/agent/status.ts
@@ -14,7 +14,7 @@ interface AgentStatusJson {
   version: string;
   agents_detected: string[];
   hooks_installed: string[];
-  gitleaks_available: boolean;
+  betterleaks_available: boolean;
   config_path: string;
   audit_log_path: string;
 }
@@ -204,7 +204,7 @@ function buildStatusJson(home: string, configPath: string, auditPath: string): A
     version: getPkgVersion(),
     agents_detected: detectAgents(home),
     hooks_installed: detectGitHooks(home),
-    gitleaks_available: isBetterleaksAvailable(),
+    betterleaks_available: isBetterleaksAvailable(),
     config_path: formatHomePath(configPath, home),
     audit_log_path: formatHomePath(auditPath, home),
   };

--- a/node/tests/agent-commands.test.ts
+++ b/node/tests/agent-commands.test.ts
@@ -665,6 +665,42 @@ describe("agent status", () => {
     expect(r.stdout).toContain("Total events:");
   });
 
+  it("outputs machine-readable JSON status", () => {
+    const r = runCli("agent status --json", home);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain("Rafter Agent Status");
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toMatchObject({
+      installed: false,
+      version: expect.any(String),
+      agents_detected: [],
+      gitleaks_available: expect.any(Boolean),
+      config_path: "~/.rafter/config.json",
+      audit_log_path: "~/.rafter/audit.jsonl",
+    });
+    expect(Array.isArray(payload.hooks_installed)).toBe(true);
+  });
+
+  it("reports detected agents and installed git hooks in JSON status", () => {
+    runCli("agent init --with-claude-code", home);
+    fs.mkdirSync(path.join(home, ".cursor"), { recursive: true });
+
+    const hooksDir = path.join(home, ".rafter", "git-hooks");
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hooksDir, "pre-commit"),
+      "#!/bin/sh\n# Rafter Security Pre-Commit Hook\n",
+      { mode: 0o755 },
+    );
+
+    const r = runCli("agent status --json", home);
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload.installed).toBe(true);
+    expect(payload.agents_detected).toEqual(expect.arrayContaining(["claude-code", "cursor"]));
+    expect(payload.hooks_installed).toContain("pre-commit");
+  });
+
   it("surfaces a legacy gitleaks install with an upgrade hint", () => {
     runCli("agent init", home);
     // Drop a fake legacy gitleaks binary in ~/.rafter/bin/gitleaks.

--- a/node/tests/agent-commands.test.ts
+++ b/node/tests/agent-commands.test.ts
@@ -674,7 +674,7 @@ describe("agent status", () => {
       installed: false,
       version: expect.any(String),
       agents_detected: [],
-      gitleaks_available: expect.any(Boolean),
+      betterleaks_available: expect.any(Boolean),
       config_path: "~/.rafter/config.json",
       audit_log_path: "~/.rafter/audit.jsonl",
     });

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -3111,7 +3111,7 @@ def _agent_status_json(config_path: Path, audit_path: Path) -> dict[str, Any]:
         "version": __version__,
         "agents_detected": _detect_agent_platforms(),
         "hooks_installed": _detect_git_hooks(),
-        "gitleaks_available": _betterleaks_available(),
+        "betterleaks_available": _betterleaks_available(),
         "config_path": _format_home_path(config_path),
         "audit_log_path": _format_home_path(audit_path),
     }

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -2951,18 +2951,24 @@ def update_betterleaks(
 # ── agent status ─────────────────────────────────────────────────────────
 
 @agent_app.command("status")
-def status():
+def status(
+    json_output: bool = typer.Option(False, "--json", help="Output status as JSON"),
+):
     """Show agent security status dashboard."""
     from ..core.config_schema import get_audit_log_path, get_rafter_dir
 
     rafter_dir = get_rafter_dir()
     audit_path = get_audit_log_path()
+    config_path = rafter_dir / "config.json"
+
+    if json_output:
+        print(json.dumps(_agent_status_json(config_path, audit_path), indent=2))
+        return
 
     print("Rafter Agent Status")
     print("=" * 50)
 
     # --- Config ---
-    config_path = rafter_dir / "config.json"
     if config_path.exists():
         try:
             cfg = ConfigManager().load()
@@ -3097,6 +3103,95 @@ def status():
         print("No events logged yet.")
 
     print()
+
+
+def _agent_status_json(config_path: Path, audit_path: Path) -> dict[str, Any]:
+    return {
+        "installed": config_path.exists(),
+        "version": __version__,
+        "agents_detected": _detect_agent_platforms(),
+        "hooks_installed": _detect_git_hooks(),
+        "gitleaks_available": _betterleaks_available(),
+        "config_path": _format_home_path(config_path),
+        "audit_log_path": _format_home_path(audit_path),
+    }
+
+
+def _detect_agent_platforms() -> list[str]:
+    home = Path.home()
+    candidates = [
+        ("claude-code", home / ".claude"),
+        ("openclaw", home / ".openclaw"),
+        ("codex", home / ".codex"),
+        ("gemini", home / ".gemini"),
+        ("cursor", home / ".cursor"),
+        ("windsurf", home / ".codeium" / "windsurf"),
+        ("continue", home / ".continue"),
+        ("aider", home / ".aider.conf.yml"),
+    ]
+    return [name for name, path in candidates if path.exists()]
+
+
+def _detect_git_hooks() -> list[str]:
+    hooks: set[str] = set()
+    specs = [
+        ("pre-commit", "Rafter Security Pre-Commit Hook"),
+        ("pre-push", "Rafter Security Pre-Push Hook"),
+    ]
+    home = Path.home()
+
+    for hook_name, marker in specs:
+        if _file_contains(home / ".rafter" / "git-hooks" / hook_name, marker):
+            hooks.add(hook_name)
+
+    try:
+        git_dir = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        ).stdout.strip()
+        hooks_dir = Path(git_dir).resolve() / "hooks"
+        for hook_name, marker in specs:
+            if _file_contains(hooks_dir / hook_name, marker):
+                hooks.add(hook_name)
+    except Exception:
+        pass
+
+    return sorted(hooks)
+
+
+def _betterleaks_available() -> bool:
+    bm = BinaryManager()
+    if shutil.which("betterleaks"):
+        try:
+            result = subprocess.run(
+                ["betterleaks", "version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return True
+        except Exception:
+            pass
+    return bm.get_betterleaks_path().exists() or bool(bm.find_legacy_gitleaks())
+
+
+def _file_contains(path: Path, needle: str) -> bool:
+    try:
+        return needle in path.read_text(encoding="utf-8")
+    except Exception:
+        return False
+
+
+def _format_home_path(path: Path) -> str:
+    home = Path.home()
+    try:
+        return f"~/{path.relative_to(home).as_posix()}"
+    except ValueError:
+        return str(path)
 
 
 # ── baseline ─────────────────────────────────────────────────────────

--- a/python/tests/test_agent_status.py
+++ b/python/tests/test_agent_status.py
@@ -24,7 +24,7 @@ class TestAgentStatusJson:
         assert isinstance(payload["version"], str)
         assert payload["agents_detected"] == []
         assert isinstance(payload["hooks_installed"], list)
-        assert isinstance(payload["gitleaks_available"], bool)
+        assert isinstance(payload["betterleaks_available"], bool)
         assert payload["config_path"] == "~/.rafter/config.json"
         assert payload["audit_log_path"] == "~/.rafter/audit.jsonl"
         assert "Rafter Agent Status" not in result.output

--- a/python/tests/test_agent_status.py
+++ b/python/tests/test_agent_status.py
@@ -1,0 +1,52 @@
+"""Tests for rafter agent status."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from rafter_cli.commands.agent import agent_app
+
+
+runner = CliRunner()
+
+
+class TestAgentStatusJson:
+    def test_outputs_machine_readable_json(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = runner.invoke(agent_app, ["status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["installed"] is False
+        assert isinstance(payload["version"], str)
+        assert payload["agents_detected"] == []
+        assert isinstance(payload["hooks_installed"], list)
+        assert isinstance(payload["gitleaks_available"], bool)
+        assert payload["config_path"] == "~/.rafter/config.json"
+        assert payload["audit_log_path"] == "~/.rafter/audit.jsonl"
+        assert "Rafter Agent Status" not in result.output
+
+    def test_reports_detected_agents_and_installed_git_hooks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        rafter_dir = tmp_path / ".rafter"
+        rafter_dir.mkdir()
+        (rafter_dir / "config.json").write_text("{}", encoding="utf-8")
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".cursor").mkdir()
+
+        hooks_dir = rafter_dir / "git-hooks"
+        hooks_dir.mkdir()
+        hook = hooks_dir / "pre-commit"
+        hook.write_text("#!/bin/sh\n# Rafter Security Pre-Commit Hook\n", encoding="utf-8")
+        hook.chmod(0o755)
+
+        result = runner.invoke(agent_app, ["status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["installed"] is True
+        assert {"claude-code", "cursor"}.issubset(set(payload["agents_detected"]))
+        assert "pre-commit" in payload["hooks_installed"]

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -809,6 +809,22 @@ With `--probe`, an additional `Claude Code (probe)` check appears as the last en
 
 Show agent security status dashboard. Displays config summary, installed integrations, audit log summary, and recent events.
 
+- `--json` — output machine-readable status JSON
+
+**JSON schema (`--json`):**
+
+```json
+{
+  "installed": true,
+  "version": "0.8.3",
+  "agents_detected": ["claude-code", "cursor"],
+  "hooks_installed": ["pre-commit"],
+  "gitleaks_available": true,
+  "config_path": "~/.rafter/config.json",
+  "audit_log_path": "~/.rafter/audit.jsonl"
+}
+```
+
 ### rafter agent update-betterleaks [OPTIONS]
 
 Update (or reinstall) the managed betterleaks binary.

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -819,7 +819,7 @@ Show agent security status dashboard. Displays config summary, installed integra
   "version": "0.8.3",
   "agents_detected": ["claude-code", "cursor"],
   "hooks_installed": ["pre-commit"],
-  "gitleaks_available": true,
+  "betterleaks_available": true,
   "config_path": "~/.rafter/config.json",
   "audit_log_path": "~/.rafter/audit.jsonl"
 }


### PR DESCRIPTION
## Summary
- add `rafter agent status --json` for Node and Python CLIs
- report installed state, version, detected agents, installed git hooks, scanner availability, and config/audit paths
- document the JSON schema in `shared-docs/CLI_SPEC.md`

Closes #30

## Tests
- `./node_modules/.bin/tsc -p tsconfig.json`
- `./node_modules/.bin/vitest run ./tests/agent-commands.test.ts -t "agent status"`
- `.venv/bin/python -m pytest tests/test_agent_status.py -q`