### PR TITLE
feat(policy): read backend's .rafter/config.yml + flat-shape compat (sable-c1c)

### DIFF
--- a/node/src/core/policy-loader.ts
+++ b/node/src/core/policy-loader.ts
@@ -50,17 +50,38 @@ export interface PolicyFile {
   docs?: PolicyDocEntry[];
 }
 
-const POLICY_FILENAMES = [".rafter.yml", ".rafter.yaml"];
+/**
+ * Policy file candidates, in precedence order.
+ *
+ * sable-c1c — the cloud scanner (rafter-backend) reads `.rafter/config.yml`
+ * (subdir + `config.yml`), while the CLI canonical is `.rafter.yml`. To
+ * unbreak customers writing either shape, the CLI now reads both
+ * indefinitely. Precedence: canonical dotfile first; backend file is the
+ * fallback. If both are present, the dotfile wins (canonical).
+ *
+ * Schema compatibility is handled separately in `mapPolicy` — top-level
+ * `exclude_paths` / `custom_patterns` (backend flat shape) is accepted
+ * alongside `scan.exclude_paths` / `scan.custom_patterns` (CLI nested).
+ */
+const POLICY_FILE_CANDIDATES: string[] = [
+  ".rafter.yml",
+  ".rafter.yaml",
+  path.join(".rafter", "config.yml"),
+  path.join(".rafter", "config.yaml"),
+];
 
 /**
- * Find a policy file by walking from cwd up to git root
+ * Find a policy file by walking from cwd up to git root.
+ *
+ * For each directory, check candidates in precedence order; the first hit
+ * wins. The walk only ascends — siblings are not considered.
  */
 export function findPolicyFile(): string | null {
   let dir = process.cwd();
   const root = getGitRoot() || path.parse(dir).root;
 
   while (true) {
-    for (const filename of POLICY_FILENAMES) {
+    for (const filename of POLICY_FILE_CANDIDATES) {
       const candidate = path.join(dir, filename);
       if (fs.existsSync(candidate)) {
         return candidate;
@@ -126,6 +147,23 @@ function mapPolicy(raw: Record<string, any>): PolicyFile {
         severity: p.severity || "high",
       }));
     }
+  }
+
+  // sable-c1c — backend flat-shape compat. rafter-backend reads
+  // exclude_paths / custom_patterns at the top level (no `scan:` nesting),
+  // so customers writing the backend shape get the same behavior locally.
+  // Nested form takes precedence if both are present in the same file.
+  if (!policy.scan?.excludePaths && Array.isArray(raw.exclude_paths)) {
+    policy.scan = policy.scan || {};
+    policy.scan.excludePaths = raw.exclude_paths;
+  }
+  if (!policy.scan?.customPatterns && Array.isArray(raw.custom_patterns)) {
+    policy.scan = policy.scan || {};
+    policy.scan.customPatterns = raw.custom_patterns.map((p: any) => ({
+      name: p.name,
+      regex: p.regex,
+      severity: p.severity || "high",
+    }));
   }
 
   if (Array.isArray(raw.ignore)) {
@@ -228,7 +266,11 @@ function deriveDocId(source: string, kind: "path" | "url"): string {
   return crypto.createHash("sha256").update(source).digest("hex").slice(0, 8);
 }
 
-const VALID_TOP_LEVEL_KEYS = new Set(["version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs"]);
+const VALID_TOP_LEVEL_KEYS = new Set([
+  "version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs",
+  // sable-c1c — backend flat-shape compat keys.
+  "exclude_paths", "custom_patterns",
+]);
 const VALID_RISK_LEVELS = new Set(["minimal", "moderate", "aggressive"]);
 const VALID_COMMAND_MODES = new Set(["allow-all", "approve-dangerous", "deny-list"]);
 const VALID_LOG_LEVELS = new Set(["debug", "info", "warn", "error"]);

--- a/node/tests/policy-loader.test.ts
+++ b/node/tests/policy-loader.test.ts
@@ -60,6 +60,89 @@ describe("Policy file parsing (via .rafter.yml)", () => {
     expect(found).toBe(path.join(tmpDir, ".rafter.yaml"));
   });
 
+  // sable-c1c — read backend's file path too (.rafter/config.yml), and
+  // accept its flat-shape schema (exclude_paths at top level).
+  describe("backend file-path + schema compat (sable-c1c)", () => {
+    it("finds .rafter/config.yml as a fallback when no dotfile exists", async () => {
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(path.join(tmpDir, ".rafter", "config.yml"), "version: '1'\n");
+      const found = await findPolicyFresh();
+      expect(found).toBe(path.join(tmpDir, ".rafter", "config.yml"));
+    });
+
+    it("finds .rafter/config.yaml as a fallback (alternate extension)", async () => {
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(path.join(tmpDir, ".rafter", "config.yaml"), "version: '1'\n");
+      const found = await findPolicyFresh();
+      expect(found).toBe(path.join(tmpDir, ".rafter", "config.yaml"));
+    });
+
+    it("dotfile wins when both .rafter.yml and .rafter/config.yml exist", async () => {
+      fs.writeFileSync(path.join(tmpDir, ".rafter.yml"), "version: 'dot'\n");
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(path.join(tmpDir, ".rafter", "config.yml"), "version: 'subdir'\n");
+      const found = await findPolicyFresh();
+      expect(found).toBe(path.join(tmpDir, ".rafter.yml"));
+      const policy = await loadPolicyFresh();
+      expect(policy?.version).toBe("dot");
+    });
+
+    it("accepts top-level exclude_paths (backend flat shape) from .rafter/config.yml", async () => {
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter", "config.yml"),
+        "exclude_paths:\n  - scripts/\n  - components/common/Mermaid.tsx\n",
+      );
+      const policy = await loadPolicyFresh();
+      expect(policy?.scan?.excludePaths).toEqual([
+        "scripts/",
+        "components/common/Mermaid.tsx",
+      ]);
+    });
+
+    it("accepts top-level custom_patterns (backend flat shape)", async () => {
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter", "config.yml"),
+        "custom_patterns:\n  - name: Foo\n    regex: 'foo-[a-z0-9]+'\n    severity: high\n",
+      );
+      const policy = await loadPolicyFresh();
+      expect(policy?.scan?.customPatterns?.[0]?.name).toBe("Foo");
+    });
+
+    it("accepts the backend flat shape inside a .rafter.yml dotfile too", async () => {
+      // A customer who used to write .rafter/config.yml may copy the same
+      // shape into a .rafter.yml dotfile — should still work.
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter.yml"),
+        "exclude_paths:\n  - tests/**\n",
+      );
+      const policy = await loadPolicyFresh();
+      expect(policy?.scan?.excludePaths).toEqual(["tests/**"]);
+    });
+
+    it("nested scan.exclude_paths wins over top-level when both are present", async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter.yml"),
+        "exclude_paths:\n  - flat\nscan:\n  exclude_paths:\n    - nested\n",
+      );
+      const policy = await loadPolicyFresh();
+      expect(policy?.scan?.excludePaths).toEqual(["nested"]);
+    });
+
+    it("does not warn on top-level exclude_paths / custom_patterns (compat keys)", async () => {
+      const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter.yml"),
+        "exclude_paths:\n  - foo/\ncustom_patterns: []\n",
+      );
+      await loadPolicyFresh();
+      const warnings = warnSpy.mock.calls.flat().join("\n");
+      expect(warnings).not.toMatch(/Unknown policy key "exclude_paths"/);
+      expect(warnings).not.toMatch(/Unknown policy key "custom_patterns"/);
+    });
+  });
+
   it("parses valid policy with all sections", async () => {
     const yml = `
 version: "1"

--- a/python/rafter_cli/core/policy_loader.py
+++ b/python/rafter_cli/core/policy_loader.py
@@ -9,20 +9,41 @@ from pathlib import Path
 from ..utils.git import get_git_root
 
 
+#: Policy file candidates, in precedence order (sable-c1c).
+#:
+#: The cloud scanner (rafter-backend) reads ``.rafter/config.yml`` (subdir
+#: + ``config.yml``), while the CLI canonical is ``.rafter.yml``. The CLI
+#: reads both indefinitely so customers writing either shape get the same
+#: behavior locally. Canonical dotfile takes precedence; backend file is
+#: the fallback. Schema compatibility (top-level ``exclude_paths`` /
+#: ``custom_patterns`` vs nested ``scan.*``) is handled in ``_map_policy``.
+POLICY_FILE_CANDIDATES: list[Path] = [
+    Path(".rafter.yml"),
+    Path(".rafter.yaml"),
+    Path(".rafter") / "config.yml",
+    Path(".rafter") / "config.yaml",
+]
+
+# Back-compat alias for code outside this module that imported the previous
+# constant. Resolves to the canonical-dotfile names only (subset).
 POLICY_FILENAMES = [".rafter.yml", ".rafter.yaml"]
 _KNOWN_DOC_KEYS = {"id", "path", "url", "description", "tags", "cache"}
 
 
 def find_policy_file() -> Path | None:
-    """Walk from cwd up to git root looking for a policy file."""
+    """Walk from cwd up to git root looking for a policy file.
+
+    Returns the first candidate that exists, in the precedence order
+    declared by ``POLICY_FILE_CANDIDATES``.
+    """
     cwd = Path.cwd()
     root = get_git_root()
     stop = Path(root) if root else cwd.anchor and Path(cwd.anchor)
 
     current = cwd
     while True:
-        for name in POLICY_FILENAMES:
-            candidate = current / name
+        for candidate_rel in POLICY_FILE_CANDIDATES:
+            candidate = current / candidate_rel
             if candidate.exists():
                 return candidate
         parent = current.parent
@@ -83,6 +104,22 @@ def _map_policy(raw: dict) -> dict:
             policy["scan"]["custom_patterns"] = [
                 {"name": p.get("name", ""), "regex": p.get("regex", ""), "severity": p.get("severity", "high")}
                 for p in scan["custom_patterns"]
+            ]
+
+    # sable-c1c — backend flat-shape compat. rafter-backend reads
+    # exclude_paths / custom_patterns at the top level (no `scan:` nesting),
+    # so customers writing the backend shape get the same behavior locally.
+    # Nested form takes precedence if both are present in the same file.
+    if "scan" not in policy or not policy["scan"].get("exclude_paths"):
+        if isinstance(raw.get("exclude_paths"), list):
+            policy.setdefault("scan", {})
+            policy["scan"]["exclude_paths"] = raw["exclude_paths"]
+    if "scan" not in policy or not policy["scan"].get("custom_patterns"):
+        if isinstance(raw.get("custom_patterns"), list):
+            policy.setdefault("scan", {})
+            policy["scan"]["custom_patterns"] = [
+                {"name": p.get("name", ""), "regex": p.get("regex", ""), "severity": p.get("severity", "high")}
+                for p in raw["custom_patterns"]
             ]
 
     ignore = raw.get("ignore")
@@ -179,7 +216,11 @@ def _derive_doc_id(source: str, kind: str) -> str:
     return hashlib.sha256(source.encode("utf-8")).hexdigest()[:8]
 
 
-_VALID_TOP_LEVEL_KEYS = {"version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs"}
+_VALID_TOP_LEVEL_KEYS = {
+    "version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs",
+    # sable-c1c — backend flat-shape compat keys.
+    "exclude_paths", "custom_patterns",
+}
 _VALID_RISK_LEVELS = {"minimal", "moderate", "aggressive"}
 _VALID_COMMAND_MODES = {"allow-all", "approve-dangerous", "deny-list"}
 _VALID_LOG_LEVELS = {"debug", "info", "warn", "error"}

--- a/python/tests/test_policy.py
+++ b/python/tests/test_policy.py
@@ -4,7 +4,68 @@ from __future__ import annotations
 import json
 
 from rafter_cli.commands.policy import _generate_claude_config
-from rafter_cli.core.policy_loader import _validate_policy, _map_policy
+from rafter_cli.core.policy_loader import _validate_policy, _map_policy, find_policy_file, load_policy
+
+
+class TestBackendCompat:
+    """sable-c1c — CLI reads .rafter/config.yml indefinitely and accepts
+    backend's flat-shape schema alongside the canonical nested form."""
+
+    def test_finds_subdir_config_yml_as_fallback(self, tmp_path, monkeypatch):
+        import subprocess
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        (tmp_path / ".rafter").mkdir()
+        (tmp_path / ".rafter" / "config.yml").write_text("version: '1'\n")
+        monkeypatch.chdir(tmp_path)
+        assert find_policy_file() == tmp_path / ".rafter" / "config.yml"
+
+    def test_finds_subdir_config_yaml_as_fallback(self, tmp_path, monkeypatch):
+        import subprocess
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        (tmp_path / ".rafter").mkdir()
+        (tmp_path / ".rafter" / "config.yaml").write_text("version: '1'\n")
+        monkeypatch.chdir(tmp_path)
+        assert find_policy_file() == tmp_path / ".rafter" / "config.yaml"
+
+    def test_dotfile_wins_over_subdir(self, tmp_path, monkeypatch):
+        import subprocess
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        (tmp_path / ".rafter.yml").write_text("version: 'dot'\n")
+        (tmp_path / ".rafter").mkdir()
+        (tmp_path / ".rafter" / "config.yml").write_text("version: 'subdir'\n")
+        monkeypatch.chdir(tmp_path)
+        assert find_policy_file() == tmp_path / ".rafter.yml"
+        policy = load_policy()
+        assert policy["version"] == "dot"
+
+    def test_top_level_exclude_paths_accepted(self):
+        raw = {"exclude_paths": ["scripts/", "components/common/Mermaid.tsx"]}
+        result = _validate_policy(_map_policy(raw), raw)
+        assert result["scan"]["exclude_paths"] == ["scripts/", "components/common/Mermaid.tsx"]
+
+    def test_top_level_custom_patterns_accepted(self):
+        raw = {
+            "custom_patterns": [
+                {"name": "Foo", "regex": "foo-[a-z0-9]+", "severity": "high"},
+            ],
+        }
+        result = _validate_policy(_map_policy(raw), raw)
+        assert result["scan"]["custom_patterns"][0]["name"] == "Foo"
+
+    def test_nested_wins_over_top_level(self):
+        raw = {
+            "exclude_paths": ["flat"],
+            "scan": {"exclude_paths": ["nested"]},
+        }
+        result = _validate_policy(_map_policy(raw), raw)
+        assert result["scan"]["exclude_paths"] == ["nested"]
+
+    def test_no_warnings_for_compat_keys(self, capsys):
+        raw = {"exclude_paths": ["foo/"], "custom_patterns": []}
+        _validate_policy(_map_policy(raw), raw)
+        err = capsys.readouterr().err
+        assert "exclude_paths" not in err
+        assert "custom_patterns" not in err
 
 
 class TestGenerateClaudeConfig:


### PR DESCRIPTION
## Summary

Backend triage (hq-4tcey) confirmed `rafter-backend` reads policy at **`.rafter/config.yml`** (subdir + `config.yml`) with `exclude_paths` / `custom_patterns` **flat at the top level**, while the CLI canonical is `.rafter.yml` with `scan.*` **nested**. Customers writing either shape get honored by only one tool — exactly what bit the recent customer (`.rafter.yml` worked locally after #152, silently no-op'd remotely).

This PR is the CLI half of the bilateral fix:

- **CLI now reads `.rafter/config.yml` indefinitely** (no deprecation — backend's file path stays a first-class location).
- **CLI accepts the backend flat shape** (top-level `exclude_paths` / `custom_patterns`) alongside the canonical nested form, in **either** file.

Backend pairs this with their own work to add `.rafter.yml` fallback + `scan.*` schema compat. Once both ship, customers can write either file with either shape and both tools honor it.

## Precedence

For each directory in the walk-up from cwd:

```
.rafter.yml   →  .rafter.yaml   →  .rafter/config.yml   →  .rafter/config.yaml
   (canonical dotfile wins if multiple files exist)
```

Within a single file, nested `scan.exclude_paths` wins over top-level `exclude_paths` if both are present (no merge — explicit precedence keeps debugging straightforward).

## What's accepted in each shape

| Shape | Where it works | Notes |
|---|---|---|
| `scan.exclude_paths` (nested) | `.rafter.yml`, `.rafter/config.yml` | CLI canonical |
| `exclude_paths` (top-level) | `.rafter.yml`, `.rafter/config.yml` | Backend flat-shape compat |
| `scan.custom_patterns` (nested) | both | CLI canonical |
| `custom_patterns` (top-level) | both | Backend flat-shape compat |

Top-level `exclude_paths` and `custom_patterns` are added to `VALID_TOP_LEVEL_KEYS` so they no longer trigger `Warning: Unknown policy key …` on validate.

## Tests

| Suite | Cases | Status |
|---|---|---|
| `node/tests/policy-loader.test.ts` (new sable-c1c block) | 8 | Pass |
| `python/tests/test_policy.py::TestBackendCompat` | 7 | Pass |
| `node/tests/policy-{loader,merge,validation}.test.ts` (regression) | 40 | Pass |
| `python/tests/test_policy.py` full suite (regression) | 25 | Pass |

Coverage hits: subdir-only discovery, both `.yml` and `.yaml` extensions, dotfile-wins precedence, top-level schema accepted on both file paths, nested-wins-on-collision, no warnings for compat keys.

## Pairs with

- **#152 (sable-yz0)** — `scan.exclude_paths` honored on both engines + multi-segment path semantics. Without #152, the policy is *loaded* but the scanners still ignore parts of it. With both PRs, the customer's flow works end-to-end on local scans.
- **Backend's `.rafter.yml` fallback** (hq-XXXX on their side) — completes the bilateral alignment for remote scans.

## Tracking

- Bead: `sable-c1c` (P1 feature, claimed by me)
- Sibling beads:
  - `sable-yz0` (P0 bug) — `scan.exclude_paths` enforcement (PR #152, pending merge)
  - `sable-s2t` (P1) — rerouted: R-XXXXX hashing lives in `github-action` / `juno`, not `rafter-backend`
  - `sable-5vo` (P1) — closed: backend confirmed which file/schema they honor; this PR is the answer
  - `sable-r9h` (P3) — follow-up: pattern-length cap for ReDoS defense-in-depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)