### PR TITLE
chore(release): bump to v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-06-01
+
+### Fixed
+- **`rafter secrets` now honors `.rafter.yml scan.exclude_paths` on both engines** (#152, sable-yz0). Customer report: planting fake secrets in three `scan.exclude_paths` entries AND a non-excluded path → all three got flagged, `exclude_paths` silently ignored. Two root causes: (1) `BetterleaksScanner.scanDirectory()` never received `excludePaths`, so the `auto`-engine happy-path (the default when the binary is on disk) silently dropped customer policy; (2) the patterns engine's walker only matched entries against single directory NAMES (`entry.name`), so multi-segment paths like `components/common/Mermaid.tsx` got no filtering at all. Fix: post-filter chokepoint after both engines (and `--staged` / `--diff` modes) with path-aware semantics — exact path, directory-prefix (trailing `/` normalized), dir-name-anywhere (preserves the historical walker behavior for `node_modules`-style entries), and globs via minimatch (Node) / fnmatch (Python). Customer's exact repro now passes on both engines.
+
+### Changed
+- **CLI reads `.rafter/config.yml` indefinitely + accepts backend's flat-shape schema** (#154, sable-c1c). The cloud scanner (`rafter-backend`) reads policy at `.rafter/config.yml` (subdir + `config.yml`) with `exclude_paths` / `custom_patterns` flat at the top level, while the CLI canonical is `.rafter.yml` with `scan.*` nested. Customers writing either shape used to get honored by only one tool. CLI now reads all four candidates in precedence order (`.rafter.yml` → `.rafter.yaml` → `.rafter/config.yml` → `.rafter/config.yaml`) and accepts both schemas in either file — nested `scan.*` wins over top-level on collision. No deprecation; backend's file path stays a first-class location. Backend pairs this with `.rafter.yml` fallback + `scan.*` schema compat on their side to complete the bilateral alignment.
+
+### Added
+- **Hermes platform support** (#151, sable-gyw). `rafter agent init --with-hermes` merges the Rafter MCP server into `~/.hermes/config.yaml` under `mcp_servers.rafter` (snake_case, distinct from Cursor/Windsurf's `mcpServers` camelCase). Existing servers and other top-level YAML keys are preserved. Recipe at `recipes/hermes.md`. MCP-only v0 — hook surface deferred pending Hermes documenting one, mirroring how Gemini and Continue.dev were initially shipped. Brings the supported-platforms list to nine.
+- **`rafter agent status --json`** (#153). Reports installed state, version, detected agents, installed git hooks, scanner availability, and config / audit paths. Schema documented in `shared-docs/CLI_SPEC.md`.
+
 ## [0.8.3] - 2026-05-31
 
 ### Changed

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "type": "module",
   "repository": {
     "type": "git",

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.3
+version: 0.8.4
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.8.3"
+version = "0.8.4"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.3
+version: 0.8.4
 homepage: https://rafter.so
 metadata:
   openclaw:


### PR DESCRIPTION
## Summary

Cuts **v0.8.4**. Headline impact: the customer's `.rafter.yml` triage flow is now fully working on local scans — #152 makes `scan.exclude_paths` enforcement actually fire on the default betterleaks code path, and #154 lets either the CLI dotfile or backend subdir file work with either schema. Bilateral remote-scan alignment still depends on `rafter-backend`'s matching work (in flight).

## How this ships

Standard prod-branch flow (same as v0.8.3):

1. This PR merges to `main`.
2. `main` → `prod` PR opened; merge triggers `publish.yaml`.
3. `publish.yaml` fires: tests → npm Trusted Publishing → PyPI (`--skip-existing`) → ClawHub → GitHub Release tagged `v0.8.4` → smoke-tests against the live registries.
4. The `v0.8.4` GitHub Release tag republishes the root `/action.yml` listing entry on the Marketplace.

## Contents of this release (since v0.8.3)

### Fixed
- **#152 (sable-yz0) — `rafter secrets` honors `.rafter.yml scan.exclude_paths` on both engines.** Customer-reported P0. Betterleaks engine no longer silently drops `exclude_paths`; pattern semantics now cover multi-segment paths (file paths, dir prefixes, dir-name-anywhere, globs) instead of only single dir NAMES.

### Changed
- **#154 (sable-c1c) — CLI reads `.rafter/config.yml` indefinitely + accepts backend's flat-shape schema.** Walks all four candidates in precedence order (`.rafter.yml` → `.rafter.yaml` → `.rafter/config.yml` → `.rafter/config.yaml`); accepts both nested `scan.*` and top-level `exclude_paths` / `custom_patterns` in either file, with nested winning on collision.

### Added
- **#151 (sable-gyw) — Hermes platform support.** Ninth supported platform. `rafter agent init --with-hermes` merges Rafter into `~/.hermes/config.yaml`. MCP-only v0; hooks deferred.
- **#153 — `rafter agent status --json`.** Reports installed state, version, detected agents, hook installations, scanner availability, config / audit paths. Schema in `shared-docs/CLI_SPEC.md`.

## Pre-flight expected to be green

- `validate-release.yml` (push-to-main trigger after this merges) — verifies all four version sites at `0.8.4`: `node/package.json`, `python/pyproject.toml`, both `rafter-security-skill.md` frontmatter copies. CHANGELOG entry present.

## Post-merge verification plan

Same as v0.8.3 — Phase 1 + 2, autonomous, ~5 min:
- npm + PyPI registry index for `0.8.4`
- `gh release view v0.8.4` confirms release rendered
- Fresh install on both runtimes → `rafter --version` reports `0.8.4`
- Fixture scan via `--engine patterns` detects fake AWS Access Key, exit 1
- For 0.8.4-specific verification: plant fake secret in `scripts/` + `safe/leaky.ts` with `.rafter.yml scan.exclude_paths: [scripts/]` → exit 1 with only `safe/leaky.ts` reported (proves #152). Confirm `.rafter/config.yml` with top-level `exclude_paths: [scripts/]` produces the same result (proves #154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)