### PR TITLE
feat(agent): surface Hermes in verify/status/list detection (sable-gyw)

### DIFF
--- a/node/src/commands/agent/components.ts
+++ b/node/src/commands/agent/components.ts
@@ -882,6 +882,61 @@ function continueMcp(): ComponentSpec {
 }
 
 /**
+ * Hermes MCP server entry (~/.hermes/config.yaml).
+ *
+ * Hermes uses a YAML config with a snake_case `mcp_servers:` block (unlike the
+ * camelCase `mcpServers` of Cursor/Windsurf/Claude Code). Per-server schema is
+ * {command, args, env}. MCP-only v0 — hooks deferred pending confirmation
+ * Hermes exposes a hook surface (sable-gyw).
+ */
+function hermesMcp(): ComponentSpec {
+  const home = os.homedir();
+  const configPath = path.join(home, ".hermes", "config.yaml");
+
+  const readYaml = (): Record<string, any> => {
+    if (!fs.existsSync(configPath)) return {};
+    try {
+      const loaded = yaml.load(fs.readFileSync(configPath, "utf-8"));
+      if (loaded && typeof loaded === "object" && !Array.isArray(loaded)) {
+        return loaded as Record<string, any>;
+      }
+    } catch { /* unparseable — treat as empty */ }
+    return {};
+  };
+
+  return {
+    id: "hermes.mcp",
+    platform: "hermes",
+    kind: "mcp",
+    description: "Hermes MCP server entry (~/.hermes/config.yaml)",
+    detectDir: path.join(home, ".hermes"),
+    path: configPath,
+    isInstalled: () => {
+      const servers = readYaml().mcp_servers;
+      return !!(servers && typeof servers === "object" && !Array.isArray(servers) && servers.rafter);
+    },
+    install: () => {
+      const dir = path.join(home, ".hermes");
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const cfg = readYaml();
+      if (!cfg.mcp_servers || typeof cfg.mcp_servers !== "object" || Array.isArray(cfg.mcp_servers)) {
+        cfg.mcp_servers = {};
+      }
+      cfg.mcp_servers.rafter = { ...RAFTER_MCP_ENTRY };
+      fs.writeFileSync(configPath, yaml.dump(cfg), "utf-8");
+    },
+    uninstall: () => {
+      if (!fs.existsSync(configPath)) return;
+      const cfg = readYaml();
+      const servers = cfg.mcp_servers;
+      if (servers && typeof servers === "object" && !Array.isArray(servers) && removeKey(servers, "rafter")) {
+        fs.writeFileSync(configPath, yaml.dump(cfg), "utf-8");
+      }
+    },
+  };
+}
+
+/**
  * Aider read-only context: writes RAFTER.md and adds it to .aider.conf.yml `read:`.
  *
  * Replaces the prior `aider.mcp` component, pruned in rf-du2o because Aider
@@ -1021,6 +1076,7 @@ export function getComponentRegistry(): ComponentSpec[] {
       continueRules(),
       continueMcp(),
       aiderRead(),
+      hermesMcp(),
       openclawSkill(),
     ];
   }

--- a/node/src/commands/agent/status.ts
+++ b/node/src/commands/agent/status.ts
@@ -128,6 +128,7 @@ export function createStatusCommand(): Command {
         { name: "Cursor", flag: "--with-cursor", configDir: path.join(home, ".cursor"), configFile: path.join(home, ".cursor", "mcp.json"), needle: "rafter" },
         { name: "Windsurf", flag: "--with-windsurf", configDir: path.join(home, ".codeium", "windsurf"), configFile: path.join(home, ".codeium", "windsurf", "mcp_config.json"), needle: "rafter" },
         { name: "Continue.dev", flag: "--with-continue", configDir: path.join(home, ".continue"), configFile: path.join(home, ".continue", "config.json"), needle: "rafter" },
+        { name: "Hermes", flag: "--with-hermes", configDir: path.join(home, ".hermes"), configFile: path.join(home, ".hermes", "config.yaml"), needle: "rafter" },
       ];
 
       for (const agent of mcpAgents) {
@@ -220,6 +221,7 @@ function detectAgents(home: string): string[] {
     ["windsurf", path.join(home, ".codeium", "windsurf")],
     ["continue", path.join(home, ".continue")],
     ["aider", path.join(home, ".aider.conf.yml")],
+    ["hermes", path.join(home, ".hermes")],
   ];
   return candidates
     .filter(([, p]) => fs.existsSync(p))

--- a/node/src/commands/agent/verify.ts
+++ b/node/src/commands/agent/verify.ts
@@ -303,6 +303,37 @@ function checkAider(): CheckResult {
   return { name, passed: true, detail: `RAFTER.md + read: entry in ${conf}` };
 }
 
+function checkHermes(): CheckResult {
+  // Hermes uses ~/.hermes/config.yaml with a snake_case `mcp_servers:` block
+  // (MCP-only v0 — no hook surface confirmed yet; sable-gyw).
+  const name = "Hermes";
+  const homeDir = os.homedir();
+  const hermesDir = path.join(homeDir, ".hermes");
+
+  if (!fs.existsSync(hermesDir)) {
+    return { name, passed: false, optional: true, detail: `Not detected — run 'rafter agent init --with-hermes' to enable` };
+  }
+
+  const configPath = path.join(hermesDir, "config.yaml");
+  if (!fs.existsSync(configPath)) {
+    return { name, passed: false, optional: true, detail: `Config not found: ${configPath} — run 'rafter agent init --with-hermes'` };
+  }
+
+  try {
+    const loaded = yaml.load(fs.readFileSync(configPath, "utf-8"));
+    const servers = (loaded && typeof loaded === "object" && !Array.isArray(loaded))
+      ? (loaded as Record<string, any>).mcp_servers
+      : undefined;
+    const hasRafterMcp = servers && typeof servers === "object" && servers.rafter != null;
+    if (!hasRafterMcp) {
+      return { name, passed: false, optional: true, detail: "Rafter MCP server not configured — run 'rafter agent init --with-hermes'" };
+    }
+    return { name, passed: true, detail: "MCP server configured" };
+  } catch (e) {
+    return { name, passed: false, optional: true, detail: `Cannot read config: ${e}` };
+  }
+}
+
 /**
  * Probe the Claude Code hook integration end-to-end (rf-65zg).
  *
@@ -406,6 +437,7 @@ export function createVerifyCommand(): Command {
         checkWindsurf(),
         checkContinueDev(),
         checkAider(),
+        checkHermes(),
       ];
 
       if (opts.probe) {

--- a/node/tests/agent-init-hermes.test.ts
+++ b/node/tests/agent-init-hermes.test.ts
@@ -150,3 +150,71 @@ describe("agent init --with-hermes", () => {
     expect(fs.existsSync(path.join(home, ".hermes", "config.yaml"))).toBe(false);
   });
 });
+
+describe("Hermes detection in verify / status / list", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = createTempHome();
+    fs.mkdirSync(path.join(home, ".hermes"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("agent status reports Hermes installed after init", () => {
+    runCli(["agent", "init", "--with-hermes"], home);
+    const r = runCli(["agent", "status"], home);
+    expect(r.stdout + r.stderr).toMatch(/Hermes:\s+MCP installed/);
+  });
+
+  it("agent status reports detected-but-missing when ~/.hermes exists without rafter", () => {
+    const r = runCli(["agent", "status"], home);
+    expect(r.stdout + r.stderr).toMatch(/Hermes:\s+detected but MCP missing/);
+  });
+
+  it("agent status --json includes hermes in agents_detected", () => {
+    const r = runCli(["agent", "status", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.agents_detected).toContain("hermes");
+  });
+
+  it("agent verify --json marks Hermes pass after init", () => {
+    runCli(["agent", "init", "--with-hermes"], home);
+    const r = runCli(["agent", "verify", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    const hermes = parsed.checks.find((c: any) => c.name === "Hermes");
+    expect(hermes).toBeDefined();
+    expect(hermes.status).toBe("pass");
+  });
+
+  it("agent verify --json warns (not fails) when Hermes config lacks rafter", () => {
+    fs.writeFileSync(
+      path.join(home, ".hermes", "config.yaml"),
+      yaml.dump({ mcp_servers: { other: { command: "other" } } }),
+      "utf-8",
+    );
+    const r = runCli(["agent", "verify", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    const hermes = parsed.checks.find((c: any) => c.name === "Hermes");
+    expect(hermes.status).toBe("warn");
+  });
+
+  it("agent list includes the hermes.mcp component", () => {
+    const r = runCli(["agent", "list", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    const ids = parsed.components.map((c: any) => c.id);
+    expect(ids).toContain("hermes.mcp");
+  });
+
+  it("hermes.mcp reports installed=true in list after init", () => {
+    runCli(["agent", "init", "--with-hermes"], home);
+    const r = runCli(["agent", "list", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    const hermes = parsed.components.find((c: any) => c.id === "hermes.mcp");
+    expect(hermes).toBeDefined();
+    expect(hermes.installed).toBe(true);
+    expect(hermes.detected).toBe(true);
+  });
+});

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -2518,6 +2518,34 @@ def _check_aider() -> _CheckResult:
     return _CheckResult(name, True, f"RAFTER.md + read: entry in {conf}")
 
 
+def _check_hermes() -> _CheckResult:
+    """Check if Hermes integration is healthy (sable-gyw).
+
+    Hermes uses ~/.hermes/config.yaml with a snake_case ``mcp_servers:`` block
+    (MCP-only v0 — no hook surface confirmed yet).
+    """
+    name = "Hermes"
+    home = Path.home()
+    hermes_dir = home / ".hermes"
+
+    if not hermes_dir.exists():
+        return _CheckResult(name, False, "Not detected — run 'rafter agent init --with-hermes' to enable", optional=True)
+
+    config_path = hermes_dir / "config.yaml"
+    if not config_path.exists():
+        return _CheckResult(name, False, f"Config not found: {config_path} — run 'rafter agent init --with-hermes'", optional=True)
+
+    try:
+        loaded = yaml.safe_load(config_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as e:
+        return _CheckResult(name, False, f"Cannot read config: {e}", optional=True)
+
+    servers = loaded.get("mcp_servers") if isinstance(loaded, dict) else None
+    if not (isinstance(servers, dict) and servers.get("rafter")):
+        return _CheckResult(name, False, "Rafter MCP server not configured — run 'rafter agent init --with-hermes'", optional=True)
+    return _CheckResult(name, True, "MCP server configured")
+
+
 def _probe_claude_code() -> _CheckResult:
     """Runtime probe of the Claude Code hook integration (rf-65zg).
 
@@ -2618,6 +2646,7 @@ def verify(
         _check_windsurf(),
         _check_continue_dev(),
         _check_aider(),
+        _check_hermes(),
     ]
 
     if probe:
@@ -3046,6 +3075,7 @@ def status(
         {"name": "Cursor", "flag": "--with-cursor", "config_dir": home / ".cursor", "config_file": home / ".cursor" / "mcp.json", "needle": "rafter"},
         {"name": "Windsurf", "flag": "--with-windsurf", "config_dir": home / ".codeium" / "windsurf", "config_file": home / ".codeium" / "windsurf" / "mcp_config.json", "needle": "rafter"},
         {"name": "Continue.dev", "flag": "--with-continue", "config_dir": home / ".continue", "config_file": home / ".continue" / "config.json", "needle": "rafter"},
+        {"name": "Hermes", "flag": "--with-hermes", "config_dir": home / ".hermes", "config_file": home / ".hermes" / "config.yaml", "needle": "rafter"},
     ]
 
     for agent in mcp_agents:
@@ -3128,6 +3158,7 @@ def _detect_agent_platforms() -> list[str]:
         ("windsurf", home / ".codeium" / "windsurf"),
         ("continue", home / ".continue"),
         ("aider", home / ".aider.conf.yml"),
+        ("hermes", home / ".hermes"),
     ]
     return [name for name, path in candidates if path.exists()]
 

--- a/python/rafter_cli/commands/agent_components.py
+++ b/python/rafter_cli/commands/agent_components.py
@@ -839,6 +839,62 @@ def _continue_mcp() -> ComponentSpec:
     )
 
 
+def _hermes_mcp() -> ComponentSpec:
+    """Hermes MCP server entry (~/.hermes/config.yaml).
+
+    Hermes uses a YAML config with a snake_case ``mcp_servers:`` block (unlike
+    the camelCase ``mcpServers`` of Cursor/Windsurf/Claude Code). MCP-only v0 —
+    hooks deferred pending confirmation Hermes exposes a hook surface (sable-gyw).
+    """
+    home = Path.home()
+    detect_dir = home / ".hermes"
+    config_path = detect_dir / "config.yaml"
+
+    def read_yaml() -> dict[str, Any]:
+        if not config_path.exists():
+            return {}
+        try:
+            loaded = yaml.safe_load(config_path.read_text())
+        except (OSError, yaml.YAMLError):
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    def is_installed() -> bool:
+        servers = read_yaml().get("mcp_servers")
+        return isinstance(servers, dict) and bool(servers.get("rafter"))
+
+    def install() -> None:
+        detect_dir.mkdir(parents=True, exist_ok=True)
+        cfg = read_yaml()
+        servers = cfg.get("mcp_servers")
+        if not isinstance(servers, dict):
+            servers = {}
+            cfg["mcp_servers"] = servers
+        servers["rafter"] = dict(RAFTER_MCP_ENTRY)
+        config_path.write_text(yaml.safe_dump(cfg))
+
+    def uninstall() -> None:
+        if not config_path.exists():
+            return
+        cfg = read_yaml()
+        servers = cfg.get("mcp_servers")
+        if isinstance(servers, dict) and "rafter" in servers:
+            del servers["rafter"]
+            config_path.write_text(yaml.safe_dump(cfg))
+
+    return ComponentSpec(
+        id="hermes.mcp",
+        platform="hermes",
+        kind="mcp",
+        description="Hermes MCP server entry (~/.hermes/config.yaml)",
+        detect_dir=detect_dir,
+        path=config_path,
+        is_installed=is_installed,
+        install=install,
+        uninstall=uninstall,
+    )
+
+
 _AIDER_LEGACY_MCP_BLOCK_RE = re.compile(
     r"\n?#\s*Rafter security MCP server\s*\nmcp-server-command:\s*rafter\s+mcp\s+serve\s*\n?",
 )
@@ -997,6 +1053,7 @@ def get_registry() -> list[ComponentSpec]:
             _continue_rules(),
             _continue_mcp(),
             _aider_read(),
+            _hermes_mcp(),
             _openclaw_skill(),
         ]
     return _REGISTRY

--- a/python/tests/test_agent_init.py
+++ b/python/tests/test_agent_init.py
@@ -86,6 +86,69 @@ class TestInstallHermesMcp:
         assert config["mcp_servers"]["rafter"]["command"] == "rafter"
 
 
+class TestHermesDetection:
+    """sable-gyw item 6 — Hermes must surface in verify / status / list."""
+
+    def test_check_hermes_not_detected(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _check_hermes
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _check_hermes()
+        assert not result.passed
+        assert result.optional
+        assert "not detected" in result.detail.lower()
+
+    def test_check_hermes_pass_after_install(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _check_hermes, _install_hermes_mcp
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _install_hermes_mcp(tmp_path)
+        result = _check_hermes()
+        assert result.passed
+        assert "configured" in result.detail.lower()
+
+    def test_check_hermes_warns_when_config_lacks_rafter(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _check_hermes
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "config.yaml").write_text(yaml.safe_dump({"mcp_servers": {"other": {"command": "other"}}}))
+        result = _check_hermes()
+        assert not result.passed
+        assert result.optional  # warn, not hard fail
+
+    def test_detect_agent_platforms_includes_hermes(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _detect_agent_platforms
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".hermes").mkdir()
+        assert "hermes" in _detect_agent_platforms()
+
+    def test_hermes_mcp_component_registered(self, tmp_path, monkeypatch):
+        from rafter_cli.commands import agent_components
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        agent_components.reset_registry_cache()
+        try:
+            ids = [c.id for c in agent_components.get_registry()]
+            assert "hermes.mcp" in ids
+        finally:
+            agent_components.reset_registry_cache()
+
+    def test_hermes_mcp_component_install_uninstall(self, tmp_path, monkeypatch):
+        from rafter_cli.commands import agent_components
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        agent_components.reset_registry_cache()
+        try:
+            spec = agent_components.resolve_component("hermes.mcp")
+            assert spec is not None
+            assert not spec.is_installed()
+            spec.install()
+            assert spec.is_installed()
+            config = yaml.safe_load((tmp_path / ".hermes" / "config.yaml").read_text())
+            assert config["mcp_servers"]["rafter"]["command"] == "rafter"
+            spec.uninstall()
+            assert not spec.is_installed()
+        finally:
+            agent_components.reset_registry_cache()
+
+
 class TestInstallClaudeCodeHooks:
     def test_creates_settings_from_scratch(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)

--- a/shared-docs/PLATFORM_PARITY_AUDIT.md
+++ b/shared-docs/PLATFORM_PARITY_AUDIT.md
@@ -245,7 +245,7 @@ Total: roughly 7-8 days of focused work for full parity. CI integration tests pe
 
 ## Out of scope for rf-cia
 
-- New platform support (Hermes / future Continue extensions / etc.) — track separately under rf-01b and similar.
+- New platform support — track separately. (Hermes landed under sable-gyw: MCP-only v0 via `--with-hermes`, with init/verify/status/list detection in both runtimes; hooks deferred pending a confirmed Hermes hook surface.)
 - Sub-agent equivalents on Codex/Cursor/etc. — none of those platforms have a first-class sub-agent primitive today. Watch quarterly.
 - The `rafter review` standalone command — separate bead rf-0z9, on hold for user review.
 


### PR DESCRIPTION
## What

Completes item (6) of **sable-gyw** — detection of an existing Hermes install across `rafter agent verify` / `status` / `list`, in both the Node and Python runtimes. Hermes install (`--with-hermes`), the recipe, README badge/list, and the dry-run plan already shipped (MCP-only v0); this fills the remaining detection gap so an existing Hermes install surfaces everywhere the other 8 platforms do.

## Changes

**Node**
- `verify.ts` — `checkHermes()` reads `~/.hermes/config.yaml` (js-yaml safe load), asserts `mcp_servers.rafter`; registered in the verify results array.
- `status.ts` — Hermes added to the `mcpAgents` status table and to `detectAgents()` (the `agents_detected` JSON field).
- `components.ts` — `hermes.mcp` `ComponentSpec` (powers `agent list`/`enable`/`disable`), mirroring `continueMcp` but on the snake_case `mcp_servers` YAML shape.

**Python parity** (`agent.py` + `agent_components.py`)
- `_check_hermes`, `mcp_agents` + `_detect_agent_platforms` entries, `_hermes_mcp` `ComponentSpec`.

**Docs**
- `PLATFORM_PARITY_AUDIT.md` — the stale "Hermes out of scope / track under rf-01b" note (rf-01b never existed as a bead) updated to record Hermes landed under sable-gyw.

## Tests

- **Node**: 7 new detection tests (status text + `--json agents_detected`, verify pass/warn `--json`, `agent list` component presence + installed round-trip). `agent-init-hermes.test.ts` 14/14 pass; `agent-components` + `agent-commands` 95/95 pass.
- **Python**: 6 new tests (`_check_hermes` not-detected/pass/warn, `_detect_agent_platforms`, component registered + install/uninstall round-trip). `test_agent_init.py` 88/88 pass.

Full-suite pre-existing failures (version-parity drift 0.8.3↔0.8.0, Gemini-hooks flake sable-784, mcp-server-stdio, component-env) are unrelated and reproduce on the clean baseline.

## Security

Diff parses/writes a local YAML config. Walked rafter-code-review (CWE Top 25): `yaml.safe_load` (Python) / js-yaml 4.1.1 `load` (safe schema) — no CWE-502; fixed `home()/.hermes` paths — no CWE-22; static MCP entry, no subprocess — no CWE-78; shape-guarded, no recursive user-input merge — no CWE-1321. `rafter secrets` clean for changed files. Remote `rafter run` not executed (no `RAFTER_API_KEY` in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)