### PR TITLE
fix(agent): report OpenClaw via canonical ClawHub path in status (sable-1vq)

### DIFF
--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -1324,7 +1324,7 @@ export function createInitCommand(): Command {
         const result = await skillManager.installRafterSkillVerbose();
         openclawOk = result.ok;
         if (result.ok) {
-          console.log(fmt.success("Installed Rafter Security skill to ~/.openclaw/skills/rafter-security.md"));
+          console.log(fmt.success(`Installed Rafter Security skill to ${result.destPath}`));
           manager.set("agent.environments.openclaw.enabled", true);
         } else {
           console.log(fmt.error("Failed to install Rafter Security skill"));

--- a/node/src/commands/agent/status.ts
+++ b/node/src/commands/agent/status.ts
@@ -8,6 +8,7 @@ import { getRafterDir, getAuditLogPath, getBinDir } from "../../core/config-defa
 import { AuditLogger } from "../../core/audit-logger.js";
 import { ConfigManager } from "../../core/config-manager.js";
 import { BinaryManager } from "../../utils/binary-manager.js";
+import { SkillManager } from "../../utils/skill-manager.js";
 
 interface AgentStatusJson {
   installed: boolean;
@@ -101,12 +102,19 @@ export function createStatusCommand(): Command {
       console.log(`PostToolUse:  ${posttoolOk ? "installed" : "not installed — run: rafter agent init --with-claude-code"}`);
 
       // --- OpenClaw skill ---
-      const skillPath = path.join(home, ".openclaw", "skills", "rafter-security.md");
-      const openclawDir = path.join(home, ".openclaw");
-      if (fs.existsSync(skillPath)) {
-        console.log(`OpenClaw:     skill installed (${skillPath})`);
-      } else if (fs.existsSync(openclawDir)) {
-        console.log("OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw");
+      // rf-zgwj moved the skill to the canonical ClawHub workspace path
+      // (~/.openclaw/workspace/skills/rafter-security/SKILL.md) and strips the
+      // legacy flat file. Detect via SkillManager so this matches `agent verify`
+      // and the installer — checking the legacy path here is a false negative.
+      const skillManager = new SkillManager();
+      if (skillManager.isRafterSkillInstalled()) {
+        console.log(`OpenClaw:     skill installed (${skillManager.getRafterSkillPath()})`);
+      } else if (skillManager.isOpenClawInstalled()) {
+        if (skillManager.hasLegacyRafterSkill()) {
+          console.log(`OpenClaw:     legacy skill at ${skillManager.getLegacyRafterSkillPath()} (not loaded) — run: rafter agent init --with-openclaw to migrate`);
+        } else {
+          console.log("OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw");
+        }
       } else {
         console.log("OpenClaw:     not detected (optional)");
       }

--- a/node/tests/openclaw-integration.test.ts
+++ b/node/tests/openclaw-integration.test.ts
@@ -174,6 +174,66 @@ describe("OpenClaw Integration", () => {
       );
       expect(result.stdout).toContain("Installed Rafter Security skill");
     });
+
+    it("init success message reports the canonical workspace path, not the legacy path (rf-zgwj)", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      const result = runCli("agent init --with-openclaw", testHomeDir);
+      expect(result.stdout).toContain("Installed Rafter Security skill");
+      // Must name the real destination, not the legacy ~/.openclaw/skills/*.md
+      expect(result.stdout).toContain(SKILL_FILE_REL);
+      expect(result.stdout).not.toMatch(/\.openclaw\/skills\/rafter-security\.md/);
+    });
+  });
+
+  // ── `agent status` / `agent verify` reporting (sable-1vq) ──────────
+  //
+  // Regression guard: status checked the legacy flat path, so after a correct
+  // canonical install it falsely reported "skill missing" — while verify (which
+  // reads the canonical path) reported it installed. Both must agree.
+
+  describe("OpenClaw status reporting", () => {
+    it("status reports 'skill installed' at the canonical path after init", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      runCli("agent init --with-openclaw", testHomeDir);
+
+      const result = runCli("agent status", testHomeDir);
+      expect(result.stdout).toMatch(/OpenClaw:\s+skill installed/);
+      expect(result.stdout).toContain(SKILL_FILE_REL);
+      expect(result.stdout).not.toMatch(/OpenClaw:\s+detected but skill missing/);
+    });
+
+    it("status and verify agree after a canonical install", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      runCli("agent init --with-openclaw", testHomeDir);
+
+      const status = runCli("agent status", testHomeDir);
+      const verify = runCli("agent verify", testHomeDir);
+      expect(status.stdout).toMatch(/OpenClaw:\s+skill installed/);
+      expect(verify.stdout).toMatch(/OpenClaw.*skill installed/);
+    });
+
+    it("status shows 'detected but skill missing' when ~/.openclaw exists without a skill", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      const result = runCli("agent status", testHomeDir);
+      expect(result.stdout).toMatch(/OpenClaw:\s+detected but skill missing/);
+    });
+
+    it("status surfaces a migration hint when only the legacy flat file exists", () => {
+      const legacyDir = path.join(testHomeDir, ".openclaw", "skills");
+      fs.mkdirSync(legacyDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(legacyDir, "rafter-security.md"),
+        "---\nname: rafter-security\nversion: 0.6.0\n---\n# old\n",
+        "utf-8",
+      );
+      const result = runCli("agent status", testHomeDir);
+      expect(result.stdout).toMatch(/OpenClaw:\s+legacy skill at .* \(not loaded\)/);
+    });
+
+    it("status reports 'not detected' when ~/.openclaw is absent", () => {
+      const result = runCli("agent status", testHomeDir);
+      expect(result.stdout).toMatch(/OpenClaw:\s+not detected/);
+    });
   });
 
   // ── 3. Idempotency ────────────────────────────────────────────────

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -3021,11 +3021,18 @@ def status(
     print(f"PostToolUse:  {posttool_status}")
 
     # --- OpenClaw skill ---
-    skill_path = Path.home() / ".openclaw" / "skills" / "rafter-security.md"
-    if skill_path.exists():
-        print(f"OpenClaw:     skill installed ({skill_path})")
-    elif (Path.home() / ".openclaw").exists():
-        print("OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw")
+    # rf-zgwj moved the skill to the canonical ClawHub workspace path
+    # (~/.openclaw/workspace/skills/rafter-security/SKILL.md) and strips the
+    # legacy flat file. Detect via SkillManager so this matches `agent verify`
+    # and the installer — checking the legacy path here is a false negative.
+    skill_manager = SkillManager()
+    if skill_manager.is_rafter_skill_installed():
+        print(f"OpenClaw:     skill installed ({skill_manager.get_rafter_skill_path()})")
+    elif skill_manager.is_openclaw_installed():
+        if skill_manager.has_legacy_rafter_skill():
+            print(f"OpenClaw:     legacy skill at {skill_manager.get_legacy_rafter_skill_path()} (not loaded) — run: rafter agent init --with-openclaw to migrate")
+        else:
+            print("OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw")
     else:
         print("OpenClaw:     not detected (optional)")
 

--- a/python/rafter_cli/utils/skill_manager.py
+++ b/python/rafter_cli/utils/skill_manager.py
@@ -1,22 +1,45 @@
 """Skill manager for OpenClaw integration — Python port of Node skill-manager.ts."""
 from __future__ import annotations
 
-import importlib.resources
-import re
 from pathlib import Path
 
 
 class SkillManager:
-    """Manage OpenClaw skill installation and detection."""
+    """Manage OpenClaw skill installation and detection.
+
+    OpenClaw auto-discovers ClawHub-shaped skills from
+    ``<workspace>/skills/<skill>/SKILL.md`` (default workspace
+    ``~/.openclaw/workspace/``). rafter ≤ 0.7.7 wrote a loose
+    ``~/.openclaw/skills/<name>.md`` file that OpenClaw never read; the canonical
+    path was adopted in rf-zgwj. Detection here must match the installer and
+    ``agent verify`` — checking the legacy path is a false negative.
+    """
+
+    def get_openclaw_root(self) -> Path:
+        return Path.home() / ".openclaw"
 
     def get_openclaw_skills_dir(self) -> Path:
-        return Path.home() / ".openclaw" / "skills"
+        return self.get_openclaw_root() / "workspace" / "skills"
+
+    def get_rafter_skill_dir(self) -> Path:
+        return self.get_openclaw_skills_dir() / "rafter-security"
 
     def get_rafter_skill_path(self) -> Path:
-        return self.get_openclaw_skills_dir() / "rafter-security.md"
+        return self.get_rafter_skill_dir() / "SKILL.md"
+
+    def get_legacy_rafter_skill_path(self) -> Path:
+        """Legacy install path used by rafter ≤ 0.7.7. Removed on reinstall."""
+        return self.get_openclaw_root() / "skills" / "rafter-security.md"
 
     def is_openclaw_installed(self) -> bool:
-        return self.get_openclaw_skills_dir().exists()
+        """Detect the platform root (~/.openclaw). A fresh OpenClaw install has
+        no workspace skills dir yet, so checking the skills dir gives a
+        false-negative until at least one skill is written."""
+        return self.get_openclaw_root().exists()
+
+    def has_legacy_rafter_skill(self) -> bool:
+        """True when the rafter ≤ 0.7.7 flat file is present (migration note)."""
+        return self.get_legacy_rafter_skill_path().exists()
 
     def is_rafter_skill_installed(self) -> bool:
         return self.get_rafter_skill_path().exists()

--- a/python/tests/test_agent_status.py
+++ b/python/tests/test_agent_status.py
@@ -50,3 +50,95 @@ class TestAgentStatusJson:
         assert payload["installed"] is True
         assert {"claude-code", "cursor"}.issubset(set(payload["agents_detected"]))
         assert "pre-commit" in payload["hooks_installed"]
+
+
+class TestAgentStatusOpenClaw:
+    """sable-1vq — `agent status` must report OpenClaw via the canonical
+    ClawHub workspace path (rf-zgwj), matching the installer and `agent verify`.
+    Checking the legacy flat path was a false negative."""
+
+    def test_reports_skill_installed_at_canonical_path_after_init(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _install_openclaw_skill
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".openclaw").mkdir()
+
+        ok, _src, _dest, _err = _install_openclaw_skill()
+        assert ok
+
+        result = runner.invoke(agent_app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "OpenClaw:     skill installed" in result.output
+        assert "workspace/skills/rafter-security/SKILL.md" in result.output
+        assert "detected but skill missing" not in result.output
+
+    def test_reports_detected_but_missing_when_no_skill(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".openclaw").mkdir()
+
+        result = runner.invoke(agent_app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "OpenClaw:     detected but skill missing" in result.output
+
+    def test_surfaces_migration_hint_for_legacy_only_install(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        legacy = tmp_path / ".openclaw" / "skills" / "rafter-security.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("---\nname: rafter-security\nversion: 0.6.0\n---\n# old\n")
+
+        result = runner.invoke(agent_app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "legacy skill at" in result.output
+        assert "(not loaded)" in result.output
+
+    def test_reports_not_detected_without_openclaw(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = runner.invoke(agent_app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "OpenClaw:     not detected" in result.output
+
+
+class TestSkillManagerCanonicalPaths:
+    """SkillManager must use canonical ClawHub paths in parity with the Node
+    implementation (node/src/utils/skill-manager.ts)."""
+
+    def test_paths_point_at_workspace_skills(self, tmp_path, monkeypatch):
+        from rafter_cli.utils.skill_manager import SkillManager
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        sm = SkillManager()
+        assert sm.get_openclaw_root() == tmp_path / ".openclaw"
+        assert sm.get_openclaw_skills_dir() == tmp_path / ".openclaw" / "workspace" / "skills"
+        assert sm.get_rafter_skill_path() == tmp_path / ".openclaw" / "workspace" / "skills" / "rafter-security" / "SKILL.md"
+        assert sm.get_legacy_rafter_skill_path() == tmp_path / ".openclaw" / "skills" / "rafter-security.md"
+
+    def test_is_openclaw_installed_detects_root_not_skills_dir(self, tmp_path, monkeypatch):
+        from rafter_cli.utils.skill_manager import SkillManager
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        sm = SkillManager()
+        assert not sm.is_openclaw_installed()
+        (tmp_path / ".openclaw").mkdir()
+        # Fresh OpenClaw root with no skills dir yet must still detect.
+        assert sm.is_openclaw_installed()
+
+    def test_detection_round_trip_via_installer(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _install_openclaw_skill
+        from rafter_cli.utils.skill_manager import SkillManager
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".openclaw").mkdir()
+        sm = SkillManager()
+        assert not sm.is_rafter_skill_installed()
+
+        ok, _src, _dest, _err = _install_openclaw_skill()
+        assert ok
+        assert sm.is_rafter_skill_installed()
+        assert not sm.has_legacy_rafter_skill()
+
+    def test_has_legacy_rafter_skill(self, tmp_path, monkeypatch):
+        from rafter_cli.utils.skill_manager import SkillManager
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        legacy = tmp_path / ".openclaw" / "skills" / "rafter-security.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("legacy")
+        sm = SkillManager()
+        assert sm.has_legacy_rafter_skill()
+        assert not sm.is_rafter_skill_installed()


### PR DESCRIPTION
## Problem

While investigating OpenClaw scaffolding (sable-1vq), found a **false-negative** introduced by the rf-zgwj path migration. rf-zgwj moved the OpenClaw skill from the legacy flat file `~/.openclaw/skills/rafter-security.md` to the canonical ClawHub path `~/.openclaw/workspace/skills/rafter-security/SKILL.md` (and *strips* the legacy file on install). `agent verify` and the installer were updated; **`agent status` and the Python `SkillManager` were not.**

Live repro (before fix), after a correct `rafter agent init --with-openclaw`:
```
OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw   # status (WRONG)
✓ OpenClaw: Rafter skill installed (v0.8.3)                                          # verify (right)
```
Also: the Node init success message hardcoded the legacy path, and Python `SkillManager` (used by `audit-skill`) reported `openClawAvailable=false` / `rafterSkillInstalled=false` even when installed.

## Fix

- **Node `status.ts`** — detect via `SkillManager` (canonical path) with a legacy-file migration hint; now matches `verify`.
- **Node `init.ts`** — success message prints the real `result.destPath` instead of the hardcoded legacy path.
- **Python `SkillManager`** — ported to the canonical ClawHub paths in parity with `node/src/utils/skill-manager.ts` (`get_openclaw_root`, workspace skills dir, `get_legacy_rafter_skill_path`, `has_legacy_rafter_skill`). Corrects `audit-skill`'s OpenClaw fields too.
- **Python `status`** — same canonical detection + migration hint.

## Tests

- **Node** (5 new in `openclaw-integration.test.ts`): status reports installed at canonical path; status↔verify agree; detected-but-missing; legacy-only migration hint; not-detected; init message names the canonical path. 27/27 pass.
- **Python** (8 new in `test_agent_status.py`): status reporting (4 states) + `SkillManager` canonical paths / root detection / installer round-trip / legacy detection. 139/139 agent-suite Python tests pass.

## Security

Detection-only change: all paths are fixed `home()`-relative literals (no user input, no traversal — CWE-22 N/A); no new deserialization, shell, or exec. `rafter secrets` clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)