### PR TITLE
pattern: add HashiCorp Vault token detection

### DIFF
--- a/node/src/scanners/secret-patterns.ts
+++ b/node/src/scanners/secret-patterns.ts
@@ -95,6 +95,14 @@ export const DEFAULT_SECRET_PATTERNS: Pattern[] = [
     description: "Twilio API Key detected"
   },
 
+  // HashiCorp Vault
+  {
+    name: "HashiCorp Vault Token",
+    regex: "hvs\\.[a-zA-Z0-9_-]{90,}",
+    severity: "critical",
+    description: "HashiCorp Vault service token detected"
+  },
+
   // Generic patterns
   {
     name: "Generic API Key",

--- a/node/tests/secret-patterns.test.ts
+++ b/node/tests/secret-patterns.test.ts
@@ -199,6 +199,20 @@ describe("Secret patterns — coverage matrix", () => {
     });
   });
 
+  describe("HashiCorp Vault Token", () => {
+    it("detects hvs service token", () => {
+      const token = fakeSecret("hv" + "s.", "A".repeat(90));
+      const r = scanString(token + "\n");
+      expect(r.matches.some((m) => m.pattern.name.includes("HashiCorp Vault"))).toBe(true);
+    });
+
+    it("ignores short hvs-like strings", () => {
+      const token = fakeSecret("hv" + "s.", "A".repeat(32));
+      const r = scanString(token + "\n");
+      expect(r.matches.filter((m) => m.pattern.name.includes("HashiCorp Vault"))).toHaveLength(0);
+    });
+  });
+
   // ── Generic patterns ──────────────────────────────────────────────
 
   describe("Generic API Key", () => {

--- a/python/rafter_cli/scanners/secret_patterns.py
+++ b/python/rafter_cli/scanners/secret_patterns.py
@@ -88,6 +88,13 @@ DEFAULT_SECRET_PATTERNS: list[Pattern] = [
         severity="critical",
         description="Twilio API Key detected",
     ),
+    # HashiCorp Vault
+    Pattern(
+        name="HashiCorp Vault Token",
+        regex=r"hvs\.[a-zA-Z0-9_-]{90,}",
+        severity="critical",
+        description="HashiCorp Vault service token detected",
+    ),
     # Generic
     Pattern(
         name="Generic API Key",

--- a/python/tests/test_regex_scanner.py
+++ b/python/tests/test_regex_scanner.py
@@ -64,6 +64,18 @@ def test_scan_text(scanner):
     assert len(matches) > 0
 
 
+def test_scan_text_detects_hashicorp_vault_token(scanner):
+    token = "hv" + "s." + ("A" * 90)
+    matches = scanner.scan_text(token)
+    assert any(m.pattern.name == "HashiCorp Vault Token" for m in matches)
+
+
+def test_scan_text_ignores_short_hashicorp_vault_like_string(scanner):
+    token = "hv" + "s." + ("A" * 32)
+    matches = scanner.scan_text(token)
+    assert not any(m.pattern.name == "HashiCorp Vault Token" for m in matches)
+
+
 def test_has_secrets(scanner):
     assert scanner.has_secrets("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")
     assert not scanner.has_secrets("just a normal string")


### PR DESCRIPTION
## Summary
- add a HashiCorp Vault service token pattern to the Node and Python scanners
- keep the regex identical across runtimes: `hvs\.[a-zA-Z0-9_-]{90,}`
- add true-positive and short-token false-positive coverage

Closes #27

## Tests
- `./node_modules/.bin/tsc -p tsconfig.json`
- `./node_modules/.bin/vitest run ./tests/secret-patterns.test.ts`
- `.venv/bin/python -m pytest tests/test_regex_scanner.py -q`