### PR TITLE
release: v0.8.4 — exclude_paths fix + Hermes + policy compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-06-01
+
+### Fixed
+- **`rafter secrets` now honors `.rafter.yml scan.exclude_paths` on both engines** (#152, sable-yz0). Customer report: planting fake secrets in three `scan.exclude_paths` entries AND a non-excluded path → all three got flagged, `exclude_paths` silently ignored. Two root causes: (1) `BetterleaksScanner.scanDirectory()` never received `excludePaths`, so the `auto`-engine happy-path (the default when the binary is on disk) silently dropped customer policy; (2) the patterns engine's walker only matched entries against single directory NAMES (`entry.name`), so multi-segment paths like `components/common/Mermaid.tsx` got no filtering at all. Fix: post-filter chokepoint after both engines (and `--staged` / `--diff` modes) with path-aware semantics — exact path, directory-prefix (trailing `/` normalized), dir-name-anywhere (preserves the historical walker behavior for `node_modules`-style entries), and globs via minimatch (Node) / fnmatch (Python). Customer's exact repro now passes on both engines.
+
+### Changed
+- **CLI reads `.rafter/config.yml` indefinitely + accepts backend's flat-shape schema** (#154, sable-c1c). The cloud scanner (`rafter-backend`) reads policy at `.rafter/config.yml` (subdir + `config.yml`) with `exclude_paths` / `custom_patterns` flat at the top level, while the CLI canonical is `.rafter.yml` with `scan.*` nested. Customers writing either shape used to get honored by only one tool. CLI now reads all four candidates in precedence order (`.rafter.yml` → `.rafter.yaml` → `.rafter/config.yml` → `.rafter/config.yaml`) and accepts both schemas in either file — nested `scan.*` wins over top-level on collision. No deprecation; backend's file path stays a first-class location. Backend pairs this with `.rafter.yml` fallback + `scan.*` schema compat on their side to complete the bilateral alignment.
+
+### Added
+- **Hermes platform support** (#151, sable-gyw). `rafter agent init --with-hermes` merges the Rafter MCP server into `~/.hermes/config.yaml` under `mcp_servers.rafter` (snake_case, distinct from Cursor/Windsurf's `mcpServers` camelCase). Existing servers and other top-level YAML keys are preserved. Recipe at `recipes/hermes.md`. MCP-only v0 — hook surface deferred pending Hermes documenting one, mirroring how Gemini and Continue.dev were initially shipped. Brings the supported-platforms list to nine.
+- **`rafter agent status --json`** (#153). Reports installed state, version, detected agents, installed git hooks, scanner availability, and config / audit paths. Schema documented in `shared-docs/CLI_SPEC.md`.
+
 ## [0.8.3] - 2026-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="#supported-platforms"><img alt="Windsurf supported" src="https://img.shields.io/badge/Windsurf-supported-00c4b4?style=flat&labelColor=0a0a0a"></a>
   <a href="#supported-platforms"><img alt="Continue.dev supported" src="https://img.shields.io/badge/Continue.dev-supported-7c3aed?style=flat&labelColor=1e1b2e"></a>
   <a href="#supported-platforms"><img alt="Aider supported" src="https://img.shields.io/badge/Aider-supported-10b981?style=flat&labelColor=111827"></a>
+  <a href="#supported-platforms"><img alt="Hermes supported" src="https://img.shields.io/badge/Hermes-supported-9333ea?style=flat&labelColor=1a0a2e"></a>
 </p>
 
 Multi-language CLI for [Rafter](https://rafter.so) — the security toolkit built for AI coding agents and the developers who use them.
@@ -24,7 +25,7 @@ Rafter is a **security primitive** that any developer or agent can call and trus
 
 **Two capabilities in one package:**
 
-1. **Local Security Toolkit** (free, no account) — Fast secret scanning (21+ built-in patterns, deterministic for a given version), policy enforcement with risk-tiered rules, pre-commit hooks, extension auditing, custom rule authoring, and full audit logging. Works offline. **No API key. No telemetry. No data leaves your machine.** Supports Claude Code, Codex CLI, OpenClaw, Gemini CLI, Cursor, Windsurf, Continue.dev, and Aider.
+1. **Local Security Toolkit** (free, no account) — Fast secret scanning (21+ built-in patterns, deterministic for a given version), policy enforcement with risk-tiered rules, pre-commit hooks, extension auditing, custom rule authoring, and full audit logging. Works offline. **No API key. No telemetry. No data leaves your machine.** Supports Claude Code, Codex CLI, OpenClaw, Gemini CLI, Cursor, Windsurf, Continue.dev, Aider, and Hermes.
 
 2. **Remote Code Analysis** — Deep security audits that combine agentic analysis with a full SAST/SCA toolchain. Rafter's engine examines your codebase the way a professional penetration tester would — tracing data flows, reasoning about business logic, and surfacing vulnerabilities that static rules alone miss — then cross-references findings with industry-standard SAST, SCA, and secret-detection tools. Structured reports in JSON or Markdown. Pipe to any tool, feed to any workflow.
 
@@ -182,7 +183,7 @@ rafter agent disable gemini                # opt a single platform out
 
 This command:
 - Creates `~/.rafter/` config and audit log (or `./.rafter/` with `--local` for ephemeral / containerized / benchmark setups)
-- Auto-detects Claude Code, Codex CLI, OpenClaw, Gemini, Cursor, Windsurf, Continue.dev, and Aider
+- Auto-detects Claude Code, Codex CLI, OpenClaw, Gemini, Cursor, Windsurf, Continue.dev, Aider, and Hermes
 - With `--with-*` or `--all`: installs Rafter skills/extensions to opted-in agents
 - With `--with-betterleaks` or `--all`: downloads [Betterleaks](https://github.com/betterleaks/betterleaks) (the gitleaks successor maintained by the original gitleaks authors) for enhanced secret scanning. Falls back to built-in 21-pattern regex scanner.
 
@@ -480,6 +481,7 @@ Add to any MCP client config:
 | Windsurf | MCP server | `~/.codeium/windsurf` | `~/.codeium/windsurf/mcp_config.json` |
 | Continue.dev | MCP server | `~/.continue` | `~/.continue/config.json` |
 | Aider | MCP server | `~/.aider.conf.yml` | `~/.aider.conf.yml` |
+| Hermes | MCP server | `~/.hermes` | `~/.hermes/config.yaml` |
 
 `rafter agent init` auto-detects which platforms are installed. Use `--with-*` flags or `--all` to install integrations.
 
@@ -492,7 +494,7 @@ Add to any MCP client config:
 
 Install, remove, or audit them at any time with `rafter skill list/install/uninstall/review`.
 
-**MCP-based platforms** (Gemini, Cursor, Windsurf, Continue.dev, Aider) connect to the Rafter MCP server (`rafter mcp serve`), which exposes `scan_secrets`, `evaluate_command`, `read_audit_log`, and `get_config` tools. See individual setup recipes in [`recipes/`](recipes/).
+**MCP-based platforms** (Gemini, Cursor, Windsurf, Continue.dev, Aider, Hermes) connect to the Rafter MCP server (`rafter mcp serve`), which exposes `scan_secrets`, `evaluate_command`, `read_audit_log`, and `get_config` tools. See individual setup recipes in [`recipes/`](recipes/).
 
 ---
 

--- a/docs/proposals/auto-registration-presence-signaling.md
+++ b/docs/proposals/auto-registration-presence-signaling.md
@@ -157,7 +157,7 @@ at session start:
   "initialized": true,
   "risk_level": "moderate",
   "command_policy": "approve-dangerous",
-  "gitleaks_available": true,
+  "betterleaks_available": true,
   "hooks_installed": { "pre_tool_use": true, "post_tool_use": true },
   "project_policy": ".rafter.yml found",
   "last_scan": "2026-03-05T10:00:00Z",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "type": "module",
   "repository": {
     "type": "git",

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.3
+version: 0.8.4
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/node/src/commands/agent/components.ts
+++ b/node/src/commands/agent/components.ts
@@ -882,6 +882,61 @@ function continueMcp(): ComponentSpec {
 }
 
 /**
+ * Hermes MCP server entry (~/.hermes/config.yaml).
+ *
+ * Hermes uses a YAML config with a snake_case `mcp_servers:` block (unlike the
+ * camelCase `mcpServers` of Cursor/Windsurf/Claude Code). Per-server schema is
+ * {command, args, env}. MCP-only v0 — hooks deferred pending confirmation
+ * Hermes exposes a hook surface (sable-gyw).
+ */
+function hermesMcp(): ComponentSpec {
+  const home = os.homedir();
+  const configPath = path.join(home, ".hermes", "config.yaml");
+
+  const readYaml = (): Record<string, any> => {
+    if (!fs.existsSync(configPath)) return {};
+    try {
+      const loaded = yaml.load(fs.readFileSync(configPath, "utf-8"));
+      if (loaded && typeof loaded === "object" && !Array.isArray(loaded)) {
+        return loaded as Record<string, any>;
+      }
+    } catch { /* unparseable — treat as empty */ }
+    return {};
+  };
+
+  return {
+    id: "hermes.mcp",
+    platform: "hermes",
+    kind: "mcp",
+    description: "Hermes MCP server entry (~/.hermes/config.yaml)",
+    detectDir: path.join(home, ".hermes"),
+    path: configPath,
+    isInstalled: () => {
+      const servers = readYaml().mcp_servers;
+      return !!(servers && typeof servers === "object" && !Array.isArray(servers) && servers.rafter);
+    },
+    install: () => {
+      const dir = path.join(home, ".hermes");
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const cfg = readYaml();
+      if (!cfg.mcp_servers || typeof cfg.mcp_servers !== "object" || Array.isArray(cfg.mcp_servers)) {
+        cfg.mcp_servers = {};
+      }
+      cfg.mcp_servers.rafter = { ...RAFTER_MCP_ENTRY };
+      fs.writeFileSync(configPath, yaml.dump(cfg), "utf-8");
+    },
+    uninstall: () => {
+      if (!fs.existsSync(configPath)) return;
+      const cfg = readYaml();
+      const servers = cfg.mcp_servers;
+      if (servers && typeof servers === "object" && !Array.isArray(servers) && removeKey(servers, "rafter")) {
+        fs.writeFileSync(configPath, yaml.dump(cfg), "utf-8");
+      }
+    },
+  };
+}
+
+/**
  * Aider read-only context: writes RAFTER.md and adds it to .aider.conf.yml `read:`.
  *
  * Replaces the prior `aider.mcp` component, pruned in rf-du2o because Aider
@@ -1021,6 +1076,7 @@ export function getComponentRegistry(): ComponentSpec[] {
       continueRules(),
       continueMcp(),
       aiderRead(),
+      hermesMcp(),
       openclawSkill(),
     ];
   }

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -48,6 +48,7 @@ function printDryRunPlan(plan: {
   wantWindsurf: boolean;
   wantContinue: boolean;
   wantAider: boolean;
+  wantHermes: boolean;
   wantBetterleaks: boolean;
   riskLevel: string;
 }): void {
@@ -159,6 +160,12 @@ function printDryRunPlan(plan: {
     console.log("Aider (--with-aider):");
     W(path.join(plan.root, "RAFTER.md"), "rafter:start/end marker block");
     W(path.join(plan.root, ".aider.conf.yml"), "appends RAFTER.md to read: list; strips legacy mcp-server-command line");
+  }
+
+  if (plan.wantHermes) {
+    console.log();
+    console.log("Hermes (--with-hermes):");
+    W(path.join(plan.root, ".hermes", "config.yaml"), "mcp_servers.rafter entry merged into existing YAML");
   }
 
   if (plan.wantOpenClaw) {
@@ -832,6 +839,50 @@ function installContinueDevMcp(root: string): boolean {
  *
  * Returns true on success.
  */
+/**
+ * Install MCP server config for Hermes (<root>/.hermes/config.yaml).
+ *
+ * Hermes uses a YAML config with an `mcp_servers:` block (snake_case, unlike
+ * Cursor/Windsurf/Claude Code which use `mcpServers` camelCase). Schema per
+ * server is {command, args, env}. We use js-yaml (already a dep, used by
+ * installAiderRead and elsewhere) to merge in the rafter entry while
+ * preserving any existing servers.
+ *
+ * Hooks (preToolUse/postToolUse equivalents) deferred to a follow-on bead
+ * pending confirmation Hermes exposes a hook surface — landing MCP-only as
+ * v0 mirrors how Gemini and Continue.dev were initially shipped.
+ */
+function installHermesMcp(root: string): boolean {
+  const hermesDir = path.join(root, ".hermes");
+  const configPath = path.join(hermesDir, "config.yaml");
+
+  if (!fs.existsSync(hermesDir)) {
+    fs.mkdirSync(hermesDir, { recursive: true });
+  }
+
+  let config: Record<string, any> = {};
+  if (fs.existsSync(configPath)) {
+    const raw = fs.readFileSync(configPath, "utf-8");
+    try {
+      const loaded = yaml.load(raw);
+      if (loaded && typeof loaded === "object" && !Array.isArray(loaded)) {
+        config = loaded as Record<string, any>;
+      }
+    } catch {
+      console.log(fmt.warning(`Existing Hermes config.yaml was not valid YAML, creating new one`));
+    }
+  }
+
+  if (!config.mcp_servers || typeof config.mcp_servers !== "object" || Array.isArray(config.mcp_servers)) {
+    config.mcp_servers = {};
+  }
+  config.mcp_servers.rafter = { ...RAFTER_MCP_ENTRY };
+
+  fs.writeFileSync(configPath, yaml.dump(config), "utf-8");
+  console.log(fmt.success(`Installed Rafter MCP server to ${configPath}`));
+  return true;
+}
+
 function installAiderRead(root: string): boolean {
   const rafterMdPath = path.join(root, "RAFTER.md");
   const configPath = path.join(root, ".aider.conf.yml");
@@ -1037,6 +1088,7 @@ export function createInitCommand(): Command {
     .option("--with-cursor", "Install Cursor integration")
     .option("--with-windsurf", "Install Windsurf integration")
     .option("--with-continue", "Install Continue.dev integration")
+    .option("--with-hermes", "Install Hermes integration")
     .option("--with-betterleaks", "Download and install Betterleaks binary")
     .option("--all", "Install all detected integrations and download Betterleaks")
     .option("-i, --interactive", "Guided setup — prompts for each detected integration")
@@ -1076,6 +1128,7 @@ export function createInitCommand(): Command {
       const hasWindsurf = scope === "user" && fs.existsSync(path.join(os.homedir(), ".codeium", "windsurf"));
       const hasContinueDev = scope === "user" && fs.existsSync(path.join(os.homedir(), ".continue"));
       const hasAider = scope === "user" && fs.existsSync(path.join(os.homedir(), ".aider.conf.yml"));
+      const hasHermes = scope === "user" && fs.existsSync(path.join(os.homedir(), ".hermes"));
 
       // Resolve opt-in flags (--all enables all detected, --interactive prompts).
       // In --local scope, --all is restricted to platforms that have a project-local
@@ -1099,6 +1152,10 @@ export function createInitCommand(): Command {
       // Aider can install at --local scope (writes RAFTER.md + .aider.conf.yml
       // in cwd) since rf-du2o.
       let wantAider = opts.withAider || opts.all;
+      // Hermes: MCP-only v0 (no hooks confirmed yet). User scope only — Hermes
+      // reads ~/.hermes/config.yaml; the project-local install story isn't
+      // established. Excluded from --all in --local for the same reason.
+      let wantHermes = opts.withHermes || (opts.all && !opts.local);
       let wantBetterleaks = opts.withBetterleaks || (opts.all && !opts.local);
 
       // Interactive mode: prompt for each detected integration
@@ -1114,6 +1171,7 @@ export function createInitCommand(): Command {
         if (hasWindsurf && !wantWindsurf) wantWindsurf = await askYesNo("Install Windsurf MCP + hooks?");
         if (hasContinueDev && !wantContinue) wantContinue = await askYesNo("Install Continue.dev MCP server?");
         if (hasAider && !wantAider) wantAider = await askYesNo("Install Aider MCP server?");
+        if (hasHermes && !wantHermes) wantHermes = await askYesNo("Install Hermes MCP server?");
         if (!wantBetterleaks) wantBetterleaks = await askYesNo("Download Betterleaks binary (enhanced scanning)?");
         console.log();
       }
@@ -1128,6 +1186,7 @@ export function createInitCommand(): Command {
       if (hasWindsurf) detected.push("Windsurf");
       if (hasContinueDev) detected.push("Continue.dev");
       if (hasAider) detected.push("Aider");
+      if (hasHermes) detected.push("Hermes");
 
       if (detected.length > 0) {
         console.log(fmt.info(`Detected environments: ${detected.join(", ")}`));
@@ -1146,6 +1205,7 @@ export function createInitCommand(): Command {
         if (wantWindsurf && !hasWindsurf) console.log(fmt.warning("Windsurf requested but not detected (~/.codeium/windsurf not found)"));
         if (wantContinue && !hasContinueDev) console.log(fmt.warning("Continue.dev requested but not detected (~/.continue not found)"));
         if (wantAider && !hasAider) console.log(fmt.warning("Aider requested but not detected (~/.aider.conf.yml not found)"));
+        if (wantHermes && !hasHermes) console.log(fmt.warning("Hermes requested but not detected (~/.hermes not found)"));
       }
 
       // --dry-run: print every file path the command would touch, then
@@ -1164,6 +1224,7 @@ export function createInitCommand(): Command {
           wantWindsurf: wantWindsurf && (hasWindsurf || opts.local),
           wantContinue: wantContinue && (hasContinueDev || opts.local),
           wantAider: wantAider && (hasAider || opts.local),
+          wantHermes: wantHermes && hasHermes,
           wantBetterleaks,
           riskLevel: opts.riskLevel,
         });
@@ -1408,6 +1469,19 @@ export function createInitCommand(): Command {
         }
       }
 
+      // Install Hermes integration if opted in (sable-gyw).
+      // User scope only — Hermes reads ~/.hermes/config.yaml. MCP-only v0;
+      // hooks deferred pending confirmation Hermes exposes a hook surface.
+      let hermesOk = false;
+      if (wantHermes && hasHermes) {
+        try {
+          hermesOk = installHermesMcp(root);
+          if (hermesOk) manager.set("agent.environments.hermes.enabled", true);
+        } catch (e) {
+          console.error(fmt.error(`Failed to install Hermes integration: ${e}`));
+        }
+      }
+
       // Install global instruction files for platforms that support them.
       // Cursor is intentionally absent — Cursor uses per-skill rules + the
       // rafter sub-agent installed in the Cursor branch above (rf-svn3).
@@ -1451,6 +1525,7 @@ export function createInitCommand(): Command {
         if (hasWindsurf) console.log("  rafter agent init --with-windsurf        # Windsurf only");
         if (hasContinueDev) console.log("  rafter agent init --with-continue        # Continue.dev only");
         if (hasAider) console.log("  rafter agent init --with-aider           # Aider only");
+        if (hasHermes) console.log("  rafter agent init --with-hermes          # Hermes only");
       } else {
         console.log("No agent environments detected. Install an agent tool and re-run with --with-<tool>.");
       }

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -1324,7 +1324,7 @@ export function createInitCommand(): Command {
         const result = await skillManager.installRafterSkillVerbose();
         openclawOk = result.ok;
         if (result.ok) {
-          console.log(fmt.success("Installed Rafter Security skill to ~/.openclaw/skills/rafter-security.md"));
+          console.log(fmt.success(`Installed Rafter Security skill to ${result.destPath}`));
           manager.set("agent.environments.openclaw.enabled", true);
         } else {
           console.log(fmt.error("Failed to install Rafter Security skill"));

--- a/node/src/commands/agent/scan.ts
+++ b/node/src/commands/agent/scan.ts
@@ -17,6 +17,7 @@ import os from "os";
 import path from "path";
 import { fmt } from "../../utils/formatter.js";
 import { createRequire } from "module";
+import { minimatch } from "minimatch";
 
 const _require = createRequire(import.meta.url);
 const { version: CLI_VERSION } = _require("../../../package.json");
@@ -50,6 +51,70 @@ function loadBaselineEntries(): BaselineEntry[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Does `relPath` (forward-slash relative path) match an `exclude_paths`
+ * entry from `.rafter.yml`?
+ *
+ * sable-yz0 — single source of truth for `scan.exclude_paths` semantics
+ * across both scan engines and the staged / diff modes. Rules (any one
+ * matches → exclude):
+ *
+ *   1. Exact match: `relPath === pattern` (the pattern is the full file path)
+ *   2. Directory-prefix: `relPath` starts with `pattern + "/"` (the pattern
+ *      is a directory; everything under it is excluded). Trailing "/" on
+ *      the pattern is ignored — `scripts/` and `scripts` mean the same.
+ *   3. Dir-name anywhere: any segment of `relPath` equals `pattern` (preserves
+ *      the historical RegexScanner walker behavior — `node_modules` skips
+ *      `pkg/foo/node_modules/...` too).
+ *   4. Glob: if `pattern` contains `* ? [`, run it through minimatch with
+ *      `dot:true, matchBase:true`. Same defaults as `policyIgnoreToSuppressions`.
+ */
+function pathMatchesExcludePattern(relPath: string, pattern: string): boolean {
+  const rel = relPath.replace(/\\/g, "/");
+  const p = pattern.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (!p) return false;
+  if (rel === p) return true;
+  if (rel.startsWith(p + "/")) return true;
+  if (rel.split("/").includes(p)) return true;
+  if (/[*?[]/.test(p)) {
+    if (minimatch(rel, p, { dot: true, matchBase: true })) return true;
+    // Auto-anchor relative globs so `foo/**` matches anywhere in the tree.
+    if (!p.startsWith("/") && !p.startsWith("**")) {
+      if (minimatch(rel, "**/" + p, { dot: true })) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Strip findings whose file path matches any `scan.exclude_paths` entry.
+ * Called at the `scanDirectory` chokepoint so both the betterleaks and
+ * patterns engines get the same filter (and the same semantics).
+ *
+ * `scanRoot` is the absolute directory the scan was rooted at; finding
+ * paths are converted to scan-root-relative before matching, so users
+ * write `components/common/Mermaid.tsx` in their `.rafter.yml`, not the
+ * absolute path on the CI runner.
+ */
+function applyExcludePaths(
+  results: ScanResult[],
+  excludePaths: string[] | undefined,
+  scanRoot: string,
+): ScanResult[] {
+  if (!excludePaths || excludePaths.length === 0) return results;
+  const root = path.resolve(scanRoot).replace(/\\/g, "/");
+  return results.filter((r) => {
+    const abs = path.resolve(r.file).replace(/\\/g, "/");
+    let rel = abs;
+    if (abs === root) {
+      rel = "";
+    } else if (abs.startsWith(root + "/")) {
+      rel = abs.slice(root.length + 1);
+    }
+    return !excludePaths.some((pat) => pathMatchesExcludePattern(rel, pat));
+  });
 }
 
 function applyBaseline(results: ScanResult[], entries: BaselineEntry[]): ScanResult[] {
@@ -391,7 +456,11 @@ async function scanDiffFiles(
       allResults.push(...results);
     }
 
-    outputScanResults(applyBaseline(allResults, baselineEntries), opts, `files changed since ${ref}`, true, suppressions);
+    // sable-yz0 — honor scan.exclude_paths in --diff mode too (was previously
+    // dropped). Use the repo root as scanRoot so user-relative paths in
+    // .rafter.yml resolve consistently with the directory-scan behavior.
+    const filteredDiff = applyExcludePaths(allResults, scanCfg?.excludePaths, repoRoot);
+    outputScanResults(applyBaseline(filteredDiff, baselineEntries), opts, `files changed since ${ref}`, true, suppressions);
   } catch (error: any) {
     if (error.status === 128) {
       console.error("Error: Not in a git repository or invalid ref");
@@ -449,7 +518,9 @@ async function scanStagedFiles(
       allResults.push(...results);
     }
 
-    outputScanResults(applyBaseline(allResults, baselineEntries), opts, "staged files", true, suppressions);
+    // sable-yz0 — honor scan.exclude_paths in --staged mode too.
+    const filteredStaged = applyExcludePaths(allResults, scanCfg?.excludePaths, repoRoot);
+    outputScanResults(applyBaseline(filteredStaged, baselineEntries), opts, "staged files", true, suppressions);
   } catch (error: any) {
     if (error.status === 128) {
       console.error("Error: Not in a git repository");
@@ -530,25 +601,40 @@ async function scanDirectory(
   // respectGitignore default is true. The patterns engine honors it via
   // RegexScanner.scanDirectory; betterleaks honors it natively (gitleaks
   // ancestry — reads .gitignore unless --no-git is set).
+  let results: ScanResult[];
   if (engine === "betterleaks") {
     try {
       const bl = new BetterleaksScanner();
-      return await bl.scanDirectory(dirPath, { useGit: history ?? false });
+      results = await bl.scanDirectory(dirPath, { useGit: history ?? false });
     } catch (e) {
       console.error(fmt.warning("Betterleaks scan failed, falling back to patterns"));
       const scanner = new RegexScanner(scanCfg?.customPatterns);
-      return scanner.scanDirectory(dirPath, {
+      results = scanner.scanDirectory(dirPath, {
         excludePaths: scanCfg?.excludePaths,
         respectGitignore,
       });
     }
   } else {
     const scanner = new RegexScanner(scanCfg?.customPatterns);
-    return scanner.scanDirectory(dirPath, {
+    results = scanner.scanDirectory(dirPath, {
       excludePaths: scanCfg?.excludePaths,
       respectGitignore,
     });
   }
+  // sable-yz0 — post-filter by `.rafter.yml scan.exclude_paths`. Two bugs
+  // motivated this chokepoint:
+  //   1. The betterleaks happy-path above never received excludePaths,
+  //      so `auto`-engine scans (the default when betterleaks is on disk)
+  //      silently ignored user policy.
+  //   2. The patterns engine's walker only matches `excludePaths` entries
+  //      against single directory NAMES (`entry.name`), so a customer
+  //      writing `components/common/Mermaid.tsx` (file path) or
+  //      `supabase/migrations/foo.sql` (multi-segment path) got no
+  //      filtering at all.
+  // The post-filter applies the same path-aware semantics to BOTH engines
+  // (exact path, directory-prefix, dir-name-anywhere, glob via minimatch),
+  // catching whatever leaks through the walker-level optimization.
+  return applyExcludePaths(results, scanCfg?.excludePaths, dirPath);
 }
 
 /**

--- a/node/src/commands/agent/status.ts
+++ b/node/src/commands/agent/status.ts
@@ -128,6 +128,7 @@ export function createStatusCommand(): Command {
         { name: "Cursor", flag: "--with-cursor", configDir: path.join(home, ".cursor"), configFile: path.join(home, ".cursor", "mcp.json"), needle: "rafter" },
         { name: "Windsurf", flag: "--with-windsurf", configDir: path.join(home, ".codeium", "windsurf"), configFile: path.join(home, ".codeium", "windsurf", "mcp_config.json"), needle: "rafter" },
         { name: "Continue.dev", flag: "--with-continue", configDir: path.join(home, ".continue"), configFile: path.join(home, ".continue", "config.json"), needle: "rafter" },
+        { name: "Hermes", flag: "--with-hermes", configDir: path.join(home, ".hermes"), configFile: path.join(home, ".hermes", "config.yaml"), needle: "rafter" },
       ];
 
       for (const agent of mcpAgents) {
@@ -220,6 +221,7 @@ function detectAgents(home: string): string[] {
     ["windsurf", path.join(home, ".codeium", "windsurf")],
     ["continue", path.join(home, ".continue")],
     ["aider", path.join(home, ".aider.conf.yml")],
+    ["hermes", path.join(home, ".hermes")],
   ];
   return candidates
     .filter(([, p]) => fs.existsSync(p))

--- a/node/src/commands/agent/status.ts
+++ b/node/src/commands/agent/status.ts
@@ -3,24 +3,41 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { execSync } from "child_process";
+import { fileURLToPath } from "url";
 import { getRafterDir, getAuditLogPath, getBinDir } from "../../core/config-defaults.js";
 import { AuditLogger } from "../../core/audit-logger.js";
 import { ConfigManager } from "../../core/config-manager.js";
 import { BinaryManager } from "../../utils/binary-manager.js";
 
+interface AgentStatusJson {
+  installed: boolean;
+  version: string;
+  agents_detected: string[];
+  hooks_installed: string[];
+  betterleaks_available: boolean;
+  config_path: string;
+  audit_log_path: string;
+}
+
 export function createStatusCommand(): Command {
   return new Command("status")
     .description("Show agent security status dashboard")
-    .action(async () => {
+    .option("--json", "Output status as JSON")
+    .action(async (opts: { json?: boolean }) => {
       const rafterDir = getRafterDir();
       const auditPath = getAuditLogPath();
       const home = os.homedir();
+      const configPath = path.join(rafterDir, "config.json");
+
+      if (opts.json) {
+        console.log(JSON.stringify(buildStatusJson(home, configPath, auditPath), null, 2));
+        return;
+      }
 
       console.log("Rafter Agent Status");
       console.log("=".repeat(50));
 
       // --- Config ---
-      const configPath = path.join(rafterDir, "config.json");
       if (fs.existsSync(configPath)) {
         try {
           const cfg = new ConfigManager().load();
@@ -179,4 +196,111 @@ export function createStatusCommand(): Command {
 
       console.log();
     });
+}
+
+function buildStatusJson(home: string, configPath: string, auditPath: string): AgentStatusJson {
+  return {
+    installed: fs.existsSync(configPath),
+    version: getPkgVersion(),
+    agents_detected: detectAgents(home),
+    hooks_installed: detectGitHooks(home),
+    betterleaks_available: isBetterleaksAvailable(),
+    config_path: formatHomePath(configPath, home),
+    audit_log_path: formatHomePath(auditPath, home),
+  };
+}
+
+function detectAgents(home: string): string[] {
+  const candidates: Array<[string, string]> = [
+    ["claude-code", path.join(home, ".claude")],
+    ["openclaw", path.join(home, ".openclaw")],
+    ["codex", path.join(home, ".codex")],
+    ["gemini", path.join(home, ".gemini")],
+    ["cursor", path.join(home, ".cursor")],
+    ["windsurf", path.join(home, ".codeium", "windsurf")],
+    ["continue", path.join(home, ".continue")],
+    ["aider", path.join(home, ".aider.conf.yml")],
+  ];
+  return candidates
+    .filter(([, p]) => fs.existsSync(p))
+    .map(([name]) => name);
+}
+
+function detectGitHooks(home: string): string[] {
+  const hooks = new Set<string>();
+  const specs: Array<[string, string]> = [
+    ["pre-commit", "Rafter Security Pre-Commit Hook"],
+    ["pre-push", "Rafter Security Pre-Push Hook"],
+  ];
+
+  for (const [hookName, marker] of specs) {
+    const globalHook = path.join(home, ".rafter", "git-hooks", hookName);
+    if (fileContains(globalHook, marker)) hooks.add(hookName);
+  }
+
+  try {
+    const gitDir = execSync("git rev-parse --git-dir", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+      timeout: 5000,
+    }).trim();
+    const hooksDir = path.resolve(gitDir, "hooks");
+    for (const [hookName, marker] of specs) {
+      if (fileContains(path.join(hooksDir, hookName), marker)) hooks.add(hookName);
+    }
+  } catch {
+    // Not in a git repository, or git unavailable.
+  }
+
+  return [...hooks].sort();
+}
+
+function isBetterleaksAvailable(): boolean {
+  const exeExt = process.platform === "win32" ? ".exe" : "";
+  const localBetterleaks = path.join(getBinDir(), `betterleaks${exeExt}`);
+  try {
+    execSync("betterleaks version", {
+      timeout: 5000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    if (fs.existsSync(localBetterleaks)) return true;
+    return Boolean(new BinaryManager().findLegacyGitleaks());
+  }
+}
+
+function fileContains(filePath: string, needle: string): boolean {
+  try {
+    return fs.readFileSync(filePath, "utf-8").includes(needle);
+  } catch {
+    return false;
+  }
+}
+
+function formatHomePath(filePath: string, home: string): string {
+  const relative = path.relative(home, filePath);
+  if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+    return path.join("~", relative).replace(/\\/g, "/");
+  }
+  return filePath;
+}
+
+function getPkgVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    let dir = path.dirname(__filename);
+    for (let i = 0; i < 6; i++) {
+      const candidate = path.join(dir, "package.json");
+      if (fs.existsSync(candidate)) {
+        const pkg = JSON.parse(fs.readFileSync(candidate, "utf-8"));
+        if (pkg.version) return pkg.version;
+      }
+      dir = path.dirname(dir);
+    }
+  } catch {
+    // fall through
+  }
+  return "unknown";
 }

--- a/node/src/commands/agent/status.ts
+++ b/node/src/commands/agent/status.ts
@@ -8,6 +8,7 @@ import { getRafterDir, getAuditLogPath, getBinDir } from "../../core/config-defa
 import { AuditLogger } from "../../core/audit-logger.js";
 import { ConfigManager } from "../../core/config-manager.js";
 import { BinaryManager } from "../../utils/binary-manager.js";
+import { SkillManager } from "../../utils/skill-manager.js";
 
 interface AgentStatusJson {
   installed: boolean;
@@ -101,12 +102,19 @@ export function createStatusCommand(): Command {
       console.log(`PostToolUse:  ${posttoolOk ? "installed" : "not installed — run: rafter agent init --with-claude-code"}`);
 
       // --- OpenClaw skill ---
-      const skillPath = path.join(home, ".openclaw", "skills", "rafter-security.md");
-      const openclawDir = path.join(home, ".openclaw");
-      if (fs.existsSync(skillPath)) {
-        console.log(`OpenClaw:     skill installed (${skillPath})`);
-      } else if (fs.existsSync(openclawDir)) {
-        console.log("OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw");
+      // rf-zgwj moved the skill to the canonical ClawHub workspace path
+      // (~/.openclaw/workspace/skills/rafter-security/SKILL.md) and strips the
+      // legacy flat file. Detect via SkillManager so this matches `agent verify`
+      // and the installer — checking the legacy path here is a false negative.
+      const skillManager = new SkillManager();
+      if (skillManager.isRafterSkillInstalled()) {
+        console.log(`OpenClaw:     skill installed (${skillManager.getRafterSkillPath()})`);
+      } else if (skillManager.isOpenClawInstalled()) {
+        if (skillManager.hasLegacyRafterSkill()) {
+          console.log(`OpenClaw:     legacy skill at ${skillManager.getLegacyRafterSkillPath()} (not loaded) — run: rafter agent init --with-openclaw to migrate`);
+        } else {
+          console.log("OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw");
+        }
       } else {
         console.log("OpenClaw:     not detected (optional)");
       }

--- a/node/src/commands/agent/verify.ts
+++ b/node/src/commands/agent/verify.ts
@@ -303,6 +303,37 @@ function checkAider(): CheckResult {
   return { name, passed: true, detail: `RAFTER.md + read: entry in ${conf}` };
 }
 
+function checkHermes(): CheckResult {
+  // Hermes uses ~/.hermes/config.yaml with a snake_case `mcp_servers:` block
+  // (MCP-only v0 — no hook surface confirmed yet; sable-gyw).
+  const name = "Hermes";
+  const homeDir = os.homedir();
+  const hermesDir = path.join(homeDir, ".hermes");
+
+  if (!fs.existsSync(hermesDir)) {
+    return { name, passed: false, optional: true, detail: `Not detected — run 'rafter agent init --with-hermes' to enable` };
+  }
+
+  const configPath = path.join(hermesDir, "config.yaml");
+  if (!fs.existsSync(configPath)) {
+    return { name, passed: false, optional: true, detail: `Config not found: ${configPath} — run 'rafter agent init --with-hermes'` };
+  }
+
+  try {
+    const loaded = yaml.load(fs.readFileSync(configPath, "utf-8"));
+    const servers = (loaded && typeof loaded === "object" && !Array.isArray(loaded))
+      ? (loaded as Record<string, any>).mcp_servers
+      : undefined;
+    const hasRafterMcp = servers && typeof servers === "object" && servers.rafter != null;
+    if (!hasRafterMcp) {
+      return { name, passed: false, optional: true, detail: "Rafter MCP server not configured — run 'rafter agent init --with-hermes'" };
+    }
+    return { name, passed: true, detail: "MCP server configured" };
+  } catch (e) {
+    return { name, passed: false, optional: true, detail: `Cannot read config: ${e}` };
+  }
+}
+
 /**
  * Probe the Claude Code hook integration end-to-end (rf-65zg).
  *
@@ -406,6 +437,7 @@ export function createVerifyCommand(): Command {
         checkWindsurf(),
         checkContinueDev(),
         checkAider(),
+        checkHermes(),
       ];
 
       if (opts.probe) {

--- a/node/src/core/policy-loader.ts
+++ b/node/src/core/policy-loader.ts
@@ -50,17 +50,38 @@ export interface PolicyFile {
   docs?: PolicyDocEntry[];
 }
 
-const POLICY_FILENAMES = [".rafter.yml", ".rafter.yaml"];
+/**
+ * Policy file candidates, in precedence order.
+ *
+ * sable-c1c — the cloud scanner (rafter-backend) reads `.rafter/config.yml`
+ * (subdir + `config.yml`), while the CLI canonical is `.rafter.yml`. To
+ * unbreak customers writing either shape, the CLI now reads both
+ * indefinitely. Precedence: canonical dotfile first; backend file is the
+ * fallback. If both are present, the dotfile wins (canonical).
+ *
+ * Schema compatibility is handled separately in `mapPolicy` — top-level
+ * `exclude_paths` / `custom_patterns` (backend flat shape) is accepted
+ * alongside `scan.exclude_paths` / `scan.custom_patterns` (CLI nested).
+ */
+const POLICY_FILE_CANDIDATES: string[] = [
+  ".rafter.yml",
+  ".rafter.yaml",
+  path.join(".rafter", "config.yml"),
+  path.join(".rafter", "config.yaml"),
+];
 
 /**
- * Find a policy file by walking from cwd up to git root
+ * Find a policy file by walking from cwd up to git root.
+ *
+ * For each directory, check candidates in precedence order; the first hit
+ * wins. The walk only ascends — siblings are not considered.
  */
 export function findPolicyFile(): string | null {
   let dir = process.cwd();
   const root = getGitRoot() || path.parse(dir).root;
 
   while (true) {
-    for (const filename of POLICY_FILENAMES) {
+    for (const filename of POLICY_FILE_CANDIDATES) {
       const candidate = path.join(dir, filename);
       if (fs.existsSync(candidate)) {
         return candidate;
@@ -126,6 +147,23 @@ function mapPolicy(raw: Record<string, any>): PolicyFile {
         severity: p.severity || "high",
       }));
     }
+  }
+
+  // sable-c1c — backend flat-shape compat. rafter-backend reads
+  // exclude_paths / custom_patterns at the top level (no `scan:` nesting),
+  // so customers writing the backend shape get the same behavior locally.
+  // Nested form takes precedence if both are present in the same file.
+  if (!policy.scan?.excludePaths && Array.isArray(raw.exclude_paths)) {
+    policy.scan = policy.scan || {};
+    policy.scan.excludePaths = raw.exclude_paths;
+  }
+  if (!policy.scan?.customPatterns && Array.isArray(raw.custom_patterns)) {
+    policy.scan = policy.scan || {};
+    policy.scan.customPatterns = raw.custom_patterns.map((p: any) => ({
+      name: p.name,
+      regex: p.regex,
+      severity: p.severity || "high",
+    }));
   }
 
   if (Array.isArray(raw.ignore)) {
@@ -228,7 +266,11 @@ function deriveDocId(source: string, kind: "path" | "url"): string {
   return crypto.createHash("sha256").update(source).digest("hex").slice(0, 8);
 }
 
-const VALID_TOP_LEVEL_KEYS = new Set(["version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs"]);
+const VALID_TOP_LEVEL_KEYS = new Set([
+  "version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs",
+  // sable-c1c — backend flat-shape compat keys.
+  "exclude_paths", "custom_patterns",
+]);
 const VALID_RISK_LEVELS = new Set(["minimal", "moderate", "aggressive"]);
 const VALID_COMMAND_MODES = new Set(["allow-all", "approve-dangerous", "deny-list"]);
 const VALID_LOG_LEVELS = new Set(["debug", "info", "warn", "error"]);

--- a/node/src/scanners/secret-patterns.ts
+++ b/node/src/scanners/secret-patterns.ts
@@ -95,6 +95,14 @@ export const DEFAULT_SECRET_PATTERNS: Pattern[] = [
     description: "Twilio API Key detected"
   },
 
+  // HashiCorp Vault
+  {
+    name: "HashiCorp Vault Token",
+    regex: "hvs\\.[a-zA-Z0-9_-]{90,}",
+    severity: "critical",
+    description: "HashiCorp Vault service token detected"
+  },
+
   // Generic patterns
   {
     name: "Generic API Key",

--- a/node/tests/agent-commands.test.ts
+++ b/node/tests/agent-commands.test.ts
@@ -665,6 +665,42 @@ describe("agent status", () => {
     expect(r.stdout).toContain("Total events:");
   });
 
+  it("outputs machine-readable JSON status", () => {
+    const r = runCli("agent status --json", home);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain("Rafter Agent Status");
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toMatchObject({
+      installed: false,
+      version: expect.any(String),
+      agents_detected: [],
+      betterleaks_available: expect.any(Boolean),
+      config_path: "~/.rafter/config.json",
+      audit_log_path: "~/.rafter/audit.jsonl",
+    });
+    expect(Array.isArray(payload.hooks_installed)).toBe(true);
+  });
+
+  it("reports detected agents and installed git hooks in JSON status", () => {
+    runCli("agent init --with-claude-code", home);
+    fs.mkdirSync(path.join(home, ".cursor"), { recursive: true });
+
+    const hooksDir = path.join(home, ".rafter", "git-hooks");
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hooksDir, "pre-commit"),
+      "#!/bin/sh\n# Rafter Security Pre-Commit Hook\n",
+      { mode: 0o755 },
+    );
+
+    const r = runCli("agent status --json", home);
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload.installed).toBe(true);
+    expect(payload.agents_detected).toEqual(expect.arrayContaining(["claude-code", "cursor"]));
+    expect(payload.hooks_installed).toContain("pre-commit");
+  });
+
   it("surfaces a legacy gitleaks install with an upgrade hint", () => {
     runCli("agent init", home);
     // Drop a fake legacy gitleaks binary in ~/.rafter/bin/gitleaks.

--- a/node/tests/agent-init-hermes.test.ts
+++ b/node/tests/agent-init-hermes.test.ts
@@ -150,3 +150,71 @@ describe("agent init --with-hermes", () => {
     expect(fs.existsSync(path.join(home, ".hermes", "config.yaml"))).toBe(false);
   });
 });
+
+describe("Hermes detection in verify / status / list", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = createTempHome();
+    fs.mkdirSync(path.join(home, ".hermes"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("agent status reports Hermes installed after init", () => {
+    runCli(["agent", "init", "--with-hermes"], home);
+    const r = runCli(["agent", "status"], home);
+    expect(r.stdout + r.stderr).toMatch(/Hermes:\s+MCP installed/);
+  });
+
+  it("agent status reports detected-but-missing when ~/.hermes exists without rafter", () => {
+    const r = runCli(["agent", "status"], home);
+    expect(r.stdout + r.stderr).toMatch(/Hermes:\s+detected but MCP missing/);
+  });
+
+  it("agent status --json includes hermes in agents_detected", () => {
+    const r = runCli(["agent", "status", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.agents_detected).toContain("hermes");
+  });
+
+  it("agent verify --json marks Hermes pass after init", () => {
+    runCli(["agent", "init", "--with-hermes"], home);
+    const r = runCli(["agent", "verify", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    const hermes = parsed.checks.find((c: any) => c.name === "Hermes");
+    expect(hermes).toBeDefined();
+    expect(hermes.status).toBe("pass");
+  });
+
+  it("agent verify --json warns (not fails) when Hermes config lacks rafter", () => {
+    fs.writeFileSync(
+      path.join(home, ".hermes", "config.yaml"),
+      yaml.dump({ mcp_servers: { other: { command: "other" } } }),
+      "utf-8",
+    );
+    const r = runCli(["agent", "verify", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    const hermes = parsed.checks.find((c: any) => c.name === "Hermes");
+    expect(hermes.status).toBe("warn");
+  });
+
+  it("agent list includes the hermes.mcp component", () => {
+    const r = runCli(["agent", "list", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    const ids = parsed.components.map((c: any) => c.id);
+    expect(ids).toContain("hermes.mcp");
+  });
+
+  it("hermes.mcp reports installed=true in list after init", () => {
+    runCli(["agent", "init", "--with-hermes"], home);
+    const r = runCli(["agent", "list", "--json"], home);
+    const parsed = JSON.parse(r.stdout);
+    const hermes = parsed.components.find((c: any) => c.id === "hermes.mcp");
+    expect(hermes).toBeDefined();
+    expect(hermes.installed).toBe(true);
+    expect(hermes.detected).toBe(true);
+  });
+});

--- a/node/tests/agent-init-hermes.test.ts
+++ b/node/tests/agent-init-hermes.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the Hermes platform integration (sable-gyw).
+ *
+ * Runs the built CLI as a subprocess against a tempdir HOME so the test
+ * exercises the real --with-hermes code path (option parsing →
+ * detection → installer → YAML write), not just the installer in
+ * isolation. Mirrors the pattern used by agent-commands.test.ts.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { execSync, spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { randomBytes } from "crypto";
+import yaml from "js-yaml";
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const CLI_DIST = path.join(PROJECT_ROOT, "dist", "index.js");
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI_DIST)) {
+    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "inherit" });
+  }
+});
+
+function createTempHome(): string {
+  const dir = path.join(
+    os.tmpdir(),
+    `rafter-hermes-test-${Date.now()}-${randomBytes(4).toString("hex")}`,
+  );
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function runCli(args: string[], homeDir: string): { stdout: string; stderr: string; exitCode: number } {
+  const r = spawnSync(process.execPath, [CLI_DIST, ...args], {
+    cwd: PROJECT_ROOT,
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      XDG_CONFIG_HOME: path.join(homeDir, ".config"),
+      CI: "1",
+    },
+  });
+  return {
+    stdout: r.stdout || "",
+    stderr: r.stderr || "",
+    exitCode: r.status ?? 1,
+  };
+}
+
+function readHermesConfig(home: string): Record<string, any> {
+  const raw = fs.readFileSync(path.join(home, ".hermes", "config.yaml"), "utf-8");
+  return yaml.load(raw) as Record<string, any>;
+}
+
+describe("agent init --with-hermes", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = createTempHome();
+    fs.mkdirSync(path.join(home, ".hermes"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("creates config.yaml from scratch with mcp_servers.rafter populated", () => {
+    const r = runCli(["agent", "init", "--with-hermes"], home);
+    expect(r.exitCode).toBe(0);
+    const cfg = readHermesConfig(home);
+    expect(cfg.mcp_servers?.rafter?.command).toBe("rafter");
+    expect(cfg.mcp_servers?.rafter?.args).toEqual(["mcp", "serve"]);
+  });
+
+  it("preserves existing mcp_servers entries and other top-level keys", () => {
+    fs.writeFileSync(
+      path.join(home, ".hermes", "config.yaml"),
+      yaml.dump({
+        mcp_servers: { other: { command: "other", args: ["go"] } },
+        log_level: "debug",
+      }),
+      "utf-8",
+    );
+
+    const r = runCli(["agent", "init", "--with-hermes"], home);
+    expect(r.exitCode).toBe(0);
+
+    const cfg = readHermesConfig(home);
+    expect(cfg.mcp_servers.other.command).toBe("other");
+    expect(cfg.mcp_servers.rafter).toBeDefined();
+    expect(cfg.log_level).toBe("debug");
+  });
+
+  it("is idempotent on a second run", () => {
+    runCli(["agent", "init", "--with-hermes"], home);
+    const first = fs.readFileSync(path.join(home, ".hermes", "config.yaml"), "utf-8");
+    runCli(["agent", "init", "--with-hermes"], home);
+    const second = fs.readFileSync(path.join(home, ".hermes", "config.yaml"), "utf-8");
+    expect(second).toBe(first);
+  });
+
+  it("recovers from an unreadable / malformed YAML config", () => {
+    fs.writeFileSync(
+      path.join(home, ".hermes", "config.yaml"),
+      "mcp_servers: [this is not\n  a valid: mapping",
+      "utf-8",
+    );
+
+    const r = runCli(["agent", "init", "--with-hermes"], home);
+    expect(r.exitCode).toBe(0);
+    const cfg = readHermesConfig(home);
+    expect(cfg.mcp_servers?.rafter?.command).toBe("rafter");
+  });
+
+  it("coerces an array-shaped mcp_servers (wrong shape) into a dict", () => {
+    fs.writeFileSync(
+      path.join(home, ".hermes", "config.yaml"),
+      yaml.dump({ mcp_servers: ["junk"] }),
+      "utf-8",
+    );
+
+    const r = runCli(["agent", "init", "--with-hermes"], home);
+    expect(r.exitCode).toBe(0);
+    const cfg = readHermesConfig(home);
+    expect(typeof cfg.mcp_servers).toBe("object");
+    expect(Array.isArray(cfg.mcp_servers)).toBe(false);
+    expect(cfg.mcp_servers.rafter?.command).toBe("rafter");
+  });
+
+  it("warns when --with-hermes is requested but ~/.hermes does not exist", () => {
+    // Tear down the dir we created in beforeEach
+    fs.rmSync(path.join(home, ".hermes"), { recursive: true, force: true });
+
+    const r = runCli(["agent", "init", "--with-hermes"], home);
+    expect(r.exitCode).toBe(0); // not detected ≠ failure
+    expect(r.stdout + r.stderr).toMatch(/Hermes requested but not detected/);
+    expect(fs.existsSync(path.join(home, ".hermes", "config.yaml"))).toBe(false);
+  });
+
+  it("lists Hermes in the dry-run plan when detected", () => {
+    const r = runCli(["agent", "init", "--with-hermes", "--dry-run"], home);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout + r.stderr).toMatch(/Hermes \(--with-hermes\):/);
+    expect(r.stdout + r.stderr).toMatch(/\.hermes\/config\.yaml/);
+    // No actual file written under --dry-run.
+    expect(fs.existsSync(path.join(home, ".hermes", "config.yaml"))).toBe(false);
+  });
+});

--- a/node/tests/openclaw-integration.test.ts
+++ b/node/tests/openclaw-integration.test.ts
@@ -174,6 +174,66 @@ describe("OpenClaw Integration", () => {
       );
       expect(result.stdout).toContain("Installed Rafter Security skill");
     });
+
+    it("init success message reports the canonical workspace path, not the legacy path (rf-zgwj)", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      const result = runCli("agent init --with-openclaw", testHomeDir);
+      expect(result.stdout).toContain("Installed Rafter Security skill");
+      // Must name the real destination, not the legacy ~/.openclaw/skills/*.md
+      expect(result.stdout).toContain(SKILL_FILE_REL);
+      expect(result.stdout).not.toMatch(/\.openclaw\/skills\/rafter-security\.md/);
+    });
+  });
+
+  // ── `agent status` / `agent verify` reporting (sable-1vq) ──────────
+  //
+  // Regression guard: status checked the legacy flat path, so after a correct
+  // canonical install it falsely reported "skill missing" — while verify (which
+  // reads the canonical path) reported it installed. Both must agree.
+
+  describe("OpenClaw status reporting", () => {
+    it("status reports 'skill installed' at the canonical path after init", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      runCli("agent init --with-openclaw", testHomeDir);
+
+      const result = runCli("agent status", testHomeDir);
+      expect(result.stdout).toMatch(/OpenClaw:\s+skill installed/);
+      expect(result.stdout).toContain(SKILL_FILE_REL);
+      expect(result.stdout).not.toMatch(/OpenClaw:\s+detected but skill missing/);
+    });
+
+    it("status and verify agree after a canonical install", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      runCli("agent init --with-openclaw", testHomeDir);
+
+      const status = runCli("agent status", testHomeDir);
+      const verify = runCli("agent verify", testHomeDir);
+      expect(status.stdout).toMatch(/OpenClaw:\s+skill installed/);
+      expect(verify.stdout).toMatch(/OpenClaw.*skill installed/);
+    });
+
+    it("status shows 'detected but skill missing' when ~/.openclaw exists without a skill", () => {
+      fs.mkdirSync(path.join(testHomeDir, ".openclaw"), { recursive: true });
+      const result = runCli("agent status", testHomeDir);
+      expect(result.stdout).toMatch(/OpenClaw:\s+detected but skill missing/);
+    });
+
+    it("status surfaces a migration hint when only the legacy flat file exists", () => {
+      const legacyDir = path.join(testHomeDir, ".openclaw", "skills");
+      fs.mkdirSync(legacyDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(legacyDir, "rafter-security.md"),
+        "---\nname: rafter-security\nversion: 0.6.0\n---\n# old\n",
+        "utf-8",
+      );
+      const result = runCli("agent status", testHomeDir);
+      expect(result.stdout).toMatch(/OpenClaw:\s+legacy skill at .* \(not loaded\)/);
+    });
+
+    it("status reports 'not detected' when ~/.openclaw is absent", () => {
+      const result = runCli("agent status", testHomeDir);
+      expect(result.stdout).toMatch(/OpenClaw:\s+not detected/);
+    });
   });
 
   // ── 3. Idempotency ────────────────────────────────────────────────

--- a/node/tests/policy-loader.test.ts
+++ b/node/tests/policy-loader.test.ts
@@ -60,6 +60,89 @@ describe("Policy file parsing (via .rafter.yml)", () => {
     expect(found).toBe(path.join(tmpDir, ".rafter.yaml"));
   });
 
+  // sable-c1c — read backend's file path too (.rafter/config.yml), and
+  // accept its flat-shape schema (exclude_paths at top level).
+  describe("backend file-path + schema compat (sable-c1c)", () => {
+    it("finds .rafter/config.yml as a fallback when no dotfile exists", async () => {
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(path.join(tmpDir, ".rafter", "config.yml"), "version: '1'\n");
+      const found = await findPolicyFresh();
+      expect(found).toBe(path.join(tmpDir, ".rafter", "config.yml"));
+    });
+
+    it("finds .rafter/config.yaml as a fallback (alternate extension)", async () => {
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(path.join(tmpDir, ".rafter", "config.yaml"), "version: '1'\n");
+      const found = await findPolicyFresh();
+      expect(found).toBe(path.join(tmpDir, ".rafter", "config.yaml"));
+    });
+
+    it("dotfile wins when both .rafter.yml and .rafter/config.yml exist", async () => {
+      fs.writeFileSync(path.join(tmpDir, ".rafter.yml"), "version: 'dot'\n");
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(path.join(tmpDir, ".rafter", "config.yml"), "version: 'subdir'\n");
+      const found = await findPolicyFresh();
+      expect(found).toBe(path.join(tmpDir, ".rafter.yml"));
+      const policy = await loadPolicyFresh();
+      expect(policy?.version).toBe("dot");
+    });
+
+    it("accepts top-level exclude_paths (backend flat shape) from .rafter/config.yml", async () => {
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter", "config.yml"),
+        "exclude_paths:\n  - scripts/\n  - components/common/Mermaid.tsx\n",
+      );
+      const policy = await loadPolicyFresh();
+      expect(policy?.scan?.excludePaths).toEqual([
+        "scripts/",
+        "components/common/Mermaid.tsx",
+      ]);
+    });
+
+    it("accepts top-level custom_patterns (backend flat shape)", async () => {
+      fs.mkdirSync(path.join(tmpDir, ".rafter"));
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter", "config.yml"),
+        "custom_patterns:\n  - name: Foo\n    regex: 'foo-[a-z0-9]+'\n    severity: high\n",
+      );
+      const policy = await loadPolicyFresh();
+      expect(policy?.scan?.customPatterns?.[0]?.name).toBe("Foo");
+    });
+
+    it("accepts the backend flat shape inside a .rafter.yml dotfile too", async () => {
+      // A customer who used to write .rafter/config.yml may copy the same
+      // shape into a .rafter.yml dotfile — should still work.
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter.yml"),
+        "exclude_paths:\n  - tests/**\n",
+      );
+      const policy = await loadPolicyFresh();
+      expect(policy?.scan?.excludePaths).toEqual(["tests/**"]);
+    });
+
+    it("nested scan.exclude_paths wins over top-level when both are present", async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter.yml"),
+        "exclude_paths:\n  - flat\nscan:\n  exclude_paths:\n    - nested\n",
+      );
+      const policy = await loadPolicyFresh();
+      expect(policy?.scan?.excludePaths).toEqual(["nested"]);
+    });
+
+    it("does not warn on top-level exclude_paths / custom_patterns (compat keys)", async () => {
+      const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      fs.writeFileSync(
+        path.join(tmpDir, ".rafter.yml"),
+        "exclude_paths:\n  - foo/\ncustom_patterns: []\n",
+      );
+      await loadPolicyFresh();
+      const warnings = warnSpy.mock.calls.flat().join("\n");
+      expect(warnings).not.toMatch(/Unknown policy key "exclude_paths"/);
+      expect(warnings).not.toMatch(/Unknown policy key "custom_patterns"/);
+    });
+  });
+
   it("parses valid policy with all sections", async () => {
     const yml = `
 version: "1"

--- a/node/tests/scan-exclude-paths.test.ts
+++ b/node/tests/scan-exclude-paths.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for sable-yz0 — `rafter secrets` must honor
+ * `.rafter.yml scan.exclude_paths` on both the betterleaks and patterns
+ * engines, and across all entry shapes (bare dir name, dir with trailing
+ * slash, full file path, glob).
+ *
+ * Mirrors the customer's exact repro: plant a fake Stripe key in three
+ * excluded paths AND one non-excluded path, expect only the non-excluded
+ * one to fire (exit 1, single finding).
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { execSync, spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { randomBytes } from "crypto";
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const CLI_DIST = path.join(PROJECT_ROOT, "dist", "index.js");
+
+// Stripe-style key, split so this file doesn't trip its own scanner.
+const FAKE_STRIPE = "sk" + "_live_" + "1234567890abcdefghijklmn";
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI_DIST)) {
+    execSync("pnpm run build", { cwd: PROJECT_ROOT, stdio: "inherit" });
+  }
+});
+
+function setupRepro(): string {
+  const dir = path.join(
+    os.tmpdir(),
+    `rafter-exclude-test-${Date.now()}-${randomBytes(4).toString("hex")}`,
+  );
+  fs.mkdirSync(dir, { recursive: true });
+  execSync("git init -q", { cwd: dir });
+  fs.mkdirSync(path.join(dir, "scripts"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "components", "common"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "supabase", "migrations"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "safe"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "scripts", "dev.ts"), `// ${FAKE_STRIPE}\n`);
+  fs.writeFileSync(path.join(dir, "components", "common", "Mermaid.tsx"), `// ${FAKE_STRIPE}\n`);
+  fs.writeFileSync(
+    path.join(dir, "supabase", "migrations", "20250215000000_resend_setup.sql"),
+    `-- ${FAKE_STRIPE}\n`,
+  );
+  fs.writeFileSync(path.join(dir, "safe", "leaky.ts"), `// ${FAKE_STRIPE}\n`);
+  fs.writeFileSync(
+    path.join(dir, ".rafter.yml"),
+    [
+      "scan:",
+      "  exclude_paths:",
+      "    - scripts/",
+      "    - components/common/Mermaid.tsx",
+      "    - supabase/migrations/20250215000000_resend_setup.sql",
+      "",
+    ].join("\n"),
+  );
+  return dir;
+}
+
+function runCli(args: string[], cwd: string, homeDir: string) {
+  const r = spawnSync(process.execPath, [CLI_DIST, ...args], {
+    cwd,
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, HOME: homeDir, XDG_CONFIG_HOME: path.join(homeDir, ".config"), CI: "1" },
+  });
+  return { stdout: r.stdout || "", stderr: r.stderr || "", exitCode: r.status ?? 1 };
+}
+
+describe("rafter secrets — scan.exclude_paths (sable-yz0)", () => {
+  let repo: string;
+  let home: string;
+
+  beforeEach(() => {
+    repo = setupRepro();
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "rafter-exclude-home-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("patterns engine flags only the non-excluded path (the customer's repro)", () => {
+    const r = runCli(["secrets", ".", "--engine", "patterns", "--format", "json"], repo, home);
+    expect(r.exitCode).toBe(1);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file).sort();
+    // Exactly one file fires — safe/leaky.ts. None of the excluded paths.
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/safe\/leaky\.ts$/);
+    expect(files.some((f: string) => f.includes("scripts/dev.ts"))).toBe(false);
+    expect(files.some((f: string) => f.includes("Mermaid.tsx"))).toBe(false);
+    expect(files.some((f: string) => f.includes("resend_setup.sql"))).toBe(false);
+  });
+
+  it("auto engine matches patterns-engine output (regardless of which engine wins)", () => {
+    const r = runCli(["secrets", ".", "--format", "json"], repo, home);
+    expect(r.exitCode).toBe(1);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file).sort();
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/safe\/leaky\.ts$/);
+  });
+
+  it("dropping the exclude_paths block re-surfaces all four findings", () => {
+    fs.writeFileSync(path.join(repo, ".rafter.yml"), "");
+    const r = runCli(["secrets", ".", "--engine", "patterns", "--format", "json"], repo, home);
+    expect(r.exitCode).toBe(1);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file).sort();
+    expect(files).toHaveLength(4);
+  });
+
+  it("dir-name-anywhere semantics: bare `node_modules` excludes nested copies", () => {
+    fs.mkdirSync(path.join(repo, "pkg", "node_modules", "foo"), { recursive: true });
+    fs.writeFileSync(path.join(repo, "pkg", "node_modules", "foo", "leak.ts"), `// ${FAKE_STRIPE}\n`);
+    fs.writeFileSync(
+      path.join(repo, ".rafter.yml"),
+      "scan:\n  exclude_paths:\n    - node_modules\n",
+    );
+
+    const r = runCli(["secrets", ".", "--engine", "patterns", "--format", "json"], repo, home);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file);
+    expect(files.some((f: string) => f.includes("node_modules"))).toBe(false);
+    // safe/leaky.ts still fires since exclude_paths only has node_modules now
+    expect(files.some((f: string) => f.includes("safe/leaky.ts"))).toBe(true);
+  });
+
+  it("glob semantics: `**/*.sql` excludes every SQL file at any depth", () => {
+    fs.writeFileSync(
+      path.join(repo, ".rafter.yml"),
+      "scan:\n  exclude_paths:\n    - '**/*.sql'\n",
+    );
+    const r = runCli(["secrets", ".", "--engine", "patterns", "--format", "json"], repo, home);
+    const out = JSON.parse(r.stdout);
+    const files = (out.results || []).map((x: any) => x.file);
+    expect(files.some((f: string) => f.endsWith(".sql"))).toBe(false);
+  });
+});

--- a/node/tests/secret-patterns.test.ts
+++ b/node/tests/secret-patterns.test.ts
@@ -199,6 +199,20 @@ describe("Secret patterns — coverage matrix", () => {
     });
   });
 
+  describe("HashiCorp Vault Token", () => {
+    it("detects hvs service token", () => {
+      const token = fakeSecret("hv" + "s.", "A".repeat(90));
+      const r = scanString(token + "\n");
+      expect(r.matches.some((m) => m.pattern.name.includes("HashiCorp Vault"))).toBe(true);
+    });
+
+    it("ignores short hvs-like strings", () => {
+      const token = fakeSecret("hv" + "s.", "A".repeat(32));
+      const r = scanString(token + "\n");
+      expect(r.matches.filter((m) => m.pattern.name.includes("HashiCorp Vault"))).toHaveLength(0);
+    });
+  });
+
   // ── Generic patterns ──────────────────────────────────────────────
 
   describe("Generic API Key", () => {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.8.3"
+version = "0.8.4"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -1493,6 +1493,68 @@ def _scan_file(file_path: str, engine: str, custom_patterns=None) -> list[ScanRe
         return [r] if r.matches else []
 
 
+def _path_matches_exclude_pattern(rel_path: str, pattern: str) -> bool:
+    """Mirror of Node ``pathMatchesExcludePattern`` (sable-yz0).
+
+    Rules (any one matches → exclude):
+      1. Exact match: ``rel_path == pattern``.
+      2. Directory-prefix: ``rel_path`` starts with ``pattern + "/"``.
+         Trailing ``/`` on the pattern is ignored.
+      3. Dir-name anywhere: any segment of ``rel_path`` equals ``pattern``.
+         Preserves the RegexScanner walker's existing dir-name behavior.
+      4. Glob: if pattern has ``* ? [``, use fnmatch with auto-anchor
+         (try ``pattern`` and ``**/pattern``) — mirrors Node ``matchGlob``.
+    """
+    import fnmatch as _fnmatch
+    rel = rel_path.replace("\\", "/")
+    p = pattern.replace("\\", "/").rstrip("/")
+    if not p:
+        return False
+    if rel == p:
+        return True
+    if rel.startswith(p + "/"):
+        return True
+    if p in rel.split("/"):
+        return True
+    if any(c in p for c in "*?["):
+        if _fnmatch.fnmatch(rel, p):
+            return True
+        if not p.startswith("/") and not p.startswith("**"):
+            if _fnmatch.fnmatch(rel, "**/" + p) or _fnmatch.fnmatch(rel, "*/" + p):
+                return True
+    return False
+
+
+def _apply_exclude_paths(
+    results: list[ScanResult],
+    exclude_paths: list[str] | None,
+    scan_root: str,
+) -> list[ScanResult]:
+    """Strip findings whose path matches any ``scan.exclude_paths`` entry.
+
+    Chokepoint that fixes sable-yz0 across both scan engines AND the staged
+    / diff modes. See the Node ``applyExcludePaths`` docstring for the full
+    rationale — both engines previously bypassed the policy on the
+    happy-path, and the existing walker-level filter only matched
+    directory NAMES, missing every multi-segment path users wrote.
+    """
+    if not exclude_paths:
+        return results
+    root = os.path.abspath(scan_root).replace("\\", "/")
+    kept: list[ScanResult] = []
+    for r in results:
+        abs_p = os.path.abspath(r.file).replace("\\", "/")
+        if abs_p == root:
+            rel = ""
+        elif abs_p.startswith(root + "/"):
+            rel = abs_p[len(root) + 1 :]
+        else:
+            rel = abs_p
+        if not any(_path_matches_exclude_pattern(rel, pat) for pat in exclude_paths):
+            kept.append(r)
+    return kept
+
+
 def _scan_directory(
     dir_path: str,
     engine: str,
@@ -1511,13 +1573,15 @@ def _scan_directory(
         try:
             bl = BetterleaksScanner()
             results = bl.scan_directory(dir_path, use_git=history)
-            return [ScanResult(file=r.file, matches=r.matches) for r in results]
+            results = [ScanResult(file=r.file, matches=r.matches) for r in results]
         except Exception:
             scanner = RegexScanner(custom)
-            return scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
+            results = scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
     else:
         scanner = RegexScanner(custom)
-        return scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
+        results = scanner.scan_directory(dir_path, exclude_paths=exclude, respect_gitignore=respect_gitignore)
+    # sable-yz0 — post-filter chokepoint. See _apply_exclude_paths docstring.
+    return _apply_exclude_paths(results, exclude, dir_path)
 
 
 def _output_scan_results(

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -2951,18 +2951,24 @@ def update_betterleaks(
 # ── agent status ─────────────────────────────────────────────────────────
 
 @agent_app.command("status")
-def status():
+def status(
+    json_output: bool = typer.Option(False, "--json", help="Output status as JSON"),
+):
     """Show agent security status dashboard."""
     from ..core.config_schema import get_audit_log_path, get_rafter_dir
 
     rafter_dir = get_rafter_dir()
     audit_path = get_audit_log_path()
+    config_path = rafter_dir / "config.json"
+
+    if json_output:
+        print(json.dumps(_agent_status_json(config_path, audit_path), indent=2))
+        return
 
     print("Rafter Agent Status")
     print("=" * 50)
 
     # --- Config ---
-    config_path = rafter_dir / "config.json"
     if config_path.exists():
         try:
             cfg = ConfigManager().load()
@@ -3097,6 +3103,95 @@ def status():
         print("No events logged yet.")
 
     print()
+
+
+def _agent_status_json(config_path: Path, audit_path: Path) -> dict[str, Any]:
+    return {
+        "installed": config_path.exists(),
+        "version": __version__,
+        "agents_detected": _detect_agent_platforms(),
+        "hooks_installed": _detect_git_hooks(),
+        "betterleaks_available": _betterleaks_available(),
+        "config_path": _format_home_path(config_path),
+        "audit_log_path": _format_home_path(audit_path),
+    }
+
+
+def _detect_agent_platforms() -> list[str]:
+    home = Path.home()
+    candidates = [
+        ("claude-code", home / ".claude"),
+        ("openclaw", home / ".openclaw"),
+        ("codex", home / ".codex"),
+        ("gemini", home / ".gemini"),
+        ("cursor", home / ".cursor"),
+        ("windsurf", home / ".codeium" / "windsurf"),
+        ("continue", home / ".continue"),
+        ("aider", home / ".aider.conf.yml"),
+    ]
+    return [name for name, path in candidates if path.exists()]
+
+
+def _detect_git_hooks() -> list[str]:
+    hooks: set[str] = set()
+    specs = [
+        ("pre-commit", "Rafter Security Pre-Commit Hook"),
+        ("pre-push", "Rafter Security Pre-Push Hook"),
+    ]
+    home = Path.home()
+
+    for hook_name, marker in specs:
+        if _file_contains(home / ".rafter" / "git-hooks" / hook_name, marker):
+            hooks.add(hook_name)
+
+    try:
+        git_dir = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        ).stdout.strip()
+        hooks_dir = Path(git_dir).resolve() / "hooks"
+        for hook_name, marker in specs:
+            if _file_contains(hooks_dir / hook_name, marker):
+                hooks.add(hook_name)
+    except Exception:
+        pass
+
+    return sorted(hooks)
+
+
+def _betterleaks_available() -> bool:
+    bm = BinaryManager()
+    if shutil.which("betterleaks"):
+        try:
+            result = subprocess.run(
+                ["betterleaks", "version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return True
+        except Exception:
+            pass
+    return bm.get_betterleaks_path().exists() or bool(bm.find_legacy_gitleaks())
+
+
+def _file_contains(path: Path, needle: str) -> bool:
+    try:
+        return needle in path.read_text(encoding="utf-8")
+    except Exception:
+        return False
+
+
+def _format_home_path(path: Path) -> str:
+    home = Path.home()
+    try:
+        return f"~/{path.relative_to(home).as_posix()}"
+    except ValueError:
+        return str(path)
 
 
 # ── baseline ─────────────────────────────────────────────────────────

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -248,6 +248,7 @@ def _print_dry_run_plan(
     want_windsurf: bool,
     want_continue: bool,
     want_aider: bool,
+    want_hermes: bool,
     want_betterleaks: bool,
     risk_level: str,
 ) -> None:
@@ -354,6 +355,11 @@ def _print_dry_run_plan(
         print("Aider (--with-aider):")
         W(root / "RAFTER.md", "rafter:start/end marker block")
         W(root / ".aider.conf.yml", "appends RAFTER.md to read: list; strips legacy mcp-server-command line")
+
+    if want_hermes:
+        print()
+        print("Hermes (--with-hermes):")
+        W(root / ".hermes" / "config.yaml", "mcp_servers.rafter entry merged into existing YAML")
 
     if want_openclaw:
         print()
@@ -987,6 +993,44 @@ def _install_aider_read(root: Path) -> bool:
     return True
 
 
+def _install_hermes_mcp(root: Path) -> bool:
+    """Install MCP server config for Hermes (<root>/.hermes/config.yaml).
+
+    Hermes uses a YAML config with an ``mcp_servers:`` block (snake_case,
+    unlike Cursor/Windsurf/Claude Code which use ``mcpServers`` camelCase).
+    Schema per server is ``{command, args, env}``. We use PyYAML (already
+    imported) to merge in the rafter entry while preserving any existing
+    servers.
+
+    Hooks (preToolUse/postToolUse equivalents) deferred to a follow-on bead
+    pending confirmation Hermes exposes a hook surface — landing MCP-only as
+    v0 mirrors how Gemini and Continue.dev were initially shipped (sable-gyw).
+    """
+    hermes_dir = root / ".hermes"
+    config_path = hermes_dir / "config.yaml"
+
+    hermes_dir.mkdir(parents=True, exist_ok=True)
+
+    config: dict[str, Any] = {}
+    if config_path.exists():
+        try:
+            loaded = yaml.safe_load(config_path.read_text())
+            if isinstance(loaded, dict):
+                config = loaded
+        except yaml.YAMLError:
+            rprint(fmt.warning("Existing Hermes config.yaml was not valid YAML, creating new one"))
+
+    mcp_servers = config.get("mcp_servers")
+    if not isinstance(mcp_servers, dict):
+        mcp_servers = {}
+        config["mcp_servers"] = mcp_servers
+    mcp_servers["rafter"] = {**_RAFTER_MCP_ENTRY}
+
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    rprint(fmt.success(f"Installed Rafter MCP server to {config_path}"))
+    return True
+
+
 @agent_app.command()
 def init(
     risk_level: str = typer.Option("moderate", "--risk-level", help="minimal, moderate, or aggressive"),
@@ -999,6 +1043,7 @@ def init(
     with_cursor: bool = typer.Option(False, "--with-cursor", help="Install Cursor integration"),
     with_windsurf: bool = typer.Option(False, "--with-windsurf", help="Install Windsurf integration"),
     with_continue: bool = typer.Option(False, "--with-continue", help="Install Continue.dev integration"),
+    with_hermes: bool = typer.Option(False, "--with-hermes", help="Install Hermes integration"),
     all_integrations: bool = typer.Option(False, "--all", help="Install all detected integrations and download Betterleaks"),
     update: bool = typer.Option(False, "--update", help="Re-download betterleaks and reinstall integrations without resetting config"),
     local: bool = typer.Option(
@@ -1037,6 +1082,7 @@ def init(
     has_windsurf = scope == "user" and (home / ".codeium" / "windsurf").exists()
     has_continue_dev = scope == "user" and (home / ".continue").exists()
     has_aider = scope == "user" and (home / ".aider.conf.yml").exists()
+    has_hermes = scope == "user" and (home / ".hermes").exists()
 
     # Resolve opt-in flags. In --local scope, --all is restricted to platforms with
     # a project-local config story (claudeCode, codex, gemini, cursor).
@@ -1057,6 +1103,10 @@ def init(
     # Aider can install at --local scope (writes RAFTER.md + .aider.conf.yml
     # in cwd) since rf-du2o.
     want_aider = with_aider or all_integrations
+    # Hermes: MCP-only v0 (no hooks confirmed yet). User scope only — Hermes
+    # reads ~/.hermes/config.yaml; project-local install story isn't
+    # established. Excluded from --all in --local for the same reason (sable-gyw).
+    want_hermes = with_hermes or (all_integrations and not local)
     want_betterleaks = with_betterleaks or (all_integrations and not local)
 
     # Show detected environments
@@ -1077,6 +1127,8 @@ def init(
         detected.append("Continue.dev")
     if has_aider:
         detected.append("Aider")
+    if has_hermes:
+        detected.append("Hermes")
 
     if detected:
         rprint(fmt.info(f"Detected environments: {', '.join(detected)}"))
@@ -1102,6 +1154,8 @@ def init(
             rprint(fmt.warning("Continue.dev requested but not detected (~/.continue not found)"))
         if want_aider and not has_aider:
             rprint(fmt.warning("Aider requested but not detected (~/.aider.conf.yml not found)"))
+        if want_hermes and not has_hermes:
+            rprint(fmt.warning("Hermes requested but not detected (~/.hermes not found)"))
 
     # --dry-run: print every file path the command would touch, then exit
     # before any filesystem write happens (rf-hrtd). Built from the same
@@ -1118,6 +1172,7 @@ def init(
             want_windsurf=want_windsurf and (has_windsurf or local),
             want_continue=want_continue and (has_continue_dev or local),
             want_aider=want_aider and (has_aider or local),
+            want_hermes=want_hermes and has_hermes,
             want_betterleaks=want_betterleaks,
             risk_level=risk_level,
         )
@@ -1312,6 +1367,18 @@ def init(
         except Exception as e:
             rprint(fmt.error(f"Failed to install Aider integration: {e}"))
 
+    # Install Hermes integration if opted in (sable-gyw).
+    # User scope only — Hermes reads ~/.hermes/config.yaml. MCP-only v0;
+    # hooks deferred pending confirmation Hermes exposes a hook surface.
+    hermes_ok = False
+    if want_hermes and has_hermes:
+        try:
+            hermes_ok = _install_hermes_mcp(root)
+            if hermes_ok:
+                manager.set("agent.environments.hermes.enabled", True)
+        except Exception as e:
+            rprint(fmt.error(f"Failed to install Hermes integration: {e}"))
+
     # Install global instruction files for platforms that support them
     _install_global_instructions(
         claude_code=claude_code_ok,
@@ -1327,7 +1394,7 @@ def init(
     rprint(fmt.success("Agent security initialized!"))
     rprint()
 
-    any_integration = openclaw_ok or claude_code_ok or codex_ok or gemini_ok or cursor_ok or windsurf_ok or continue_ok or aider_ok
+    any_integration = openclaw_ok or claude_code_ok or codex_ok or gemini_ok or cursor_ok or windsurf_ok or continue_ok or aider_ok or hermes_ok
 
     if any_integration:
         rprint("Next steps:")
@@ -1372,6 +1439,8 @@ def init(
             rprint("  rafter agent init --with-continue        # Continue.dev only")
         if has_aider:
             rprint("  rafter agent init --with-aider           # Aider only")
+        if has_hermes:
+            rprint("  rafter agent init --with-hermes          # Hermes only")
     else:
         rprint("No agent environments detected. Install an agent tool and re-run with --with-<tool>.")
 

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -3021,11 +3021,18 @@ def status(
     print(f"PostToolUse:  {posttool_status}")
 
     # --- OpenClaw skill ---
-    skill_path = Path.home() / ".openclaw" / "skills" / "rafter-security.md"
-    if skill_path.exists():
-        print(f"OpenClaw:     skill installed ({skill_path})")
-    elif (Path.home() / ".openclaw").exists():
-        print("OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw")
+    # rf-zgwj moved the skill to the canonical ClawHub workspace path
+    # (~/.openclaw/workspace/skills/rafter-security/SKILL.md) and strips the
+    # legacy flat file. Detect via SkillManager so this matches `agent verify`
+    # and the installer — checking the legacy path here is a false negative.
+    skill_manager = SkillManager()
+    if skill_manager.is_rafter_skill_installed():
+        print(f"OpenClaw:     skill installed ({skill_manager.get_rafter_skill_path()})")
+    elif skill_manager.is_openclaw_installed():
+        if skill_manager.has_legacy_rafter_skill():
+            print(f"OpenClaw:     legacy skill at {skill_manager.get_legacy_rafter_skill_path()} (not loaded) — run: rafter agent init --with-openclaw to migrate")
+        else:
+            print("OpenClaw:     detected but skill missing — run: rafter agent init --with-openclaw")
     else:
         print("OpenClaw:     not detected (optional)")
 

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -2518,6 +2518,34 @@ def _check_aider() -> _CheckResult:
     return _CheckResult(name, True, f"RAFTER.md + read: entry in {conf}")
 
 
+def _check_hermes() -> _CheckResult:
+    """Check if Hermes integration is healthy (sable-gyw).
+
+    Hermes uses ~/.hermes/config.yaml with a snake_case ``mcp_servers:`` block
+    (MCP-only v0 — no hook surface confirmed yet).
+    """
+    name = "Hermes"
+    home = Path.home()
+    hermes_dir = home / ".hermes"
+
+    if not hermes_dir.exists():
+        return _CheckResult(name, False, "Not detected — run 'rafter agent init --with-hermes' to enable", optional=True)
+
+    config_path = hermes_dir / "config.yaml"
+    if not config_path.exists():
+        return _CheckResult(name, False, f"Config not found: {config_path} — run 'rafter agent init --with-hermes'", optional=True)
+
+    try:
+        loaded = yaml.safe_load(config_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as e:
+        return _CheckResult(name, False, f"Cannot read config: {e}", optional=True)
+
+    servers = loaded.get("mcp_servers") if isinstance(loaded, dict) else None
+    if not (isinstance(servers, dict) and servers.get("rafter")):
+        return _CheckResult(name, False, "Rafter MCP server not configured — run 'rafter agent init --with-hermes'", optional=True)
+    return _CheckResult(name, True, "MCP server configured")
+
+
 def _probe_claude_code() -> _CheckResult:
     """Runtime probe of the Claude Code hook integration (rf-65zg).
 
@@ -2618,6 +2646,7 @@ def verify(
         _check_windsurf(),
         _check_continue_dev(),
         _check_aider(),
+        _check_hermes(),
     ]
 
     if probe:
@@ -3046,6 +3075,7 @@ def status(
         {"name": "Cursor", "flag": "--with-cursor", "config_dir": home / ".cursor", "config_file": home / ".cursor" / "mcp.json", "needle": "rafter"},
         {"name": "Windsurf", "flag": "--with-windsurf", "config_dir": home / ".codeium" / "windsurf", "config_file": home / ".codeium" / "windsurf" / "mcp_config.json", "needle": "rafter"},
         {"name": "Continue.dev", "flag": "--with-continue", "config_dir": home / ".continue", "config_file": home / ".continue" / "config.json", "needle": "rafter"},
+        {"name": "Hermes", "flag": "--with-hermes", "config_dir": home / ".hermes", "config_file": home / ".hermes" / "config.yaml", "needle": "rafter"},
     ]
 
     for agent in mcp_agents:
@@ -3128,6 +3158,7 @@ def _detect_agent_platforms() -> list[str]:
         ("windsurf", home / ".codeium" / "windsurf"),
         ("continue", home / ".continue"),
         ("aider", home / ".aider.conf.yml"),
+        ("hermes", home / ".hermes"),
     ]
     return [name for name, path in candidates if path.exists()]
 

--- a/python/rafter_cli/commands/agent_components.py
+++ b/python/rafter_cli/commands/agent_components.py
@@ -839,6 +839,62 @@ def _continue_mcp() -> ComponentSpec:
     )
 
 
+def _hermes_mcp() -> ComponentSpec:
+    """Hermes MCP server entry (~/.hermes/config.yaml).
+
+    Hermes uses a YAML config with a snake_case ``mcp_servers:`` block (unlike
+    the camelCase ``mcpServers`` of Cursor/Windsurf/Claude Code). MCP-only v0 —
+    hooks deferred pending confirmation Hermes exposes a hook surface (sable-gyw).
+    """
+    home = Path.home()
+    detect_dir = home / ".hermes"
+    config_path = detect_dir / "config.yaml"
+
+    def read_yaml() -> dict[str, Any]:
+        if not config_path.exists():
+            return {}
+        try:
+            loaded = yaml.safe_load(config_path.read_text())
+        except (OSError, yaml.YAMLError):
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    def is_installed() -> bool:
+        servers = read_yaml().get("mcp_servers")
+        return isinstance(servers, dict) and bool(servers.get("rafter"))
+
+    def install() -> None:
+        detect_dir.mkdir(parents=True, exist_ok=True)
+        cfg = read_yaml()
+        servers = cfg.get("mcp_servers")
+        if not isinstance(servers, dict):
+            servers = {}
+            cfg["mcp_servers"] = servers
+        servers["rafter"] = dict(RAFTER_MCP_ENTRY)
+        config_path.write_text(yaml.safe_dump(cfg))
+
+    def uninstall() -> None:
+        if not config_path.exists():
+            return
+        cfg = read_yaml()
+        servers = cfg.get("mcp_servers")
+        if isinstance(servers, dict) and "rafter" in servers:
+            del servers["rafter"]
+            config_path.write_text(yaml.safe_dump(cfg))
+
+    return ComponentSpec(
+        id="hermes.mcp",
+        platform="hermes",
+        kind="mcp",
+        description="Hermes MCP server entry (~/.hermes/config.yaml)",
+        detect_dir=detect_dir,
+        path=config_path,
+        is_installed=is_installed,
+        install=install,
+        uninstall=uninstall,
+    )
+
+
 _AIDER_LEGACY_MCP_BLOCK_RE = re.compile(
     r"\n?#\s*Rafter security MCP server\s*\nmcp-server-command:\s*rafter\s+mcp\s+serve\s*\n?",
 )
@@ -997,6 +1053,7 @@ def get_registry() -> list[ComponentSpec]:
             _continue_rules(),
             _continue_mcp(),
             _aider_read(),
+            _hermes_mcp(),
             _openclaw_skill(),
         ]
     return _REGISTRY

--- a/python/rafter_cli/commands/scan.py
+++ b/python/rafter_cli/commands/scan.py
@@ -107,6 +107,7 @@ def scan_local(
         _output_sarif,
         _watch_and_scan,
         _apply_baseline,
+        _apply_exclude_paths,
         _load_baseline_entries,
     )
     from ..core.config_manager import ConfigManager
@@ -164,6 +165,9 @@ def scan_local(
             resolved = os.path.join(repo_root, f)
             if os.path.isfile(resolved):
                 all_results.extend(_scan_file(resolved, eng, custom_patterns))
+        # sable-yz0 — honor scan.exclude_paths in --diff mode too.
+        exclude = scan_cfg.exclude_paths if scan_cfg else None
+        all_results = _apply_exclude_paths(all_results, exclude, repo_root)
         filtered = _apply_baseline(all_results, baseline_entries)
         _output_scan_results(filtered, json_output, quiet, f"files changed since {diff}", format=format, suppressions=suppressions)
         return
@@ -201,6 +205,9 @@ def scan_local(
             resolved = os.path.join(repo_root, f)
             if os.path.isfile(resolved):
                 all_results.extend(_scan_file(resolved, eng, custom_patterns))
+        # sable-yz0 — honor scan.exclude_paths in --staged mode too.
+        exclude = scan_cfg.exclude_paths if scan_cfg else None
+        all_results = _apply_exclude_paths(all_results, exclude, repo_root)
         filtered = _apply_baseline(all_results, baseline_entries)
         _output_scan_results(filtered, json_output, quiet, "staged files", format=format, suppressions=suppressions)
         return

--- a/python/rafter_cli/core/policy_loader.py
+++ b/python/rafter_cli/core/policy_loader.py
@@ -9,20 +9,41 @@ from pathlib import Path
 from ..utils.git import get_git_root
 
 
+#: Policy file candidates, in precedence order (sable-c1c).
+#:
+#: The cloud scanner (rafter-backend) reads ``.rafter/config.yml`` (subdir
+#: + ``config.yml``), while the CLI canonical is ``.rafter.yml``. The CLI
+#: reads both indefinitely so customers writing either shape get the same
+#: behavior locally. Canonical dotfile takes precedence; backend file is
+#: the fallback. Schema compatibility (top-level ``exclude_paths`` /
+#: ``custom_patterns`` vs nested ``scan.*``) is handled in ``_map_policy``.
+POLICY_FILE_CANDIDATES: list[Path] = [
+    Path(".rafter.yml"),
+    Path(".rafter.yaml"),
+    Path(".rafter") / "config.yml",
+    Path(".rafter") / "config.yaml",
+]
+
+# Back-compat alias for code outside this module that imported the previous
+# constant. Resolves to the canonical-dotfile names only (subset).
 POLICY_FILENAMES = [".rafter.yml", ".rafter.yaml"]
 _KNOWN_DOC_KEYS = {"id", "path", "url", "description", "tags", "cache"}
 
 
 def find_policy_file() -> Path | None:
-    """Walk from cwd up to git root looking for a policy file."""
+    """Walk from cwd up to git root looking for a policy file.
+
+    Returns the first candidate that exists, in the precedence order
+    declared by ``POLICY_FILE_CANDIDATES``.
+    """
     cwd = Path.cwd()
     root = get_git_root()
     stop = Path(root) if root else cwd.anchor and Path(cwd.anchor)
 
     current = cwd
     while True:
-        for name in POLICY_FILENAMES:
-            candidate = current / name
+        for candidate_rel in POLICY_FILE_CANDIDATES:
+            candidate = current / candidate_rel
             if candidate.exists():
                 return candidate
         parent = current.parent
@@ -83,6 +104,22 @@ def _map_policy(raw: dict) -> dict:
             policy["scan"]["custom_patterns"] = [
                 {"name": p.get("name", ""), "regex": p.get("regex", ""), "severity": p.get("severity", "high")}
                 for p in scan["custom_patterns"]
+            ]
+
+    # sable-c1c — backend flat-shape compat. rafter-backend reads
+    # exclude_paths / custom_patterns at the top level (no `scan:` nesting),
+    # so customers writing the backend shape get the same behavior locally.
+    # Nested form takes precedence if both are present in the same file.
+    if "scan" not in policy or not policy["scan"].get("exclude_paths"):
+        if isinstance(raw.get("exclude_paths"), list):
+            policy.setdefault("scan", {})
+            policy["scan"]["exclude_paths"] = raw["exclude_paths"]
+    if "scan" not in policy or not policy["scan"].get("custom_patterns"):
+        if isinstance(raw.get("custom_patterns"), list):
+            policy.setdefault("scan", {})
+            policy["scan"]["custom_patterns"] = [
+                {"name": p.get("name", ""), "regex": p.get("regex", ""), "severity": p.get("severity", "high")}
+                for p in raw["custom_patterns"]
             ]
 
     ignore = raw.get("ignore")
@@ -179,7 +216,11 @@ def _derive_doc_id(source: str, kind: str) -> str:
     return hashlib.sha256(source.encode("utf-8")).hexdigest()[:8]
 
 
-_VALID_TOP_LEVEL_KEYS = {"version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs"}
+_VALID_TOP_LEVEL_KEYS = {
+    "version", "risk_level", "command_policy", "scan", "ignore", "audit", "docs",
+    # sable-c1c — backend flat-shape compat keys.
+    "exclude_paths", "custom_patterns",
+}
 _VALID_RISK_LEVELS = {"minimal", "moderate", "aggressive"}
 _VALID_COMMAND_MODES = {"allow-all", "approve-dangerous", "deny-list"}
 _VALID_LOG_LEVELS = {"debug", "info", "warn", "error"}

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.3
+version: 0.8.4
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/rafter_cli/scanners/secret_patterns.py
+++ b/python/rafter_cli/scanners/secret_patterns.py
@@ -88,6 +88,13 @@ DEFAULT_SECRET_PATTERNS: list[Pattern] = [
         severity="critical",
         description="Twilio API Key detected",
     ),
+    # HashiCorp Vault
+    Pattern(
+        name="HashiCorp Vault Token",
+        regex=r"hvs\.[a-zA-Z0-9_-]{90,}",
+        severity="critical",
+        description="HashiCorp Vault service token detected",
+    ),
     # Generic
     Pattern(
         name="Generic API Key",

--- a/python/rafter_cli/utils/skill_manager.py
+++ b/python/rafter_cli/utils/skill_manager.py
@@ -1,22 +1,45 @@
 """Skill manager for OpenClaw integration — Python port of Node skill-manager.ts."""
 from __future__ import annotations
 
-import importlib.resources
-import re
 from pathlib import Path
 
 
 class SkillManager:
-    """Manage OpenClaw skill installation and detection."""
+    """Manage OpenClaw skill installation and detection.
+
+    OpenClaw auto-discovers ClawHub-shaped skills from
+    ``<workspace>/skills/<skill>/SKILL.md`` (default workspace
+    ``~/.openclaw/workspace/``). rafter ≤ 0.7.7 wrote a loose
+    ``~/.openclaw/skills/<name>.md`` file that OpenClaw never read; the canonical
+    path was adopted in rf-zgwj. Detection here must match the installer and
+    ``agent verify`` — checking the legacy path is a false negative.
+    """
+
+    def get_openclaw_root(self) -> Path:
+        return Path.home() / ".openclaw"
 
     def get_openclaw_skills_dir(self) -> Path:
-        return Path.home() / ".openclaw" / "skills"
+        return self.get_openclaw_root() / "workspace" / "skills"
+
+    def get_rafter_skill_dir(self) -> Path:
+        return self.get_openclaw_skills_dir() / "rafter-security"
 
     def get_rafter_skill_path(self) -> Path:
-        return self.get_openclaw_skills_dir() / "rafter-security.md"
+        return self.get_rafter_skill_dir() / "SKILL.md"
+
+    def get_legacy_rafter_skill_path(self) -> Path:
+        """Legacy install path used by rafter ≤ 0.7.7. Removed on reinstall."""
+        return self.get_openclaw_root() / "skills" / "rafter-security.md"
 
     def is_openclaw_installed(self) -> bool:
-        return self.get_openclaw_skills_dir().exists()
+        """Detect the platform root (~/.openclaw). A fresh OpenClaw install has
+        no workspace skills dir yet, so checking the skills dir gives a
+        false-negative until at least one skill is written."""
+        return self.get_openclaw_root().exists()
+
+    def has_legacy_rafter_skill(self) -> bool:
+        """True when the rafter ≤ 0.7.7 flat file is present (migration note)."""
+        return self.get_legacy_rafter_skill_path().exists()
 
     def is_rafter_skill_installed(self) -> bool:
         return self.get_rafter_skill_path().exists()

--- a/python/tests/test_agent_init.py
+++ b/python/tests/test_agent_init.py
@@ -86,6 +86,69 @@ class TestInstallHermesMcp:
         assert config["mcp_servers"]["rafter"]["command"] == "rafter"
 
 
+class TestHermesDetection:
+    """sable-gyw item 6 — Hermes must surface in verify / status / list."""
+
+    def test_check_hermes_not_detected(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _check_hermes
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _check_hermes()
+        assert not result.passed
+        assert result.optional
+        assert "not detected" in result.detail.lower()
+
+    def test_check_hermes_pass_after_install(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _check_hermes, _install_hermes_mcp
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _install_hermes_mcp(tmp_path)
+        result = _check_hermes()
+        assert result.passed
+        assert "configured" in result.detail.lower()
+
+    def test_check_hermes_warns_when_config_lacks_rafter(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _check_hermes
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "config.yaml").write_text(yaml.safe_dump({"mcp_servers": {"other": {"command": "other"}}}))
+        result = _check_hermes()
+        assert not result.passed
+        assert result.optional  # warn, not hard fail
+
+    def test_detect_agent_platforms_includes_hermes(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _detect_agent_platforms
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".hermes").mkdir()
+        assert "hermes" in _detect_agent_platforms()
+
+    def test_hermes_mcp_component_registered(self, tmp_path, monkeypatch):
+        from rafter_cli.commands import agent_components
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        agent_components.reset_registry_cache()
+        try:
+            ids = [c.id for c in agent_components.get_registry()]
+            assert "hermes.mcp" in ids
+        finally:
+            agent_components.reset_registry_cache()
+
+    def test_hermes_mcp_component_install_uninstall(self, tmp_path, monkeypatch):
+        from rafter_cli.commands import agent_components
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        agent_components.reset_registry_cache()
+        try:
+            spec = agent_components.resolve_component("hermes.mcp")
+            assert spec is not None
+            assert not spec.is_installed()
+            spec.install()
+            assert spec.is_installed()
+            config = yaml.safe_load((tmp_path / ".hermes" / "config.yaml").read_text())
+            assert config["mcp_servers"]["rafter"]["command"] == "rafter"
+            spec.uninstall()
+            assert not spec.is_installed()
+        finally:
+            agent_components.reset_registry_cache()
+
+
 class TestInstallClaudeCodeHooks:
     def test_creates_settings_from_scratch(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)

--- a/python/tests/test_agent_init.py
+++ b/python/tests/test_agent_init.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import yaml
+
 from rafter_cli.commands.agent import (
     _install_claude_code_hooks,
     _install_claude_code_mcp,
@@ -14,7 +16,74 @@ from rafter_cli.commands.agent import (
     _install_continue_dev_mcp,
     _install_continue_dev_rules,
     _install_aider_read,
+    _install_hermes_mcp,
 )
+
+
+class TestInstallHermesMcp:
+    def test_creates_config_from_scratch(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _install_hermes_mcp(tmp_path)
+
+        config_path = tmp_path / ".hermes" / "config.yaml"
+        assert config_path.exists()
+        config = yaml.safe_load(config_path.read_text())
+        assert config["mcp_servers"]["rafter"]["command"] == "rafter"
+        assert config["mcp_servers"]["rafter"]["args"] == ["mcp", "serve"]
+
+    def test_preserves_existing_servers(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "config.yaml").write_text(yaml.safe_dump({
+            "mcp_servers": {
+                "other": {"command": "other", "args": ["go"]},
+            },
+            "log_level": "debug",
+        }))
+
+        _install_hermes_mcp(tmp_path)
+
+        config = yaml.safe_load((hermes_dir / "config.yaml").read_text())
+        assert "other" in config["mcp_servers"]
+        assert "rafter" in config["mcp_servers"]
+        # Non-mcp_servers top-level keys must survive the merge.
+        assert config["log_level"] == "debug"
+
+    def test_idempotent_on_reinstall(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _install_hermes_mcp(tmp_path)
+        first = (tmp_path / ".hermes" / "config.yaml").read_text()
+
+        _install_hermes_mcp(tmp_path)
+        second = (tmp_path / ".hermes" / "config.yaml").read_text()
+
+        assert first == second, "second install should be a no-op"
+
+    def test_recovers_from_unreadable_yaml(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        # Deliberately broken YAML — installer must not raise; should
+        # warn and write a fresh config containing the rafter entry.
+        (hermes_dir / "config.yaml").write_text("mcp_servers: [this is not\n  a valid: mapping")
+
+        assert _install_hermes_mcp(tmp_path)
+        config = yaml.safe_load((hermes_dir / "config.yaml").read_text())
+        assert "rafter" in config["mcp_servers"]
+
+    def test_replaces_array_shape_mcp_servers(self, tmp_path, monkeypatch):
+        """If a user wrote `mcp_servers:` as a list (wrong shape), the
+        installer must coerce it to a dict rather than blow up."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "config.yaml").write_text(yaml.safe_dump({"mcp_servers": ["junk"]}))
+
+        assert _install_hermes_mcp(tmp_path)
+        config = yaml.safe_load((hermes_dir / "config.yaml").read_text())
+        assert isinstance(config["mcp_servers"], dict)
+        assert config["mcp_servers"]["rafter"]["command"] == "rafter"
 
 
 class TestInstallClaudeCodeHooks:

--- a/python/tests/test_agent_status.py
+++ b/python/tests/test_agent_status.py
@@ -50,3 +50,95 @@ class TestAgentStatusJson:
         assert payload["installed"] is True
         assert {"claude-code", "cursor"}.issubset(set(payload["agents_detected"]))
         assert "pre-commit" in payload["hooks_installed"]
+
+
+class TestAgentStatusOpenClaw:
+    """sable-1vq — `agent status` must report OpenClaw via the canonical
+    ClawHub workspace path (rf-zgwj), matching the installer and `agent verify`.
+    Checking the legacy flat path was a false negative."""
+
+    def test_reports_skill_installed_at_canonical_path_after_init(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _install_openclaw_skill
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".openclaw").mkdir()
+
+        ok, _src, _dest, _err = _install_openclaw_skill()
+        assert ok
+
+        result = runner.invoke(agent_app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "OpenClaw:     skill installed" in result.output
+        assert "workspace/skills/rafter-security/SKILL.md" in result.output
+        assert "detected but skill missing" not in result.output
+
+    def test_reports_detected_but_missing_when_no_skill(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".openclaw").mkdir()
+
+        result = runner.invoke(agent_app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "OpenClaw:     detected but skill missing" in result.output
+
+    def test_surfaces_migration_hint_for_legacy_only_install(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        legacy = tmp_path / ".openclaw" / "skills" / "rafter-security.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("---\nname: rafter-security\nversion: 0.6.0\n---\n# old\n")
+
+        result = runner.invoke(agent_app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "legacy skill at" in result.output
+        assert "(not loaded)" in result.output
+
+    def test_reports_not_detected_without_openclaw(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = runner.invoke(agent_app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "OpenClaw:     not detected" in result.output
+
+
+class TestSkillManagerCanonicalPaths:
+    """SkillManager must use canonical ClawHub paths in parity with the Node
+    implementation (node/src/utils/skill-manager.ts)."""
+
+    def test_paths_point_at_workspace_skills(self, tmp_path, monkeypatch):
+        from rafter_cli.utils.skill_manager import SkillManager
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        sm = SkillManager()
+        assert sm.get_openclaw_root() == tmp_path / ".openclaw"
+        assert sm.get_openclaw_skills_dir() == tmp_path / ".openclaw" / "workspace" / "skills"
+        assert sm.get_rafter_skill_path() == tmp_path / ".openclaw" / "workspace" / "skills" / "rafter-security" / "SKILL.md"
+        assert sm.get_legacy_rafter_skill_path() == tmp_path / ".openclaw" / "skills" / "rafter-security.md"
+
+    def test_is_openclaw_installed_detects_root_not_skills_dir(self, tmp_path, monkeypatch):
+        from rafter_cli.utils.skill_manager import SkillManager
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        sm = SkillManager()
+        assert not sm.is_openclaw_installed()
+        (tmp_path / ".openclaw").mkdir()
+        # Fresh OpenClaw root with no skills dir yet must still detect.
+        assert sm.is_openclaw_installed()
+
+    def test_detection_round_trip_via_installer(self, tmp_path, monkeypatch):
+        from rafter_cli.commands.agent import _install_openclaw_skill
+        from rafter_cli.utils.skill_manager import SkillManager
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".openclaw").mkdir()
+        sm = SkillManager()
+        assert not sm.is_rafter_skill_installed()
+
+        ok, _src, _dest, _err = _install_openclaw_skill()
+        assert ok
+        assert sm.is_rafter_skill_installed()
+        assert not sm.has_legacy_rafter_skill()
+
+    def test_has_legacy_rafter_skill(self, tmp_path, monkeypatch):
+        from rafter_cli.utils.skill_manager import SkillManager
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        legacy = tmp_path / ".openclaw" / "skills" / "rafter-security.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("legacy")
+        sm = SkillManager()
+        assert sm.has_legacy_rafter_skill()
+        assert not sm.is_rafter_skill_installed()

--- a/python/tests/test_agent_status.py
+++ b/python/tests/test_agent_status.py
@@ -1,0 +1,52 @@
+"""Tests for rafter agent status."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from rafter_cli.commands.agent import agent_app
+
+
+runner = CliRunner()
+
+
+class TestAgentStatusJson:
+    def test_outputs_machine_readable_json(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = runner.invoke(agent_app, ["status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["installed"] is False
+        assert isinstance(payload["version"], str)
+        assert payload["agents_detected"] == []
+        assert isinstance(payload["hooks_installed"], list)
+        assert isinstance(payload["betterleaks_available"], bool)
+        assert payload["config_path"] == "~/.rafter/config.json"
+        assert payload["audit_log_path"] == "~/.rafter/audit.jsonl"
+        assert "Rafter Agent Status" not in result.output
+
+    def test_reports_detected_agents_and_installed_git_hooks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        rafter_dir = tmp_path / ".rafter"
+        rafter_dir.mkdir()
+        (rafter_dir / "config.json").write_text("{}", encoding="utf-8")
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".cursor").mkdir()
+
+        hooks_dir = rafter_dir / "git-hooks"
+        hooks_dir.mkdir()
+        hook = hooks_dir / "pre-commit"
+        hook.write_text("#!/bin/sh\n# Rafter Security Pre-Commit Hook\n", encoding="utf-8")
+        hook.chmod(0o755)
+
+        result = runner.invoke(agent_app, ["status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["installed"] is True
+        assert {"claude-code", "cursor"}.issubset(set(payload["agents_detected"]))
+        assert "pre-commit" in payload["hooks_installed"]

--- a/python/tests/test_policy.py
+++ b/python/tests/test_policy.py
@@ -4,7 +4,68 @@ from __future__ import annotations
 import json
 
 from rafter_cli.commands.policy import _generate_claude_config
-from rafter_cli.core.policy_loader import _validate_policy, _map_policy
+from rafter_cli.core.policy_loader import _validate_policy, _map_policy, find_policy_file, load_policy
+
+
+class TestBackendCompat:
+    """sable-c1c — CLI reads .rafter/config.yml indefinitely and accepts
+    backend's flat-shape schema alongside the canonical nested form."""
+
+    def test_finds_subdir_config_yml_as_fallback(self, tmp_path, monkeypatch):
+        import subprocess
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        (tmp_path / ".rafter").mkdir()
+        (tmp_path / ".rafter" / "config.yml").write_text("version: '1'\n")
+        monkeypatch.chdir(tmp_path)
+        assert find_policy_file() == tmp_path / ".rafter" / "config.yml"
+
+    def test_finds_subdir_config_yaml_as_fallback(self, tmp_path, monkeypatch):
+        import subprocess
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        (tmp_path / ".rafter").mkdir()
+        (tmp_path / ".rafter" / "config.yaml").write_text("version: '1'\n")
+        monkeypatch.chdir(tmp_path)
+        assert find_policy_file() == tmp_path / ".rafter" / "config.yaml"
+
+    def test_dotfile_wins_over_subdir(self, tmp_path, monkeypatch):
+        import subprocess
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        (tmp_path / ".rafter.yml").write_text("version: 'dot'\n")
+        (tmp_path / ".rafter").mkdir()
+        (tmp_path / ".rafter" / "config.yml").write_text("version: 'subdir'\n")
+        monkeypatch.chdir(tmp_path)
+        assert find_policy_file() == tmp_path / ".rafter.yml"
+        policy = load_policy()
+        assert policy["version"] == "dot"
+
+    def test_top_level_exclude_paths_accepted(self):
+        raw = {"exclude_paths": ["scripts/", "components/common/Mermaid.tsx"]}
+        result = _validate_policy(_map_policy(raw), raw)
+        assert result["scan"]["exclude_paths"] == ["scripts/", "components/common/Mermaid.tsx"]
+
+    def test_top_level_custom_patterns_accepted(self):
+        raw = {
+            "custom_patterns": [
+                {"name": "Foo", "regex": "foo-[a-z0-9]+", "severity": "high"},
+            ],
+        }
+        result = _validate_policy(_map_policy(raw), raw)
+        assert result["scan"]["custom_patterns"][0]["name"] == "Foo"
+
+    def test_nested_wins_over_top_level(self):
+        raw = {
+            "exclude_paths": ["flat"],
+            "scan": {"exclude_paths": ["nested"]},
+        }
+        result = _validate_policy(_map_policy(raw), raw)
+        assert result["scan"]["exclude_paths"] == ["nested"]
+
+    def test_no_warnings_for_compat_keys(self, capsys):
+        raw = {"exclude_paths": ["foo/"], "custom_patterns": []}
+        _validate_policy(_map_policy(raw), raw)
+        err = capsys.readouterr().err
+        assert "exclude_paths" not in err
+        assert "custom_patterns" not in err
 
 
 class TestGenerateClaudeConfig:

--- a/python/tests/test_regex_scanner.py
+++ b/python/tests/test_regex_scanner.py
@@ -64,6 +64,18 @@ def test_scan_text(scanner):
     assert len(matches) > 0
 
 
+def test_scan_text_detects_hashicorp_vault_token(scanner):
+    token = "hv" + "s." + ("A" * 90)
+    matches = scanner.scan_text(token)
+    assert any(m.pattern.name == "HashiCorp Vault Token" for m in matches)
+
+
+def test_scan_text_ignores_short_hashicorp_vault_like_string(scanner):
+    token = "hv" + "s." + ("A" * 32)
+    matches = scanner.scan_text(token)
+    assert not any(m.pattern.name == "HashiCorp Vault Token" for m in matches)
+
+
 def test_has_secrets(scanner):
     assert scanner.has_secrets("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")
     assert not scanner.has_secrets("just a normal string")

--- a/python/tests/test_scan_exclude_paths.py
+++ b/python/tests/test_scan_exclude_paths.py
@@ -1,0 +1,146 @@
+"""Regression tests for sable-yz0 (Python parity).
+
+Three layers of coverage:
+
+1. ``_path_matches_exclude_pattern`` — the pure matching function.
+   Same semantics as Node ``pathMatchesExcludePattern``.
+2. ``_apply_exclude_paths`` — the chokepoint that turns a list of
+   ``ScanResult`` into a filtered list. This is what plugs into the
+   betterleaks + patterns engines and the staged / diff modes.
+3. ``_scan_directory`` end-to-end via the in-repo RegexScanner — proves
+   the chokepoint catches what the walker-level filter missed.
+
+We test the helpers directly (mirroring ``test_agent_init.py``) rather
+than subprocessing the CLI, so the suite runs in any environment that
+can import the package — CI installs the package via ``pip install -e``;
+local dev may not.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from rafter_cli.commands.agent import (
+    _apply_exclude_paths,
+    _path_matches_exclude_pattern,
+    _scan_directory,
+)
+from rafter_cli.core.pattern_engine import PatternMatch
+from rafter_cli.scanners.regex_scanner import ScanResult
+
+# Stripe-style key, split so this file doesn't trip its own scanner.
+FAKE_STRIPE = "sk" + "_live_" + "1234567890abcdefghijklmn"
+
+
+def _make_result(file_path: str) -> ScanResult:
+    """Build a minimal ScanResult with one fake match for filtering tests."""
+    from rafter_cli.core.pattern_engine import Pattern
+    p = Pattern(name="Test", regex="x", severity="high", description="t")
+    m = PatternMatch(pattern=p, match="x", line=1, column=1, redacted="x")
+    return ScanResult(file=file_path, matches=[m])
+
+
+class TestPathMatchesExcludePattern:
+    def test_exact_match(self):
+        assert _path_matches_exclude_pattern("components/common/Mermaid.tsx", "components/common/Mermaid.tsx")
+        assert not _path_matches_exclude_pattern("components/common/Other.tsx", "components/common/Mermaid.tsx")
+
+    def test_directory_prefix_no_slash(self):
+        assert _path_matches_exclude_pattern("scripts/dev.ts", "scripts")
+        assert _path_matches_exclude_pattern("scripts/sub/foo.ts", "scripts")
+        assert not _path_matches_exclude_pattern("scripted/foo.ts", "scripts")
+
+    def test_directory_prefix_trailing_slash(self):
+        assert _path_matches_exclude_pattern("scripts/dev.ts", "scripts/")
+        assert _path_matches_exclude_pattern("scripts/sub/foo.ts", "scripts/")
+
+    def test_dirname_anywhere(self):
+        """Bare name matches a dir at any depth — preserves the prior
+        RegexScanner walker behavior so users with `node_modules` keep
+        working for nested copies."""
+        assert _path_matches_exclude_pattern("pkg/node_modules/foo.ts", "node_modules")
+        assert not _path_matches_exclude_pattern("pkg/notnode_modules/foo.ts", "node_modules")
+
+    def test_glob_with_recursion(self):
+        assert _path_matches_exclude_pattern("supabase/migrations/foo.sql", "**/*.sql")
+        assert not _path_matches_exclude_pattern("supabase/migrations/foo.json", "**/*.sql")
+
+    def test_glob_extension_anywhere(self):
+        assert _path_matches_exclude_pattern("a/b/c/foo.snap", "*.snap")
+        assert _path_matches_exclude_pattern("foo.snap", "*.snap")
+
+    def test_empty_pattern_never_matches(self):
+        assert not _path_matches_exclude_pattern("anything", "")
+        assert not _path_matches_exclude_pattern("anything", "/")
+
+
+class TestApplyExcludePaths:
+    """Chokepoint filter — what plugs into both scan engines."""
+
+    def test_no_excludes_returns_unchanged(self):
+        results = [_make_result("/repo/a.ts"), _make_result("/repo/b.ts")]
+        assert _apply_exclude_paths(results, None, "/repo") == results
+        assert _apply_exclude_paths(results, [], "/repo") == results
+
+    def test_customer_repro(self, tmp_path):
+        """User's exact .rafter.yml — three excludes, one safe path."""
+        results = [
+            _make_result(str(tmp_path / "scripts" / "dev.ts")),
+            _make_result(str(tmp_path / "components" / "common" / "Mermaid.tsx")),
+            _make_result(str(tmp_path / "supabase" / "migrations" / "20250215000000_resend_setup.sql")),
+            _make_result(str(tmp_path / "safe" / "leaky.ts")),
+        ]
+        excludes = [
+            "scripts/",
+            "components/common/Mermaid.tsx",
+            "supabase/migrations/20250215000000_resend_setup.sql",
+        ]
+        kept = _apply_exclude_paths(results, excludes, str(tmp_path))
+        assert len(kept) == 1
+        assert kept[0].file.endswith("safe/leaky.ts")
+
+    def test_filter_resolves_relative_to_scan_root(self, tmp_path):
+        """A multi-segment exclude must match against the path relative
+        to scan_root, not the absolute path."""
+        results = [_make_result(str(tmp_path / "components" / "common" / "Mermaid.tsx"))]
+        assert _apply_exclude_paths(results, ["components/common/Mermaid.tsx"], str(tmp_path)) == []
+
+    def test_glob(self, tmp_path):
+        results = [
+            _make_result(str(tmp_path / "supabase" / "migrations" / "x.sql")),
+            _make_result(str(tmp_path / "safe.ts")),
+        ]
+        kept = _apply_exclude_paths(results, ["**/*.sql"], str(tmp_path))
+        assert len(kept) == 1
+        assert kept[0].file.endswith("safe.ts")
+
+
+class TestScanDirectoryEndToEnd:
+    """Plant real fake secrets, run _scan_directory, assert chokepoint filtered."""
+
+    def test_full_repro(self, tmp_path):
+        from rafter_cli.core.config_schema import ScanConfig
+
+        for sub in ("scripts", "components/common", "supabase/migrations", "safe"):
+            (tmp_path / sub).mkdir(parents=True)
+        (tmp_path / "scripts" / "dev.ts").write_text(f"// {FAKE_STRIPE}\n")
+        (tmp_path / "components" / "common" / "Mermaid.tsx").write_text(f"// {FAKE_STRIPE}\n")
+        (tmp_path / "supabase" / "migrations" / "20250215000000_resend_setup.sql").write_text(f"-- {FAKE_STRIPE}\n")
+        (tmp_path / "safe" / "leaky.ts").write_text(f"// {FAKE_STRIPE}\n")
+
+        scan_cfg = ScanConfig(
+            exclude_paths=[
+                "scripts/",
+                "components/common/Mermaid.tsx",
+                "supabase/migrations/20250215000000_resend_setup.sql",
+            ],
+            custom_patterns=[],
+            ignore=[],
+        )
+
+        results = _scan_directory(str(tmp_path), engine="patterns", scan_cfg=scan_cfg, respect_gitignore=False)
+        files = sorted(r.file for r in results)
+        assert len(files) == 1, f"expected only safe/leaky.ts, got: {files}"
+        assert files[0].endswith("safe/leaky.ts")

--- a/recipes/hermes.md
+++ b/recipes/hermes.md
@@ -1,0 +1,63 @@
+# Hermes Setup
+
+Rafter's Hermes integration installs the Rafter MCP server into Hermes' user-scope config. v0 is MCP-only — `scan_secrets`, `evaluate_command`, `read_audit_log`, and `get_config` tools become available to Hermes once the config block is in place. Pre/post-tool hooks are deferred to a follow-on once Hermes' hook surface is documented; track this under bead `sable-gyw` follow-ons.
+
+## Install the CLI first
+
+```sh
+npm install -g @rafter-security/cli   # Node
+# or:
+pip install rafter-cli                 # Python
+```
+
+> Using `npx`? The canonical form is `npx @rafter-security/cli` — the bare `npx rafter-cli` resolves to an **unrelated** package on npm.
+
+## Automatic setup
+
+```sh
+rafter agent init --with-hermes
+```
+
+Auto-detects `~/.hermes`. The Rafter MCP server entry is merged into `~/.hermes/config.yaml` under `mcp_servers.rafter` — existing servers and other top-level YAML keys are preserved.
+
+User scope only — Hermes itself reads `~/.hermes/config.yaml`, and `rafter agent init --local --with-hermes` is intentionally not supported in v0 (Hermes does not have an established project-local config story).
+
+## Manual setup
+
+Append the following to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  rafter:
+    command: rafter
+    args:
+      - mcp
+      - serve
+```
+
+Restart Hermes so it picks up the new server. Verify:
+
+```sh
+rafter agent verify
+```
+
+## What you get
+
+The Rafter MCP server exposes four tools to Hermes:
+
+| Tool | Purpose |
+|---|---|
+| `scan_secrets` | Scan text or files for credentials before sending them across an agent boundary |
+| `evaluate_command` | Classify a shell command's risk (`critical` / `high` / `medium` / `low`) before executing |
+| `read_audit_log` | Inspect the JSON-lines audit log (`~/.rafter/audit.jsonl`) — every scan, every blocked command, with SHA-256 chain integrity |
+| `get_config` | Read the active Rafter config (risk-level, custom patterns, audit settings) |
+
+Plus two resources (`rafter://config`, `rafter://policy`) that surface the live config and `.rafter.yml` policy as MCP resources.
+
+## Troubleshooting
+
+**`agent init --with-hermes` says "Hermes requested but not detected."** Rafter looks for `~/.hermes/`. If Hermes is installed elsewhere, point it at the right home: `HOME=/custom/path rafter agent init --with-hermes`, or `rafter agent init --local --with-hermes` from inside a project that has its own `.hermes/` directory (project-local is treated as opt-in v0 — the config is written but Hermes itself may or may not consume it).
+
+**`mcp_servers.rafter` already exists in my config.** The installer replaces the `rafter` entry idempotently — every other server and key in the file is preserved untouched. Run `rafter agent init --with-hermes` whenever you upgrade the CLI to refresh the entry.
+
+**My YAML config got rewritten in a different style after `agent init`.** YAML round-trips through PyYAML (Python) / js-yaml (Node) lose comments and reorder keys. If you have a hand-curated config, prefer the manual setup above and pin the rafter block in place by hand.

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -809,6 +809,22 @@ With `--probe`, an additional `Claude Code (probe)` check appears as the last en
 
 Show agent security status dashboard. Displays config summary, installed integrations, audit log summary, and recent events.
 
+- `--json` — output machine-readable status JSON
+
+**JSON schema (`--json`):**
+
+```json
+{
+  "installed": true,
+  "version": "0.8.3",
+  "agents_detected": ["claude-code", "cursor"],
+  "hooks_installed": ["pre-commit"],
+  "betterleaks_available": true,
+  "config_path": "~/.rafter/config.json",
+  "audit_log_path": "~/.rafter/audit.jsonl"
+}
+```
+
 ### rafter agent update-betterleaks [OPTIONS]
 
 Update (or reinstall) the managed betterleaks binary.

--- a/shared-docs/PLATFORM_PARITY_AUDIT.md
+++ b/shared-docs/PLATFORM_PARITY_AUDIT.md
@@ -245,7 +245,7 @@ Total: roughly 7-8 days of focused work for full parity. CI integration tests pe
 
 ## Out of scope for rf-cia
 
-- New platform support (Hermes / future Continue extensions / etc.) — track separately under rf-01b and similar.
+- New platform support — track separately. (Hermes landed under sable-gyw: MCP-only v0 via `--with-hermes`, with init/verify/status/list detection in both runtimes; hooks deferred pending a confirmed Hermes hook surface.)
 - Sub-agent equivalents on Codex/Cursor/etc. — none of those platforms have a first-class sub-agent primitive today. Watch quarterly.
 - The `rafter review` standalone command — separate bead rf-0z9, on hold for user review.
 


### PR DESCRIPTION
## Ship to prod

Promotes `main` → `prod`. The `publish.yaml` workflow fires on this merge and will publish **v0.8.4** to npm (via OIDC Trusted Publishing), PyPI (with `--skip-existing` idempotency), and ClawHub, then create the `v0.8.4` GitHub Release (which is what GitHub Marketplace picks up to republish the root `/action.yml` listing entry), then smoke-test against the live registries.

## What ships in this release

Headline impact: the customer's `.rafter.yml` triage flow is fully working on local scans now. Backend's matching work for remote scans is still in flight.

### Fixed
- **#152 (sable-yz0) — `rafter secrets` honors `.rafter.yml scan.exclude_paths` on both engines.** Customer-reported P0. Betterleaks engine no longer silently drops `exclude_paths`; pattern semantics now cover file paths, dir prefixes, dir-name-anywhere, and globs.

### Changed
- **#154 (sable-c1c) — CLI reads `.rafter/config.yml` indefinitely + accepts backend's flat-shape schema.** Both file paths and both schemas accepted, with nested `scan.*` winning on collision.

### Added
- **#151 + #156 (sable-gyw) — Hermes platform support.** Ninth supported platform. `rafter agent init --with-hermes` writes `~/.hermes/config.yaml` (#151); detection now surfaces in `rafter agent verify` / `status` / `list` (#156, the follow-on for the surface I'd explicitly deferred).
- **#153 — `rafter agent status --json`** with a documented schema in `shared-docs/CLI_SPEC.md`.

### Fixed (small follow-on after #155)
- **#157 (sable-1vq) — `rafter agent status` reports OpenClaw via the canonical ClawHub path.** Small consistency fix; not user-blocking, but cleans up status output.

> **CHANGELOG note:** the release chore (#155) was cut against `main` at the time of #154, so the file-based `CHANGELOG.md` doesn't yet mention #156 and #157 — they'll be backfilled into the v0.8.5 entry or amended into the v0.8.4 entry depending on what's tidier. Not blocking the release.

## Pre-flight already green on main

- `validate-release.yml` (push-to-main trigger) — verified all four version sites at `0.8.4`: `node/package.json`, `python/pyproject.toml`, both `rafter-security-skill.md` frontmatter copies.
- All PRs (#151-#157 inclusive) passed their per-PR CI before merging.

## Post-merge verification plan

Phase 1 + 2 — autonomous, ~5 min:
- `curl https://registry.npmjs.org/@rafter-security%2Fcli/0.8.4` → 200
- `curl https://pypi.org/pypi/rafter-cli/0.8.4/json` → 200
- `gh release view v0.8.4`
- `npm i -g @rafter-security/cli@0.8.4 && rafter --version` → `0.8.4`
- Fixture scan, MCP-serve parity check
- Python parity: `pip install rafter-cli==0.8.4 && rafter --version` → `0.8.4`
- **Customer's exact repro (new for v0.8.4):** plant fake Stripe key in `scripts/dev.ts` + `safe/leaky.ts` with `.rafter.yml scan.exclude_paths: [scripts/]` → expect exit 1, only `safe/leaky.ts` reported (proves #152). Then move the same policy to `.rafter/config.yml` with top-level `exclude_paths: [scripts/]` → same result (proves #154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)