### PR TITLE
Cut phantom `// rafter-ignore` from the rafter skill triage doc

### DIFF
--- a/node/resources/skills/rafter/docs/finding-triage.md
+++ b/node/resources/skills/rafter/docs/finding-triage.md
@@ -59,7 +59,7 @@ Suppress only when the finding is a real false positive *for this context*, with
   ```yaml
   ignore:
     - paths: ["tests/fixtures/**", "src/legacy/config.py"]
-      rules: ["AWS Access Key"]   # omit `rules` to suppress every finding on those paths
+      rules: ["AWS Access Key ID"]   # omit `rules` to suppress every finding on those paths
       reason: "fake test keys — no live path"
   ```
   Match `rules` on the finding's **rule name** (case-insensitive), not a hashed `R-…` id. On a local `rafter scan`, suppressed findings move into a `_suppressed[]` array and don't affect the exit code — you only fail on a *non-suppressed* finding. Docs: https://docs.rafter.so/suppression

--- a/node/resources/skills/rafter/docs/finding-triage.md
+++ b/node/resources/skills/rafter/docs/finding-triage.md
@@ -55,8 +55,15 @@ If the finding is a leaked secret that was committed:
 
 Suppress only when the finding is a real false positive *for this context*, with a written reason. Two mechanisms:
 
-- **Inline**: `// rafter-ignore: HARDCODED_API_KEY — test fixture, not a real key`
-- **Baseline**: `rafter agent baseline` snapshots current findings; only *new* findings fail future scans. Good for adopting Rafter on a legacy codebase without a big bang.
+- **`.rafter.yml`**: add an `ignore:` rule naming the path(s), the rule(s), and a `reason` (your evidence). Repo-tied; persists across scans:
+  ```yaml
+  ignore:
+    - paths: ["tests/fixtures/**", "src/legacy/config.py"]
+      rules: ["AWS Access Key"]   # omit `rules` to suppress every finding on those paths
+      reason: "fake test keys — no live path"
+  ```
+  Match `rules` on the finding's **rule name** (case-insensitive), not a hashed `R-…` id. On a local `rafter scan`, suppressed findings move into a `_suppressed[]` array and don't affect the exit code — you only fail on a *non-suppressed* finding. Docs: https://docs.rafter.so/suppression
+- **Baseline**: `rafter agent baseline create` snapshots current findings; scan with `rafter scan --baseline` so only *new* findings surface. Good for adopting Rafter on a legacy codebase without a big bang.
 
 Never suppress by:
 - Commenting out the rule globally.

--- a/python/rafter_cli/resources/skills/rafter/docs/finding-triage.md
+++ b/python/rafter_cli/resources/skills/rafter/docs/finding-triage.md
@@ -59,7 +59,7 @@ Suppress only when the finding is a real false positive *for this context*, with
   ```yaml
   ignore:
     - paths: ["tests/fixtures/**", "src/legacy/config.py"]
-      rules: ["AWS Access Key"]   # omit `rules` to suppress every finding on those paths
+      rules: ["AWS Access Key ID"]   # omit `rules` to suppress every finding on those paths
       reason: "fake test keys — no live path"
   ```
   Match `rules` on the finding's **rule name** (case-insensitive), not a hashed `R-…` id. On a local `rafter scan`, suppressed findings move into a `_suppressed[]` array and don't affect the exit code — you only fail on a *non-suppressed* finding. Docs: https://docs.rafter.so/suppression

--- a/python/rafter_cli/resources/skills/rafter/docs/finding-triage.md
+++ b/python/rafter_cli/resources/skills/rafter/docs/finding-triage.md
@@ -55,8 +55,15 @@ If the finding is a leaked secret that was committed:
 
 Suppress only when the finding is a real false positive *for this context*, with a written reason. Two mechanisms:
 
-- **Inline**: `// rafter-ignore: HARDCODED_API_KEY — test fixture, not a real key`
-- **Baseline**: `rafter agent baseline` snapshots current findings; only *new* findings fail future scans. Good for adopting Rafter on a legacy codebase without a big bang.
+- **`.rafter.yml`**: add an `ignore:` rule naming the path(s), the rule(s), and a `reason` (your evidence). Repo-tied; persists across scans:
+  ```yaml
+  ignore:
+    - paths: ["tests/fixtures/**", "src/legacy/config.py"]
+      rules: ["AWS Access Key"]   # omit `rules` to suppress every finding on those paths
+      reason: "fake test keys — no live path"
+  ```
+  Match `rules` on the finding's **rule name** (case-insensitive), not a hashed `R-…` id. On a local `rafter scan`, suppressed findings move into a `_suppressed[]` array and don't affect the exit code — you only fail on a *non-suppressed* finding. Docs: https://docs.rafter.so/suppression
+- **Baseline**: `rafter agent baseline create` snapshots current findings; scan with `rafter scan --baseline` so only *new* findings surface. Good for adopting Rafter on a legacy codebase without a big bang.
 
 Never suppress by:
 - Commenting out the rule globally.


### PR DESCRIPTION
`docs/finding-triage.md` (node + python skill copies) told agents to suppress findings with `// rafter-ignore: …`. That comment is only implemented in the **VS Code extension** (`vscode/src/secret-scanner.ts`) — the CLI scanner and `rafter run` don't honor it, so an agent following the triage guide would try it and it'd silently do nothing.

Replaces it with the **real** CLI suppression mechanism:
- a `.rafter.yml` `ignore:` rule (`paths` / `rules` / `reason`),
- match `rules` on the rule **name**, not the hashed `R-…` PR-comment id,
- the `_suppressed[]` + exit-code behavior on local scans,
- baseline corrected to `rafter agent baseline create` + `rafter scan --baseline`,
- links to https://docs.rafter.so/suppression.

Verified against the CLI source + the existing suppression/policy/baseline tests (all pass). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)