### PR TITLE
fix(hook): bound stdin read so a never-closing stdin can't wedge the hook

### DIFF
--- a/node/src/commands/hook/posttool.ts
+++ b/node/src/commands/hook/posttool.ts
@@ -142,16 +142,34 @@ function countMatches(scanner: RegexScanner, tool_response: PostToolInput["tool_
   return count;
 }
 
-const STDIN_TIMEOUT_MS = 5000;
+// Bound the stdin read so a hung/never-closing stdin can't wedge the hook.
+// Overridable via env (milliseconds) as an operator safety valve / for tests.
+function stdinTimeoutMs(): number {
+  const n = Number(process.env.RAFTER_HOOK_STDIN_TIMEOUT_MS);
+  return Number.isFinite(n) && n > 0 ? n : 5000;
+}
 
 function readStdin(): Promise<string> {
   return new Promise((resolve) => {
     let data = "";
-    const timeout = setTimeout(() => { resolve(data); }, STDIN_TIMEOUT_MS);
+    const onData = (chunk: string) => { data += chunk; };
+    const finish = () => {
+      clearTimeout(timeout);
+      process.stdin.removeListener("data", onData);
+      process.stdin.removeListener("end", finish);
+      process.stdin.removeListener("error", finish);
+      // A piped stdin with no EOF stays in flowing mode and keeps the Node
+      // event loop alive indefinitely — even after we resolve. Pause it so the
+      // process can exit once the output is written (was a hard hang on the
+      // timeout path: output emitted at 5s but the process never exited).
+      process.stdin.pause();
+      resolve(data);
+    };
+    const timeout = setTimeout(finish, stdinTimeoutMs());
     process.stdin.setEncoding("utf-8");
-    process.stdin.on("data", (chunk) => { data += chunk; });
-    process.stdin.on("end", () => { clearTimeout(timeout); resolve(data); });
-    process.stdin.on("error", () => { clearTimeout(timeout); resolve(data); });
+    process.stdin.on("data", onData);
+    process.stdin.on("end", finish);
+    process.stdin.on("error", finish);
     process.stdin.resume();
   });
 }

--- a/node/src/commands/hook/pretool.ts
+++ b/node/src/commands/hook/pretool.ts
@@ -385,16 +385,34 @@ export function formatStagedSecretReason(scan: StagedScanResult): string {
   ].join("\n");
 }
 
-const STDIN_TIMEOUT_MS = 5000;
+// Bound the stdin read so a hung/never-closing stdin can't wedge the hook.
+// Overridable via env (milliseconds) as an operator safety valve / for tests.
+function stdinTimeoutMs(): number {
+  const n = Number(process.env.RAFTER_HOOK_STDIN_TIMEOUT_MS);
+  return Number.isFinite(n) && n > 0 ? n : 5000;
+}
 
 function readStdin(): Promise<string> {
   return new Promise((resolve) => {
     let data = "";
-    const timeout = setTimeout(() => { resolve(data); }, STDIN_TIMEOUT_MS);
+    const onData = (chunk: string) => { data += chunk; };
+    const finish = () => {
+      clearTimeout(timeout);
+      process.stdin.removeListener("data", onData);
+      process.stdin.removeListener("end", finish);
+      process.stdin.removeListener("error", finish);
+      // A piped stdin with no EOF stays in flowing mode and keeps the Node
+      // event loop alive indefinitely — even after we resolve. Pause it so the
+      // process can exit once the decision is written (was a hard hang on the
+      // timeout path: output emitted at 5s but the process never exited).
+      process.stdin.pause();
+      resolve(data);
+    };
+    const timeout = setTimeout(finish, stdinTimeoutMs());
     process.stdin.setEncoding("utf-8");
-    process.stdin.on("data", (chunk) => { data += chunk; });
-    process.stdin.on("end", () => { clearTimeout(timeout); resolve(data); });
-    process.stdin.on("error", () => { clearTimeout(timeout); resolve(data); });
+    process.stdin.on("data", onData);
+    process.stdin.on("end", finish);
+    process.stdin.on("error", finish);
     process.stdin.resume();
   });
 }

--- a/node/tests/hook-stdin-timeout.test.ts
+++ b/node/tests/hook-stdin-timeout.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { spawn } from "child_process";
+import path from "path";
+
+// Regression: `rafter hook pretool/posttool` must not hang when stdin is held
+// open with no EOF (e.g. a harness that wires up a pipe but never writes/closes
+// it). The read is bounded by a timeout, but the bound only protects OUTPUT
+// latency — the process itself must also EXIT. A piped stdin left in flowing
+// mode keeps the Node event loop alive forever, so the hook hung indefinitely
+// AFTER emitting its decision. The fix pauses stdin on the timeout path.
+//
+// We pin the bound low via RAFTER_HOOK_STDIN_TIMEOUT_MS so the test is fast.
+
+const CLI_ENTRY = path.join(path.resolve(__dirname, ".."), "dist", "index.js");
+const BOUND_MS = 300;
+
+/**
+ * Spawn the real hook subcommand, hold stdin open (never write, never end),
+ * and resolve with how it terminated.
+ */
+function runWithOpenStdin(
+  sub: "pretool" | "posttool",
+): Promise<{ code: number | null; stdout: string; timedOut: boolean }> {
+  return new Promise((resolve) => {
+    const child = spawn("node", [CLI_ENTRY, "hook", sub, "--format", "claude"], {
+      stdio: ["pipe", "pipe", "ignore"],
+      env: { ...process.env, RAFTER_HOOK_STDIN_TIMEOUT_MS: String(BOUND_MS) },
+    });
+
+    let stdout = "";
+    child.stdout.setEncoding("utf-8");
+    child.stdout.on("data", (c) => { stdout += c; });
+
+    // Hard backstop: if the process is still alive well past its own bound,
+    // it hung — record that and kill it so the test fails loudly (not by
+    // timing out the whole suite).
+    const backstop = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve({ code: null, stdout, timedOut: true });
+    }, BOUND_MS + 4000);
+
+    child.on("exit", (code) => {
+      clearTimeout(backstop);
+      resolve({ code, stdout, timedOut: false });
+    });
+
+    // Intentionally never call child.stdin.end() — stdin stays open with no EOF.
+  });
+}
+
+describe("hook stdin read is bounded — process exits even when stdin never closes", () => {
+  it("pretool: exits (fail-open allow) instead of hanging", async () => {
+    const r = await runWithOpenStdin("pretool");
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout || "{}");
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("allow");
+  });
+
+  it("posttool: exits instead of hanging", async () => {
+    const r = await runWithOpenStdin("posttool");
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout || "{}");
+    expect(out.hookSpecificOutput?.hookEventName).toBe("PostToolUse");
+  });
+});

--- a/python/rafter_cli/commands/hook.py
+++ b/python/rafter_cli/commands/hook.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import subprocess
 import sys
@@ -52,6 +53,23 @@ def _format_approval_message(command: str, evaluation) -> str:
 
 _STDIN_TIMEOUT_S = 5
 
+def _stdin_timeout_s() -> float:
+    # Bound the stdin read so a hung/never-closing stdin can't wedge the hook.
+    # Overridable via env (milliseconds, parity with the Node hook) as an
+    # operator safety valve / for tests.
+    raw = os.environ.get("RAFTER_HOOK_STDIN_TIMEOUT_MS")
+    if raw:
+        try:
+            ms = float(raw)
+            # Require finite and positive (parity with the Node `Number.isFinite`
+            # check). `inf`/`nan` must NOT pass — `join(timeout=inf)` would
+            # reintroduce the exact unbounded hang this bound exists to prevent.
+            if math.isfinite(ms) and ms > 0:
+                return ms / 1000.0
+        except ValueError:
+            pass
+    return _STDIN_TIMEOUT_S
+
 def _read_stdin() -> str:
     import threading
     result: list[str] = [""]
@@ -60,9 +78,11 @@ def _read_stdin() -> str:
             result[0] = sys.stdin.read()
         except Exception:
             pass
+    # daemon=True: if stdin never closes, the abandoned reader thread does not
+    # block interpreter exit, so the process exits after the join timeout.
     t = threading.Thread(target=_reader, daemon=True)
     t.start()
-    t.join(timeout=_STDIN_TIMEOUT_S)
+    t.join(timeout=_stdin_timeout_s())
     return result[0]
 
 

--- a/python/tests/test_hook_stdin_timeout.py
+++ b/python/tests/test_hook_stdin_timeout.py
@@ -1,0 +1,54 @@
+"""Regression: the hook stdin read must be bounded so a never-closing stdin
+(a harness that wires up a pipe but never writes/closes it) can't wedge the
+hook. Python uses a daemon reader thread joined with a timeout, so the process
+can exit even if stdin never EOFs. Parity with the Node hook's
+RAFTER_HOOK_STDIN_TIMEOUT_MS override.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+from rafter_cli.commands import hook as hookmod
+
+
+def test_stdin_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("RAFTER_HOOK_STDIN_TIMEOUT_MS", "250")
+    assert hookmod._stdin_timeout_s() == 0.25
+
+    # Unset → default.
+    monkeypatch.delenv("RAFTER_HOOK_STDIN_TIMEOUT_MS", raising=False)
+    assert hookmod._stdin_timeout_s() == hookmod._STDIN_TIMEOUT_S
+
+    # Garbage / non-positive → default (fail safe, never 0/negative).
+    monkeypatch.setenv("RAFTER_HOOK_STDIN_TIMEOUT_MS", "not-a-number")
+    assert hookmod._stdin_timeout_s() == hookmod._STDIN_TIMEOUT_S
+    monkeypatch.setenv("RAFTER_HOOK_STDIN_TIMEOUT_MS", "0")
+    assert hookmod._stdin_timeout_s() == hookmod._STDIN_TIMEOUT_S
+    monkeypatch.setenv("RAFTER_HOOK_STDIN_TIMEOUT_MS", "-100")
+    assert hookmod._stdin_timeout_s() == hookmod._STDIN_TIMEOUT_S
+
+    # Non-finite must NOT pass — float("inf") would make join(timeout=inf) hang
+    # forever, reintroducing the exact bug. Parity with Node's Number.isFinite.
+    for bad in ("inf", "Infinity", "-inf", "nan"):
+        monkeypatch.setenv("RAFTER_HOOK_STDIN_TIMEOUT_MS", bad)
+        assert hookmod._stdin_timeout_s() == hookmod._STDIN_TIMEOUT_S, bad
+
+
+def test_read_stdin_returns_promptly_when_stdin_never_eofs(monkeypatch):
+    class BlockingStdin:
+        """A stdin whose read() blocks forever — i.e. an open pipe with no EOF."""
+
+        def read(self) -> str:
+            time.sleep(60)
+            return "should-never-be-returned"
+
+    monkeypatch.setenv("RAFTER_HOOK_STDIN_TIMEOUT_MS", "200")
+    monkeypatch.setattr(sys, "stdin", BlockingStdin())
+
+    start = time.monotonic()
+    out = hookmod._read_stdin()
+    elapsed = time.monotonic() - start
+
+    assert out == ""  # bailed on the bound, did not wait for the blocked read
+    assert elapsed < 2.0, f"read_stdin took {elapsed:.2f}s — not bounded"

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -888,6 +888,8 @@ On a `git commit` / `git push` (and on `Write`/`Edit`), the hook scans for secre
 
 **Hook off-switch.** The hook can be disabled at runtime from **trusted sources only** — the `RAFTER_DISABLE_HOOKS` / `RAFTER_DISABLE_SECRET_SCAN` / `RAFTER_DISABLE_COMMAND_POLICY` env vars (`1`/`true`/`yes`/`on` = off; `0`/`false` = force-on) and the global `~/.rafter/config.json` `agent.hooks.{enabled,secretScan,commandPolicy}` keys. Env overrides global; default is enabled; a corrupt config or unrecognized value fails safe to enabled. By design this is **never** read from project-local `.rafter.yml`, so a hostile repo cannot ship a config that silently disables a victim's hook. `rafter agent status` reports the effective state and its source. See `shared-docs/CONFIG.md` for the full configuration reference.
 
+**Bounded stdin read.** Both `hook pretool` and `hook posttool` bound their stdin read so a host that opens the hook's stdin but never writes/closes it (no EOF) cannot wedge the hook: after the bound elapses the hook reads whatever arrived (typically nothing), fails open (`allow` / no-op redaction), and the process **exits** — it does not merely emit a decision and keep running. The bound is **5000 ms** by default and is overridable via `RAFTER_HOOK_STDIN_TIMEOUT_MS` (positive integer milliseconds; non-positive or unparseable values fall back to the default). Both implementations honor the same env var identically.
+
 ### rafter hook posttool [OPTIONS]
 
 PostToolUse hook handler. Reads tool output from stdin, redacts any secrets found, and writes JSON to stdout.


### PR DESCRIPTION
## Problem

`rafter hook pretool` / `hook posttool` read stdin with a 5s timeout, but on **Node** that timeout only bounded *output latency*, not process exit. A piped stdin with **no EOF** stays in flowing mode and keeps the event loop alive — so after emitting its decision at 5s, the hook process **hung indefinitely**.

Reproduced (before fix):
```
$ sleep 30 | rafter hook pretool --format claude
{"hookSpecificOutput":{...,"permissionDecision":"allow",...}}   # printed at 5s
# ...then hangs forever — outer guard had to SIGKILL it (rc=124)
```

Any host that opens the hook's stdin but never writes/closes it wedges a zombie `node` per tool call. (Reported via `hq-ryfyt` from codegen_security_arena/crew/turing.)

## Fix

- **Node**: on the timeout/end/error paths, remove listeners and `process.stdin.pause()` so the event loop drains and the process exits (~5s, fail-open). Verified: never-closing stdin now exits at ~5.5s default / ~0.9s with a 300ms override.
- **Python**: already exited (daemon reader thread doesn't block interpreter exit) — behavior unchanged; added a clarifying comment.
- Adds **`RAFTER_HOOK_STDIN_TIMEOUT_MS`** (ms, default 5000) as an operator safety valve and to keep tests fast. Both implementations parse it identically: **finite and > 0**, else fall back to default — so `Infinity` / `nan` / `0` / negative / garbage can never re-create the unbounded wait.

## Security review (required gate)

Ran `rafter-code-review` (CWE Top-25 walk) on the diff. One finding, fixed in this PR:

> **Parity/fail-safe gap:** Node rejects non-finite via `Number.isFinite`, but Python's `float("inf") > 0` is `True` → `join(timeout=inf)` would reintroduce the exact hang. Guarded Python with `math.isfinite` to match Node.

Local secrets scan clean on all changed files. `rafter run` (remote SAST) **not** executed — no `RAFTER_API_KEY` in this environment; recommend CI runs it.

## Tests

- **Node** (`hook-stdin-timeout.test.ts`): spawns the real hook with a never-closing stdin, asserts bounded exit + fail-open decision (pretool & posttool).
- **Python** (`test_hook_stdin_timeout.py`): asserts the bound returns promptly on a blocking stdin, and env parsing rejects non-finite / non-positive / garbage.
- All existing hook suites pass. (Note: `hook-integration.test.ts > blocks rm -rf /` fails on `main` too — **pre-existing**, unrelated to this diff; filed separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)