### PR TITLE
fix(config): harden RAFTER_API_KEY handling — 0600 perms, redaction, wire backend.apiKey (sable-q9to)

### DIFF
--- a/node/src/commands/agent/config.ts
+++ b/node/src/commands/agent/config.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { ConfigManager } from "../../core/config-manager.js";
+import { ConfigManager, redactConfigSecrets, isSecretConfigKey, maskSecretValue } from "../../core/config-manager.js";
 import { fmt } from "../../utils/formatter.js";
 
 export function createConfigCommand(): Command {
@@ -13,7 +13,7 @@ export function createConfigCommand(): Command {
     .action(() => {
       const manager = new ConfigManager();
       const cfg = manager.load();
-      console.log(JSON.stringify(cfg, null, 2));
+      console.log(JSON.stringify(redactConfigSecrets(cfg), null, 2));
     });
 
   // Get specific value
@@ -30,8 +30,11 @@ export function createConfigCommand(): Command {
         process.exit(1);
       }
 
+      const leaf = key.split(".").pop() ?? key;
       if (typeof value === "object") {
-        console.log(JSON.stringify(value, null, 2));
+        console.log(JSON.stringify(redactConfigSecrets(value), null, 2));
+      } else if (isSecretConfigKey(leaf) && typeof value === "string") {
+        console.log(maskSecretValue(value));
       } else {
         console.log(value);
       }
@@ -55,7 +58,11 @@ export function createConfigCommand(): Command {
       }
 
       manager.set(key, parsedValue);
-      console.log(fmt.success(`Set ${key} = ${JSON.stringify(parsedValue)}`));
+      const leaf = key.split(".").pop() ?? key;
+      const echo = isSecretConfigKey(leaf) && typeof parsedValue === "string"
+        ? JSON.stringify(maskSecretValue(parsedValue))
+        : JSON.stringify(parsedValue);
+      console.log(fmt.success(`Set ${key} = ${echo}`));
     });
 
   return config;

--- a/node/src/commands/mcp/server.ts
+++ b/node/src/commands/mcp/server.ts
@@ -12,7 +12,7 @@ import { BetterleaksScanner } from "../../scanners/betterleaks.js";
 import { unionScanResults } from "../../scanners/union.js";
 import { CommandInterceptor } from "../../core/command-interceptor.js";
 import { AuditLogger } from "../../core/audit-logger.js";
-import { ConfigManager } from "../../core/config-manager.js";
+import { ConfigManager, redactConfigSecrets, isSecretConfigKey, maskSecretValue } from "../../core/config-manager.js";
 import { listDocs, resolveDocSelector, fetchDoc } from "../../core/docs-loader.js";
 import { writeSuppression } from "../../core/suppression-writer.js";
 import { createRequire } from "module";
@@ -233,7 +233,12 @@ export function createServer(): Server {
       case "get_config": {
         const manager = new ConfigManager();
         const key = args?.key as string | undefined;
-        const value = key ? manager.get(key) : manager.load();
+        const raw = key ? manager.get(key) : manager.load();
+        // Never hand a stored credential (e.g. backend.apiKey) to the MCP client.
+        const leaf = key ? (key.split(".").pop() ?? key) : undefined;
+        const value = leaf && isSecretConfigKey(leaf) && typeof raw === "string"
+          ? maskSecretValue(raw)
+          : redactConfigSecrets(raw);
         return textResult(value);
       }
 
@@ -337,7 +342,7 @@ export function createServer(): Server {
           contents: [{
             uri: "rafter://config",
             mimeType: "application/json",
-            text: JSON.stringify(manager.load(), null, 2),
+            text: JSON.stringify(redactConfigSecrets(manager.load()), null, 2),
           }],
         };
 
@@ -346,7 +351,7 @@ export function createServer(): Server {
           contents: [{
             uri: "rafter://policy",
             mimeType: "application/json",
-            text: JSON.stringify(manager.loadWithPolicy(), null, 2),
+            text: JSON.stringify(redactConfigSecrets(manager.loadWithPolicy()), null, 2),
           }],
         };
 

--- a/node/src/core/config-manager.ts
+++ b/node/src/core/config-manager.ts
@@ -8,6 +8,41 @@ const VALID_RISK_LEVELS = new Set(["minimal", "moderate", "aggressive"]);
 const VALID_COMMAND_MODES = new Set(["allow-all", "approve-dangerous", "deny-list"]);
 const VALID_LOG_LEVELS = new Set(["debug", "info", "warn", "error"]);
 
+// Config keys whose *leaf name* names a bearer credential. Values under these
+// keys must be masked before the config is shown to a human or handed to an MCP
+// client — never logged or echoed in cleartext.
+const SECRET_CONFIG_KEY_RE = /(api_?key|token|secret|password|passwd|credential)/i;
+
+export function isSecretConfigKey(leafKey: string): boolean {
+  return SECRET_CONFIG_KEY_RE.test(leafKey);
+}
+
+/** Mask a credential value, keeping a 4-char prefix for recognizability. */
+export function maskSecretValue(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) return "****";
+  return value.length <= 4 ? "****" : `${value.slice(0, 4)}****`;
+}
+
+/**
+ * Deep-clone a config value, masking any string whose KEY name looks like a
+ * credential. Pure — never mutates the input (so the stored config is unchanged).
+ */
+export function redactConfigSecrets<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => redactConfigSecrets(v)) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = isSecretConfigKey(k) && typeof v === "string"
+        ? maskSecretValue(v)
+        : redactConfigSecrets(v);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}
+
 /**
  * Validate a parsed config JSON object, warning and falling back to defaults for invalid fields.
  */
@@ -144,14 +179,20 @@ export class ConfigManager {
    * Save config to disk
    */
   save(config: RafterConfig): void {
-    // Ensure directory exists
+    // Ensure directory exists (0700 — the dir can hold credentials/audit log).
     const dir = path.dirname(this.configPath);
     if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
     }
 
-    // Write config
-    fs.writeFileSync(this.configPath, JSON.stringify(config, null, 2), "utf-8");
+    // Write config 0600 — it may hold a backend API key. writeFileSync's `mode`
+    // only applies when the file is *created*, so chmod existing files too.
+    fs.writeFileSync(this.configPath, JSON.stringify(config, null, 2), { encoding: "utf-8", mode: 0o600 });
+    try {
+      fs.chmodSync(this.configPath, 0o600);
+    } catch {
+      // Best effort — chmod is a no-op/throws on some platforms (e.g. Windows).
+    }
   }
 
   /**

--- a/node/src/utils/api.ts
+++ b/node/src/utils/api.ts
@@ -1,3 +1,5 @@
+import { ConfigManager } from "../core/config-manager.js";
+
 export const API = "https://rafter.so/api/";
 
 // Exit codes
@@ -42,7 +44,17 @@ export function handleScopeError(e: any): boolean {
 export function resolveKey(cliKey?: string): string {
   if (cliKey) return cliKey;
   if (process.env.RAFTER_API_KEY) return process.env.RAFTER_API_KEY;
-  console.error("No API key provided. Use --api-key or set RAFTER_API_KEY");
+  // Lowest precedence: a key persisted in the GLOBAL ~/.rafter/config.json via
+  // `rafter agent config set backend.apiKey`. Read through load() (global only)
+  // — loadWithPolicy() never merges backend.*, so a project-local .rafter.yml
+  // can NOT inject a key that would redirect scans to another account.
+  try {
+    const stored = new ConfigManager().get("backend.apiKey");
+    if (typeof stored === "string" && stored.trim()) return stored.trim();
+  } catch {
+    // Config unreadable — fall through to the error below.
+  }
+  console.error("No API key provided. Use --api-key, set RAFTER_API_KEY, or run 'rafter agent config set backend.apiKey <key>'");
   process.exit(EXIT_GENERAL_ERROR);
 }
 

--- a/node/tests/config-secret-handling.test.ts
+++ b/node/tests/config-secret-handling.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import {
+  ConfigManager,
+  redactConfigSecrets,
+  maskSecretValue,
+  isSecretConfigKey,
+} from "../src/core/config-manager.js";
+import { resolveKey } from "../src/utils/api.js";
+
+// Hardening for sable-q9to: API key never stored world-readable, never echoed
+// in cleartext, and backend.apiKey is an actual (lowest-precedence) cred source.
+
+describe("config secret handling", () => {
+  describe("redaction helpers", () => {
+    it("masks credential-named keys, leaves the rest, never mutates input", () => {
+      const cfg = {
+        backend: { apiKey: "sk-secret-7777777" },
+        agent: { riskLevel: "moderate" },
+        token: "tok-abcdef",
+        nested: { authToken: "zzzz9999", note: "plain" },
+        list: [{ password: "hunter2xx" }],
+      };
+      const r = redactConfigSecrets(cfg) as any;
+      expect(r.backend.apiKey).toBe("sk-s****");
+      expect(r.token).toBe("tok-****");
+      expect(r.nested.authToken).toBe("zzzz****");
+      expect(r.nested.note).toBe("plain");
+      expect(r.agent.riskLevel).toBe("moderate");
+      expect(r.list[0].password).toBe("hunt****");
+      // input untouched
+      expect(cfg.backend.apiKey).toBe("sk-secret-7777777");
+    });
+
+    it("maskSecretValue handles short/empty/non-string", () => {
+      expect(maskSecretValue("")).toBe("****");
+      expect(maskSecretValue("abcd")).toBe("****");
+      expect(maskSecretValue("abcde")).toBe("abcd****");
+      expect(maskSecretValue(undefined)).toBe("****");
+      expect(maskSecretValue(12345)).toBe("****");
+    });
+
+    it("isSecretConfigKey matches credential leaf names only", () => {
+      for (const k of ["apiKey", "api_key", "apikey", "token", "authToken", "secret", "password", "credential"]) {
+        expect(isSecretConfigKey(k)).toBe(true);
+      }
+      for (const k of ["riskLevel", "mode", "name", "url", "version"]) {
+        expect(isSecretConfigKey(k)).toBe(false);
+      }
+    });
+  });
+
+  describe("save() writes the config 0600", () => {
+    const p = path.join(os.tmpdir(), `rafter-perm-${Date.now()}-${process.pid}.json`);
+    afterEach(() => { if (fs.existsSync(p)) fs.unlinkSync(p); });
+
+    it("a freshly written config is owner-only", () => {
+      new ConfigManager(p).set("backend.apiKey", "sk-xyz");
+      expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+    });
+
+    it("an existing world-readable config is tightened on next write", () => {
+      fs.writeFileSync(p, "{}", { mode: 0o644 });
+      fs.chmodSync(p, 0o644);
+      new ConfigManager(p).set("agent.riskLevel", "minimal");
+      expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+    });
+  });
+
+  describe("resolveKey precedence: --api-key > RAFTER_API_KEY > global config", () => {
+    const origHome = process.env.HOME;
+    const origKey = process.env.RAFTER_API_KEY;
+    let home: string;
+
+    beforeEach(() => {
+      home = fs.mkdtempSync(path.join(os.tmpdir(), "rk-home-"));
+      process.env.HOME = home;
+      delete process.env.RAFTER_API_KEY;
+      // Hand-write the config under the temp HOME — never via a default-path
+      // ConfigManager, so the real ~/.rafter is never touched.
+      const dir = path.join(home, ".rafter");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "config.json"), JSON.stringify({ backend: { apiKey: "CONFIG-key" } }));
+    });
+    afterEach(() => {
+      process.env.HOME = origHome;
+      if (origKey) process.env.RAFTER_API_KEY = origKey; else delete process.env.RAFTER_API_KEY;
+      fs.rmSync(home, { recursive: true, force: true });
+    });
+
+    it("flag wins over env and config", () => {
+      process.env.RAFTER_API_KEY = "ENV-key";
+      expect(resolveKey("FLAG-key")).toBe("FLAG-key");
+    });
+
+    it("env wins over config", () => {
+      process.env.RAFTER_API_KEY = "ENV-key";
+      expect(resolveKey(undefined)).toBe("ENV-key");
+    });
+
+    it("global config backend.apiKey is used when no flag/env (no longer a dead path)", () => {
+      expect(resolveKey(undefined)).toBe("CONFIG-key");
+    });
+  });
+});

--- a/node/tests/mcp-server-integration.test.ts
+++ b/node/tests/mcp-server-integration.test.ts
@@ -64,7 +64,11 @@ vi.mock("../src/core/audit-logger.js", () => ({
   }),
 }));
 
-vi.mock("../src/core/config-manager.js", () => ({
+vi.mock("../src/core/config-manager.js", async (importOriginal) => ({
+  // Keep the real pure helpers (redactConfigSecrets / isSecretConfigKey /
+  // maskSecretValue) so the server's redaction is exercised; mock only the
+  // stateful ConfigManager.
+  ...(await importOriginal<typeof import("../src/core/config-manager.js")>()),
   ConfigManager: vi.fn().mockImplementation(function () {
     return {
       load: vi.fn().mockReturnValue({

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -25,7 +25,12 @@ from rich import print as rprint
 from .. import __version__
 from ..core.audit_logger import AuditLogger
 from ..core.command_interceptor import CommandInterceptor
-from ..core.config_manager import ConfigManager
+from ..core.config_manager import (
+    ConfigManager,
+    is_secret_config_key,
+    mask_secret_value,
+    redact_config_secrets,
+)
 from ..core.pattern_engine import PatternEngine
 from ..scanners.betterleaks import BetterleaksScanner
 from ..scanners.regex_scanner import RegexScanner, ScanResult
@@ -47,7 +52,7 @@ def config_show():
     from dataclasses import asdict
 
     manager = ConfigManager()
-    print(json.dumps(asdict(manager.load()), indent=2))
+    print(json.dumps(redact_config_secrets(asdict(manager.load())), indent=2))
 
 
 @config_app.command("get")
@@ -58,8 +63,11 @@ def config_get(key: str = typer.Argument(..., help="Config key (e.g. agent.risk_
     if value is None:
         print(f"Key not found: {key}", file=sys.stderr)
         raise typer.Exit(code=1)
+    leaf = key.split(".")[-1]
     if isinstance(value, dict):
-        print(json.dumps(value, indent=2))
+        print(json.dumps(redact_config_secrets(value), indent=2))
+    elif is_secret_config_key(leaf) and isinstance(value, str):
+        print(mask_secret_value(value))
     else:
         print(value)
 
@@ -76,7 +84,13 @@ def config_set(
     except (json.JSONDecodeError, ValueError):
         parsed = value
     manager.set(key, parsed)
-    rprint(fmt.success(f"Set {key} = {json.dumps(parsed)}"))
+    leaf = key.split(".")[-1]
+    echo = (
+        json.dumps(mask_secret_value(parsed))
+        if is_secret_config_key(leaf) and isinstance(parsed, str)
+        else json.dumps(parsed)
+    )
+    rprint(fmt.success(f"Set {key} = {echo}"))
 
 
 agent_app.add_typer(config_app)

--- a/python/rafter_cli/commands/mcp_server.py
+++ b/python/rafter_cli/commands/mcp_server.py
@@ -11,7 +11,12 @@ import typer
 
 from ..core.audit_logger import AuditLogger
 from ..core.command_interceptor import CommandInterceptor
-from ..core.config_manager import ConfigManager
+from ..core.config_manager import (
+    ConfigManager,
+    is_secret_config_key,
+    mask_secret_value,
+    redact_config_secrets,
+)
 from ..core.docs_loader import fetch_doc, list_docs, resolve_doc_selector
 from ..scanners.betterleaks import BetterleaksScanner
 from ..scanners.regex_scanner import RegexScanner, ScanResult
@@ -115,23 +120,30 @@ def handle_read_audit_log(
 
 
 def handle_get_config(key: str | None = None) -> dict:
-    """Read Rafter configuration."""
+    """Read Rafter configuration (credentials masked — never hand a key to MCP)."""
     manager = ConfigManager()
     if key:
-        return {"key": key, "value": manager.get(key)}
-    return asdict(manager.load())
+        leaf = key.split(".")[-1]
+        raw = manager.get(key)
+        value = (
+            mask_secret_value(raw)
+            if is_secret_config_key(leaf) and isinstance(raw, str)
+            else redact_config_secrets(raw)
+        )
+        return {"key": key, "value": value}
+    return redact_config_secrets(asdict(manager.load()))
 
 
 def handle_get_config_resource() -> str:
-    """Return full config as JSON string."""
+    """Return full config as JSON string (credentials masked)."""
     manager = ConfigManager()
-    return json.dumps(asdict(manager.load()), indent=2)
+    return json.dumps(redact_config_secrets(asdict(manager.load())), indent=2)
 
 
 def handle_get_policy_resource() -> str:
-    """Return merged policy as JSON string."""
+    """Return merged policy as JSON string (credentials masked)."""
     manager = ConfigManager()
-    return json.dumps(asdict(manager.load_with_policy()), indent=2)
+    return json.dumps(redact_config_secrets(asdict(manager.load_with_policy())), indent=2)
 
 
 def handle_list_docs(tag: str | None = None) -> list[dict]:

--- a/python/rafter_cli/core/config_manager.py
+++ b/python/rafter_cli/core/config_manager.py
@@ -19,6 +19,37 @@ _VALID_RISK_LEVELS = {"minimal", "moderate", "aggressive"}
 _VALID_COMMAND_MODES = {"allow-all", "approve-dangerous", "deny-list"}
 _VALID_LOG_LEVELS = {"debug", "info", "warn", "error"}
 
+# Config keys whose leaf name names a bearer credential — their values must be
+# masked before the config is shown to a human or handed to an MCP client.
+_SECRET_CONFIG_KEY_RE = _re.compile(
+    r"(api_?key|token|secret|password|passwd|credential)", _re.IGNORECASE
+)
+
+
+def is_secret_config_key(leaf_key: str) -> bool:
+    return bool(_SECRET_CONFIG_KEY_RE.search(leaf_key))
+
+
+def mask_secret_value(value) -> str:
+    """Mask a credential value, keeping a 4-char prefix for recognizability."""
+    if not isinstance(value, str) or not value:
+        return "****"
+    return "****" if len(value) <= 4 else value[:4] + "****"
+
+
+def redact_config_secrets(value):
+    """Deep-copy a config value, masking any string under a credential-named key.
+    Pure — never mutates the input (so the stored config is unchanged)."""
+    if isinstance(value, list):
+        return [redact_config_secrets(v) for v in value]
+    if isinstance(value, dict):
+        return {
+            k: (mask_secret_value(v) if is_secret_config_key(k) and isinstance(v, str)
+                else redact_config_secrets(v))
+            for k, v in value.items()
+        }
+    return value
+
 
 class ConfigManager:
     def __init__(self, config_path: Path | None = None):
@@ -48,7 +79,17 @@ class ConfigManager:
 
     def save(self, config: RafterConfig) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._path.parent.chmod(0o700)  # dir may hold credentials/audit log
+        except OSError:
+            pass
         self._path.write_text(json.dumps(self._to_dict(config), indent=2))
+        # Config may hold a backend API key — keep it owner-only. write_text does
+        # not set mode, and an existing file keeps its old perms, so chmod here.
+        try:
+            self._path.chmod(0o600)
+        except OSError:
+            pass  # best effort (e.g. Windows)
 
     # ------------------------------------------------------------------
     # CRUD helpers

--- a/python/rafter_cli/utils/api.py
+++ b/python/rafter_cli/utils/api.py
@@ -60,14 +60,32 @@ API_TIMEOUT_SHORT = (10, 30)
 
 
 def resolve_key(cli_opt: str | None) -> str:
-    """Resolve API key from CLI option, env var, or error."""
+    """Resolve API key: --api-key flag > RAFTER_API_KEY env > global config."""
     if cli_opt:
         return cli_opt
     load_dotenv()
     env_key = os.getenv("RAFTER_API_KEY")
     if env_key:
         return env_key
-    print("No API key provided. Use --api-key or set RAFTER_API_KEY", file=sys.stderr)
+    # Lowest precedence: a key persisted in the GLOBAL ~/.rafter/config.json via
+    # `rafter agent config set backend.apiKey`. Read through load() (global only)
+    # — load_with_policy() never merges backend.*, so a project-local .rafter.yml
+    # can NOT inject a key that would redirect scans to another account.
+    try:
+        from ..core.config_manager import ConfigManager
+
+        # Python config serializes the dataclass field as snake_case
+        # (backend.api_key); Node uses backend.apiKey. Same value, per-language key.
+        stored = ConfigManager().get("backend.api_key")
+        if isinstance(stored, str) and stored.strip():
+            return stored.strip()
+    except Exception:
+        pass  # config unreadable — fall through to the error below
+    print(
+        "No API key provided. Use --api-key, set RAFTER_API_KEY, or run "
+        "'rafter agent config set backend.apiKey <key>'",
+        file=sys.stderr,
+    )
     raise typer.Exit(code=EXIT_GENERAL_ERROR)
 
 

--- a/python/tests/test_config_secret_handling.py
+++ b/python/tests/test_config_secret_handling.py
@@ -1,0 +1,92 @@
+"""Hardening for sable-q9to: the API key is never stored world-readable, never
+echoed in cleartext, and backend.api_key is a real (lowest-precedence) source.
+Parity with the Node config-secret-handling tests."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from rafter_cli.core.config_manager import (
+    ConfigManager,
+    is_secret_config_key,
+    mask_secret_value,
+    redact_config_secrets,
+)
+from rafter_cli.utils.api import resolve_key
+
+
+class TestRedactionHelpers:
+    def test_masks_credential_keys_only_and_does_not_mutate(self):
+        cfg = {
+            "backend": {"api_key": "sk-secret-7777777"},
+            "agent": {"risk_level": "moderate"},
+            "token": "tok-abcdef",
+            "nested": {"authToken": "zzzz9999", "note": "plain"},
+            "list": [{"password": "hunter2xx"}],
+        }
+        r = redact_config_secrets(cfg)
+        assert r["backend"]["api_key"] == "sk-s****"
+        assert r["token"] == "tok-****"
+        assert r["nested"]["authToken"] == "zzzz****"
+        assert r["nested"]["note"] == "plain"
+        assert r["agent"]["risk_level"] == "moderate"
+        assert r["list"][0]["password"] == "hunt****"
+        assert cfg["backend"]["api_key"] == "sk-secret-7777777"  # untouched
+
+    def test_mask_secret_value_edges(self):
+        assert mask_secret_value("") == "****"
+        assert mask_secret_value("abcd") == "****"
+        assert mask_secret_value("abcde") == "abcd****"
+        assert mask_secret_value(None) == "****"
+        assert mask_secret_value(12345) == "****"
+
+    def test_is_secret_config_key(self):
+        for k in ["apiKey", "api_key", "apikey", "token", "authToken", "secret", "password", "credential"]:
+            assert is_secret_config_key(k) is True
+        for k in ["risk_level", "mode", "name", "url", "version"]:
+            assert is_secret_config_key(k) is False
+
+
+class TestSavePerms:
+    def test_fresh_config_is_owner_only(self, tmp_path):
+        p = tmp_path / "config.json"
+        ConfigManager(p).set("backend.api_key", "sk-xyz")
+        assert stat.S_IMODE(p.stat().st_mode) == 0o600
+
+    def test_existing_world_readable_config_is_tightened(self, tmp_path):
+        p = tmp_path / "config.json"
+        p.write_text("{}")
+        p.chmod(0o644)
+        ConfigManager(p).set("agent.risk_level", "minimal")
+        assert stat.S_IMODE(p.stat().st_mode) == 0o600
+
+
+class TestResolveKeyPrecedence:
+    """--api-key > RAFTER_API_KEY > global config backend.api_key."""
+
+    @pytest.fixture
+    def home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("RAFTER_API_KEY", raising=False)
+        # Hand-write the config under the temp HOME (never a default-path
+        # ConfigManager write) so the real ~/.rafter is never touched.
+        d = tmp_path / ".rafter"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.json").write_text(json.dumps({"backend": {"api_key": "CONFIG-key"}}))
+        return tmp_path
+
+    def test_flag_wins(self, home, monkeypatch):
+        monkeypatch.setenv("RAFTER_API_KEY", "ENV-key")
+        assert resolve_key("FLAG-key") == "FLAG-key"
+
+    def test_env_over_config(self, home, monkeypatch):
+        monkeypatch.setenv("RAFTER_API_KEY", "ENV-key")
+        assert resolve_key(None) == "ENV-key"
+
+    def test_global_config_used_when_no_flag_or_env(self, home):
+        # No longer a dead path.
+        assert resolve_key(None) == "CONFIG-key"

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -64,7 +64,7 @@ Aliases: `rafter scan`, `rafter scan remote`
 
 Trigger a new security scan for a repository.
 
-- `-k, --api-key TEXT` — API key or `RAFTER_API_KEY` env var
+- `-k, --api-key TEXT` — API key. Resolution order: this flag → `RAFTER_API_KEY` env → `backend.apiKey` in global config (see `rafter agent config`)
 - `-r, --repo TEXT` — org/repo (default: auto-detected from git remote)
 - `-b, --branch TEXT` — branch (default: current branch or 'main')
 - `-f, --format [json|md]` — output format (default: md)
@@ -78,7 +78,7 @@ Trigger a new security scan for a repository.
 
 Retrieve results from a scan.
 
-- `-k, --api-key TEXT` — API key or `RAFTER_API_KEY` env var
+- `-k, --api-key TEXT` — API key. Resolution order: this flag → `RAFTER_API_KEY` env → `backend.apiKey` in global config (see `rafter agent config`)
 - `-f, --format [json|md]` — output format (default: md)
 - `--interactive` — poll until scan completes (10-second intervals)
 - `--quiet` — suppress status messages on stderr
@@ -90,7 +90,7 @@ Retrieve results from a scan.
 
 Check API quota and usage statistics.
 
-- `-k, --api-key TEXT` — API key or `RAFTER_API_KEY` env var
+- `-k, --api-key TEXT` — API key. Resolution order: this flag → `RAFTER_API_KEY` env → `backend.apiKey` in global config (see `rafter agent config`)
 - `-h, --help`
 
 ---
@@ -749,7 +749,11 @@ Manage agent configuration (dot-notation paths).
 - `rafter agent config get <key>` — read value
 - `rafter agent config set <key> <value>` — write value
 
-Config keys: `agent.riskLevel`, `agent.skills.autoUpdate`, `agent.skills.installOnInit`, `agent.skills.backupBeforeUpdate`, `agent.commandPolicy.mode`, `agent.commandPolicy.blockedPatterns`, `agent.commandPolicy.requireApproval`, `agent.outputFiltering.redactSecrets`, `agent.audit.logAllActions`, `agent.audit.retentionDays`, `agent.audit.logLevel`, `agent.notifications.webhook`, `agent.notifications.minRiskLevel`.
+Config keys: `agent.riskLevel`, `agent.skills.autoUpdate`, `agent.skills.installOnInit`, `agent.skills.backupBeforeUpdate`, `agent.commandPolicy.mode`, `agent.commandPolicy.blockedPatterns`, `agent.commandPolicy.requireApproval`, `agent.outputFiltering.redactSecrets`, `agent.audit.logAllActions`, `agent.audit.retentionDays`, `agent.audit.logLevel`, `agent.notifications.webhook`, `agent.notifications.minRiskLevel`, `backend.apiKey` (Python: `backend.api_key`).
+
+**Credential handling.** The global config (`~/.rafter/config.json`) is written with `0600` perms (owner-only; the directory is `0700`), and an existing looser-perm file is tightened on the next write. Values under credential-named keys (matching `api_?key`/`token`/`secret`/`password`/`credential`) are **masked** (`abcd****`) anywhere the config is rendered — `config show`, `config get`, the `config set` confirmation echo, and the MCP `get_config` tool + `rafter://config` / `rafter://policy` resources — so a stored key is never printed in cleartext or handed to an MCP client. The value is still stored verbatim on disk (it is a bearer token); the protection is file perms + display redaction.
+
+**API-key resolution order** (for `run`/`get`/`usage` and other backend calls): `--api-key` flag → `RAFTER_API_KEY` env → `backend.apiKey` in the **global** config. The config fallback is read only from `~/.rafter/config.json` (never a project-local `.rafter.yml`), so a hostile repository cannot inject an API key that redirects scans to another account.
 
 ### rafter agent init-project [OPTIONS]
 


### PR DESCRIPTION
Fixes **sable-q9to**. Three credential-handling gaps in `RAFTER_API_KEY` handling (both Node + Python). The intended env-var / `--api-key` path was already solid (HTTPS, `x-api-key` header only, not logged); these are the storage/display/dead-path gaps surfaced during the secbolt credential spike.

## Gaps fixed

1. **Plaintext, world-readable.** `ConfigManager.save()` wrote `~/.rafter/config.json` with the default umask (typically `0644`). Now writes **`0600`** (dir `0700`) and chmods an existing looser-perm file on the next write.
2. **Unredacted echo.** `config show`/`get`, the `config set` confirmation, and the MCP `get_config` tool + `rafter://config` / `rafter://policy` resources serialized the full config verbatim — handing any stored key to the terminal or MCP client. Added `redactConfigSecrets`/`maskSecretValue` (mask values under keys matching `api_?key|token|secret|password|credential` → `abcd****`), applied at **every** render path. Pure — the stored config is never mutated.
3. **Dead credential path.** `backend.apiKey` existed in the schema but `resolveKey` never read it. Wired as the **lowest-precedence** source: `--api-key` flag → `RAFTER_API_KEY` env → global config `backend.apiKey`.

## Security design

- **Why `0600` plaintext, not encryption:** it's a *bearer* token (presented verbatim → can't hash); encrypting a local CLI config needs a KEK the CLI reads unattended, sitting right next to the ciphertext ("keys next to data"). So the boundary is **file perms + display redaction** — same as `gh`/`aws`/`npm`.
- **Trust boundary (verified):** the config fallback is read only from the **global** `~/.rafter/config.json` via `load()` — `loadWithPolicy()` never merges `backend.*`, so a hostile project-local `.rafter.yml` **cannot** inject an API key that redirects scans to an attacker's account. Confirmed empirically (a planted `.rafter.yml backend.apiKey` does not appear in `config show` and `resolveKey` refuses it).
- Ran `rafter-secure-design` before coding (decisions recorded on the bead); refuse-list clean (no homegrown crypto, opaque bearer token, revocation is backend-side).

## Tests

New `config-secret-handling` suites in both languages: redaction helpers (mask/leaf-match/no-mutation), `save()` writes `0600` on fresh **and** tightens an existing `0644` file, and `resolveKey` precedence `flag > env > config`. Node **67** / Python **19** config tests pass; broader config + mcp + api suites green. Secrets scan clean on all changed files. `rafter run` (remote SAST) not run — no `RAFTER_API_KEY` in this env; recommend CI.

## Notes

- Node key is `backend.apiKey`; Python is `backend.api_key` (dataclass snake_case) — same value, per-language path; the redaction regex (`api_?key`) covers both.
- `CLI_SPEC.md` documents the resolution order, redaction, `0600`, and the global-only trust boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)