### PR TITLE
fix(release): bump ClawHub skill resource versions to 0.8.9

### DIFF
--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.7
+version: 0.8.9
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.7
+version: 0.8.9
 homepage: https://rafter.so
 metadata:
   openclaw:


### PR DESCRIPTION
Fixes the two failing `validate-versions` checks on the main→prod release PR (#176).

## Root cause

`node/resources/rafter-security-skill.md` and `python/rafter_cli/resources/rafter-security-skill.md` carry a `version:` frontmatter field that `validate-release.yml` requires to match the package version. They were left at **0.8.7** through the 0.8.8 (#170) and 0.8.9 (#175) bumps — the release PRs bumped `package.json`/`pyproject.toml` but missed these.

`validate-versions` only runs as a gate on PRs→prod (and on push→main, post-merge, non-blocking), which is why it didn't surface until #176.

## Why it matters (would it block the deploy?)

The deploy workflow `publish.yaml` (push→prod) doesn't re-run `validate-versions`, so it wouldn't be *aborted* by the red checks. **But `publish-clawhub` uses this SKILL.md frontmatter version as the ClawHub release version** — so deploying as-is would publish npm/PyPI at **0.8.9** while ClawHub ships the skill at a stale **0.8.7** (cross-registry skew), and the published packages would internally claim 0.8.7. That's exactly the drift the gate guards against.

## Fix

Bump both resource files `0.8.7 → 0.8.9` (verified the `validate-versions` logic passes locally). Once this merges to `main`, #176 picks it up and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)