### PR TITLE
fix(security): unconditional hard-block for critical destructive commands (sable-nf2i)

### DIFF
--- a/node/src/core/command-interceptor.ts
+++ b/node/src/core/command-interceptor.ts
@@ -1,6 +1,6 @@
 import { ConfigManager } from "./config-manager.js";
 import { AuditLogger } from "./audit-logger.js";
-import { assessCommandRisk, CommandRiskLevel } from "./risk-rules.js";
+import { assessCommandRisk, matchedCriticalPattern, CommandRiskLevel } from "./risk-rules.js";
 
 export type { CommandRiskLevel } from "./risk-rules.js";
 
@@ -26,14 +26,42 @@ export class CommandInterceptor {
    * Evaluate if a command should be allowed
    */
   evaluate(command: string): CommandEvaluation {
+    const riskLevel = this.assessRisk(command);
+
+    // Unconditional hard-block: catastrophic destructive commands (rm -rf /,
+    // fork bombs, disk wipes, mkfs, …) are NEVER allowed, regardless of the
+    // configured policy — or its absence. Security must not depend on a policy
+    // being present (the default config may be missing one) or on the chosen
+    // mode (even allow-all / a custom deny-list cannot opt out of these).
+    if (riskLevel === "critical") {
+      return {
+        command,
+        riskLevel,
+        allowed: false,
+        requiresApproval: false,
+        reason: "Matches built-in blocked pattern (critical destructive command)",
+        matchedPattern: matchedCriticalPattern(command) ?? "builtin:critical-destructive"
+      };
+    }
+
     const cfg = this.config.loadWithPolicy();
     const policy = cfg.agent?.commandPolicy;
 
     if (!policy) {
-      // No policy configured, allow by default but still assess risk
+      // No policy configured — fall back to safe built-in defaults rather than
+      // allow-all: high-risk commands still require approval.
+      if (riskLevel === "high") {
+        return {
+          command,
+          riskLevel,
+          allowed: false,
+          requiresApproval: true,
+          reason: "High risk command requires approval"
+        };
+      }
       return {
         command,
-        riskLevel: this.assessRisk(command),
+        riskLevel,
         allowed: true,
         requiresApproval: false
       };

--- a/node/src/core/risk-rules.ts
+++ b/node/src/core/risk-rules.ts
@@ -96,3 +96,17 @@ export function assessCommandRisk(command: string): CommandRiskLevel {
   }
   return "low";
 }
+
+/**
+ * Return the source of the first CRITICAL pattern matching the command, or null.
+ * Mirrors assessCommandRisk's lowercasing. Intended to be called only once a
+ * command is already classified "critical" (safe-prefix exclusion is handled by
+ * assessCommandRisk), to surface *which* built-in rule matched.
+ */
+export function matchedCriticalPattern(command: string): string | null {
+  const cmd = command.toLowerCase().trim();
+  for (const pattern of CRITICAL_PATTERNS) {
+    if (pattern.test(cmd)) return pattern.source;
+  }
+  return null;
+}

--- a/node/tests/command-interceptor-policy.test.ts
+++ b/node/tests/command-interceptor-policy.test.ts
@@ -41,12 +41,21 @@ describe("CommandInterceptor — Policy modes", () => {
   // ── No policy (agent.commandPolicy undefined) ───────────────────────
 
   describe("No policy configured", () => {
-    it("should allow any command and still assess risk", () => {
+    it("should hard-block critical destructive commands even with no policy", () => {
       stubPolicy(interceptor, null);
       const result = interceptor.evaluate("rm -rf /");
-      expect(result.allowed).toBe(true);
+      expect(result.allowed).toBe(false);
       expect(result.requiresApproval).toBe(false);
       expect(result.riskLevel).toBe("critical");
+      expect(result.matchedPattern).toBeDefined();
+    });
+
+    it("should require approval for high-risk commands even with no policy", () => {
+      stubPolicy(interceptor, null);
+      const result = interceptor.evaluate("rm -rf node_modules");
+      expect(result.allowed).toBe(false);
+      expect(result.requiresApproval).toBe(true);
+      expect(result.riskLevel).toBe("high");
     });
 
     it("should return low risk for safe command", () => {
@@ -126,7 +135,7 @@ describe("CommandInterceptor — Policy modes", () => {
       expect(result.reason).toContain("High risk");
     });
 
-    it("should require approval for critical-risk commands", () => {
+    it("should hard-block critical-risk commands (never merely require approval)", () => {
       stubPolicy(interceptor, {
         mode: "approve-dangerous",
         blockedPatterns: [],
@@ -134,7 +143,7 @@ describe("CommandInterceptor — Policy modes", () => {
       });
       const result = interceptor.evaluate("mkfs.ext4 /dev/sda1");
       expect(result.allowed).toBe(false);
-      expect(result.requiresApproval).toBe(true);
+      expect(result.requiresApproval).toBe(false);
       expect(result.riskLevel).toBe("critical");
     });
 
@@ -190,14 +199,14 @@ describe("CommandInterceptor — Policy modes", () => {
   // ── allow-all mode ──────────────────────────────────────────────────
 
   describe("allow-all mode", () => {
-    it("should allow even critical commands", () => {
+    it("should still hard-block critical destructive commands (allow-all cannot opt out)", () => {
       stubPolicy(interceptor, {
         mode: "allow-all",
         blockedPatterns: [],
         requireApproval: [],
       });
       const result = interceptor.evaluate("rm -rf /");
-      expect(result.allowed).toBe(true);
+      expect(result.allowed).toBe(false);
       expect(result.requiresApproval).toBe(false);
       expect(result.riskLevel).toBe("critical");
     });
@@ -341,18 +350,20 @@ describe("CommandInterceptor — Policy modes", () => {
   // ── Policy override replaces defaults ───────────────────────────────
 
   describe("Policy overrides defaults", () => {
-    it("custom blockedPatterns replace default blocked patterns", () => {
-      // With custom blocked patterns that don't include "rm -rf /",
-      // the default blocked patterns should NOT apply
+    it("built-in critical hard-block applies even when custom blockedPatterns omit it", () => {
+      // Custom blocked patterns replace the policy defaults, but the built-in
+      // critical-destructive hard-block is unconditional and still applies —
+      // "rm -rf /" can never be allowed through, whatever the policy says.
       stubPolicy(interceptor, {
         mode: "deny-list",
         blockedPatterns: ["only-this-is-blocked"],
         requireApproval: [],
       });
 
-      // "rm -rf /" would be blocked by defaults, but custom replaces them
       const result = interceptor.evaluate("rm -rf /");
-      expect(result.allowed).toBe(true); // not in custom blockedPatterns
+      expect(result.allowed).toBe(false);
+      expect(result.requiresApproval).toBe(false);
+      expect(result.riskLevel).toBe("critical");
     });
 
     it("custom requireApproval replaces default approval patterns", () => {

--- a/python/rafter_cli/core/command_interceptor.py
+++ b/python/rafter_cli/core/command_interceptor.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from .audit_logger import AuditLogger
 from .config_manager import ConfigManager
-from .risk_rules import assess_command_risk
+from .risk_rules import assess_command_risk, match_critical_pattern
 
 
 @dataclass
@@ -25,6 +25,21 @@ class CommandInterceptor:
         self._audit = AuditLogger()
 
     def evaluate(self, command: str) -> CommandEvaluation:
+        # Unconditional hard-block: catastrophic destructive commands (rm -rf /,
+        # fork bombs, disk wipes, mkfs, …) are NEVER allowed, regardless of the
+        # configured policy — or its absence. Security must not depend on a
+        # policy being present or on the chosen mode (even allow-all / a custom
+        # deny-list cannot opt out of these).
+        if assess_command_risk(command) == "critical":
+            return CommandEvaluation(
+                command=command,
+                risk_level="critical",
+                allowed=False,
+                requires_approval=False,
+                reason="Matches built-in blocked pattern (critical destructive command)",
+                matched_pattern=match_critical_pattern(command) or "builtin:critical-destructive",
+            )
+
         cfg = self._config.load_with_policy()
         policy = cfg.agent.command_policy
 

--- a/python/rafter_cli/core/risk_rules.py
+++ b/python/rafter_cli/core/risk_rules.py
@@ -85,3 +85,16 @@ def assess_command_risk(command: str) -> str:
         if re.search(p, command, re.IGNORECASE):
             return "medium"
     return "low"
+
+
+def match_critical_pattern(command: str) -> str | None:
+    """Return the first CRITICAL pattern matching the command, or None.
+
+    Mirrors assess_command_risk's matching. Intended to be called only once a
+    command is already classified "critical" (safe-prefix exclusion is handled
+    by assess_command_risk), to surface *which* built-in rule matched.
+    """
+    for p in CRITICAL_PATTERNS:
+        if re.search(p, command, re.IGNORECASE):
+            return p
+    return None

--- a/python/tests/test_command_interceptor_policy.py
+++ b/python/tests/test_command_interceptor_policy.py
@@ -155,13 +155,14 @@ class TestApproveDangerousMode:
         assert result.risk_level == "high"
         assert "high risk" in (result.reason or "").lower()
 
-    def test_critical_risk_requires_approval(self):
+    def test_critical_risk_hard_blocked(self):
+        # Critical destructive commands are hard-blocked, never merely approval.
         result = _eval_with_policy(
             "mkfs.ext4 /dev/sda1",
             mode="approve-dangerous",
         )
         assert not result.allowed
-        assert result.requires_approval
+        assert not result.requires_approval
         assert result.risk_level == "critical"
 
     def test_medium_risk_allowed(self):
@@ -203,12 +204,13 @@ class TestApproveDangerousMode:
 
 
 class TestAllowAllMode:
-    def test_critical_command_allowed(self):
+    def test_critical_command_still_hard_blocked(self):
+        # allow-all cannot opt out of the built-in critical hard-block.
         result = _eval_with_policy(
             "rm -rf /",
             mode="allow-all",
         )
-        assert result.allowed
+        assert not result.allowed
         assert not result.requires_approval
         assert result.risk_level == "critical"
 
@@ -340,15 +342,18 @@ class TestEmptyPatterns:
 
 
 class TestPolicyOverrides:
-    def test_custom_blocked_replaces_defaults(self):
+    def test_builtin_critical_block_survives_custom_blocked(self):
+        # Custom blocked patterns replace the policy defaults, but the built-in
+        # critical-destructive hard-block is unconditional and still applies.
         result = _eval_with_policy(
             "rm -rf /",
             mode="deny-list",
             blocked_patterns=["only-this-is-blocked"],
             require_approval=[],
         )
-        # "rm -rf /" is NOT in the custom blocked list
-        assert result.allowed
+        assert not result.allowed
+        assert not result.requires_approval
+        assert result.risk_level == "critical"
 
     def test_custom_approval_replaces_defaults(self):
         result = _eval_with_policy(


### PR DESCRIPTION
## Summary

Fixes **sable-nf2i** (P1 security): `CommandInterceptor.evaluate()` returned `{allowed:true, requiresApproval:false, riskLevel:'critical'}` for catastrophic destructive commands (`rm -rf /`, `rm -fr /`, fork bombs, `dd` to disk, `mkfs`, …) whenever **no `commandPolicy` was configured** — the real-world default, since a user's `~/.rafter/config.json` often omits `agent.commandPolicy`.

The pretool hook denies only when `(!allowed && !requiresApproval) || requiresApproval`, so `allowed=true` + `requiresApproval=false` **bypassed the hard-block** → a security CLI that did not block `rm -rf /` by default.

## Fix

Add an **unconditional** critical-destructive hard-block at the very top of `evaluate()`, **before any policy is loaded**, in both implementations:

- Critical commands always return `allowed:false, requiresApproval:false`, surfacing the matched built-in pattern — regardless of whether a policy exists or which mode is set. **`allow-all` and custom deny-lists can no longer opt out of catastrophic commands** (closing the trivial bypass).
- With no policy configured, high-risk commands now fall back to **requiring approval** instead of allow-all.
- New helpers `matchedCriticalPattern()` / `match_critical_pattern()` report which built-in rule matched.

## Contract change (intentional)

Previously `allow-all` mode (and custom deny-lists that replaced defaults, and `approve-dangerous` for critical) permitted / merely-prompted `rm -rf /`. Now critical-destructive commands are **always** hard-blocked. The policy-mode tests that encoded the old behavior were updated to assert the hard-block.

## Verification

- Repairs the 13 red `command-interceptor.test.ts` cases, the `hook-integration` "blocks rm -rf / even in a git repo" case, and the two `error-handling-gauntlet` interceptor cases.
- **Node**: full suite 1926 passed / 9 skipped. The 3 remaining failures are **pre-existing & unrelated** (version-parity stale artifact, AuditLogger JSONL, openclaw flaky) — confirmed on a clean tree. Beaded: sable-lcch, sable-qqmc, sable-j3ic.
- **Python**: full suite 1443 passed. The 1 failure is the same pre-existing version-artifact issue (sable-lcch).
- **Exact node/python parity** verified: 16/16 commands identical decisions under the same config.
- No ReDoS (50–100k-char pathological inputs classify in single-digit ms; helper reuses existing patterns, runs only post-classification).

## Security gate (per CLAUDE.md)

- `rafter-code-review` walked (CWE Top-25 / CLI): no new findings; surfaced 2 pre-existing items (sable-619t over-block, sable-c3w1 config-default parity gap).
- `rafter secrets` clean on source changes.
- WARNING: `rafter run` (remote SAST/SCA) **not run locally — `RAFTER_API_KEY` not set in this env**. Please ensure CI runs it on this PR.

Closes sable-nf2i.

🤖 Generated with [Claude Code](https://claude.com/claude-code)