### PR TITLE
fix(claude-code): narrow PostToolUse hook matcher from .* to Bash|Write|Edit|MultiEdit (sable-h0ah)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Claude Code `PostToolUse` hook matcher narrowed from `.*` to `Bash|Write|Edit|MultiEdit`** (Node + Python, sable-h0ah). `rafter agent init --with-claude-code` (and `rafter agent enable claude-code.hooks`) previously registered the `rafter hook posttool` redaction hook with a catch-all `.*` matcher, so it fired after **every** Claude Code tool call — including `Read` and MCP tools, which never produce secrets to redact — adding latency to every operation. The matcher now targets only the tools whose output is worth scanning: shell output (`Bash`) and file writes (`Write`/`Edit`/`MultiEdit`). PreToolUse matchers are unchanged. Codex (`.*` PostToolUse) and Gemini (`.*` AfterTool) have the same broad-matcher latency issue and are tracked separately for platform-correct narrow matchers.
+
 ## [0.8.9] - 2026-06-20
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -128,7 +128,7 @@ rafter agent exec "rm -rf /"              # critical -- blocked
 When installed via `rafter agent init --with-claude-code`, Rafter registers hooks in `~/.claude/settings.json`:
 
 - **PreToolUse** hooks on `Bash` and `Write|Edit` tool calls. Every shell command is evaluated against the risk policy before execution. Dangerous commands are blocked or require approval transparently -- no manual invocation needed.
-- **PostToolUse** hooks on all tool calls (`.*` matcher). Scans output for accidentally leaked secrets and redacts them.
+- **PostToolUse** hooks on `Bash`, `Write`, `Edit`, and `MultiEdit` tool calls (`Bash|Write|Edit|MultiEdit` matcher). Scans command output and file writes for accidentally leaked secrets and redacts them. (Scoped to these tools so the hook doesn't fire on every `Read`/MCP call, which never produces secrets to redact and only added latency.)
 
 The hooks read JSON from stdin and write a `{"decision": "allow"}` or `{"decision": "deny", "reason": "..."}` response to stdout. This is the Claude Code hook protocol.
 
@@ -142,7 +142,7 @@ Manual hook config (if not using `rafter agent init`):
       { "matcher": "Write|Edit", "hooks": [{ "type": "command", "command": "rafter hook pretool" }] }
     ],
     "PostToolUse": [
-      { "matcher": ".*", "hooks": [{ "type": "command", "command": "rafter hook posttool" }] }
+      { "matcher": "Bash|Write|Edit|MultiEdit", "hooks": [{ "type": "command", "command": "rafter hook posttool" }] }
     ]
   }
 }

--- a/node/src/commands/agent/components.ts
+++ b/node/src/commands/agent/components.ts
@@ -174,7 +174,9 @@ function claudeCodeHooks(): ComponentSpec {
         { matcher: "Bash", hooks: [pre] },
         { matcher: "Write|Edit", hooks: [pre] },
       );
-      settings.hooks.PostToolUse.push({ matcher: ".*", hooks: [post] });
+      // Narrow to tools that produce scannable output (shell output + file
+      // writes); avoids firing posttool on every Read/MCP call (latency).
+      settings.hooks.PostToolUse.push({ matcher: "Bash|Write|Edit|MultiEdit", hooks: [post] });
 
       writeJson(settingsPath, settings);
     },

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -322,8 +322,11 @@ function installClaudeCodeHooks(root: string): void {
     { matcher: "Bash", hooks: [preHook] },
     { matcher: "Write|Edit", hooks: [preHook] },
   );
+  // Narrow to tools that produce scannable output (shell output + file
+  // writes). Firing posttool on every tool — including Read and MCP calls —
+  // added latency to operations that never produce secrets to redact.
   settings.hooks.PostToolUse.push(
-    { matcher: ".*", hooks: [postHook] },
+    { matcher: "Bash|Write|Edit|MultiEdit", hooks: [postHook] },
   );
 
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), "utf-8");

--- a/node/tests/agent-compatibility.test.ts
+++ b/node/tests/agent-compatibility.test.ts
@@ -727,7 +727,7 @@ describe("Agent Init: Environment Detection & Hook/Skill Installation", () => {
             { matcher: "Write|Edit", hooks: [{ type: "command", command: "rafter hook pretool" }] },
           ],
           PostToolUse: [
-            { matcher: ".*", hooks: [{ type: "command", command: "rafter hook posttool" }] },
+            { matcher: "Bash|Write|Edit|MultiEdit", hooks: [{ type: "command", command: "rafter hook posttool" }] },
           ],
         },
       };
@@ -739,7 +739,7 @@ describe("Agent Init: Environment Detection & Hook/Skill Installation", () => {
       expect(loaded.hooks.PostToolUse).toHaveLength(1);
       expect(loaded.hooks.PreToolUse[0].matcher).toBe("Bash");
       expect(loaded.hooks.PreToolUse[1].matcher).toBe("Write|Edit");
-      expect(loaded.hooks.PostToolUse[0].matcher).toBe(".*");
+      expect(loaded.hooks.PostToolUse[0].matcher).toBe("Bash|Write|Edit|MultiEdit");
     });
 
     it("preserves existing non-rafter hooks when installing", () => {
@@ -776,7 +776,7 @@ describe("Agent Init: Environment Detection & Hook/Skill Installation", () => {
         { matcher: "Write|Edit", hooks: [{ type: "command", command: "rafter hook pretool" }] },
       );
       settings.hooks.PostToolUse.push(
-        { matcher: ".*", hooks: [{ type: "command", command: "rafter hook posttool" }] },
+        { matcher: "Bash|Write|Edit|MultiEdit", hooks: [{ type: "command", command: "rafter hook posttool" }] },
       );
 
       fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
@@ -800,7 +800,7 @@ describe("Agent Init: Environment Detection & Hook/Skill Installation", () => {
             { matcher: "Bash", hooks: [{ type: "command", command: "rafter hook pretool" }] },
           ],
           PostToolUse: [
-            { matcher: ".*", hooks: [{ type: "command", command: "rafter hook posttool" }] },
+            { matcher: "Bash|Write|Edit|MultiEdit", hooks: [{ type: "command", command: "rafter hook posttool" }] },
           ],
         },
       };
@@ -827,7 +827,7 @@ describe("Agent Init: Environment Detection & Hook/Skill Installation", () => {
         { matcher: "Write|Edit", hooks: [{ type: "command", command: "rafter hook pretool" }] },
       );
       settings.hooks.PostToolUse.push(
-        { matcher: ".*", hooks: [{ type: "command", command: "rafter hook posttool" }] },
+        { matcher: "Bash|Write|Edit|MultiEdit", hooks: [{ type: "command", command: "rafter hook posttool" }] },
       );
 
       fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
@@ -886,7 +886,7 @@ describe("Agent Init: Environment Detection & Hook/Skill Installation", () => {
               { matcher: "Bash", hooks: [{ type: "command", command: "rafter hook pretool" }] },
             ],
             PostToolUse: [
-              { matcher: ".*", hooks: [{ type: "command", command: "rafter hook posttool" }] },
+              { matcher: "Bash|Write|Edit|MultiEdit", hooks: [{ type: "command", command: "rafter hook posttool" }] },
             ],
           },
         }, null, 2)

--- a/node/tests/platform-integration.test.ts
+++ b/node/tests/platform-integration.test.ts
@@ -1171,9 +1171,10 @@ describe("Platform Integration — MCP Installs via CLI", () => {
       );
       expect(postCommands).toContain("rafter hook posttool");
 
-      // PostToolUse should have catch-all matcher
+      // PostToolUse matcher is scoped to tools that produce scannable output
+      // (shell output + file writes) rather than firing on every tool call.
       const postMatchers = settings.hooks.PostToolUse.map((e: any) => e.matcher);
-      expect(postMatchers).toContain(".*");
+      expect(postMatchers).toContain("Bash|Write|Edit|MultiEdit");
     });
 
     it("should install skills to ~/.claude/skills/", () => {

--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -205,8 +205,11 @@ def _install_claude_code_hooks(root: Path) -> None:
         {"matcher": "Bash", "hooks": [pre_hook]},
         {"matcher": "Write|Edit", "hooks": [pre_hook]},
     ])
+    # Narrow to tools that produce scannable output (shell output + file
+    # writes). Firing posttool on every tool — including Read and MCP calls —
+    # added latency to operations that never produce secrets to redact.
     settings["hooks"]["PostToolUse"].extend([
-        {"matcher": ".*", "hooks": [post_hook]},
+        {"matcher": "Bash|Write|Edit|MultiEdit", "hooks": [post_hook]},
     ])
 
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")

--- a/python/rafter_cli/commands/agent_components.py
+++ b/python/rafter_cli/commands/agent_components.py
@@ -186,7 +186,9 @@ def _claude_code_hooks() -> ComponentSpec:
             {"matcher": "Bash", "hooks": [pre]},
             {"matcher": "Write|Edit", "hooks": [pre]},
         ])
-        hooks["PostToolUse"].append({"matcher": ".*", "hooks": [post]})
+        # Narrow to tools that produce scannable output (shell output + file
+        # writes); avoids firing posttool on every Read/MCP call (latency).
+        hooks["PostToolUse"].append({"matcher": "Bash|Write|Edit|MultiEdit", "hooks": [post]})
         _write_json(settings_path, s)
 
     def uninstall() -> None:

--- a/python/tests/test_agent_init.py
+++ b/python/tests/test_agent_init.py
@@ -166,6 +166,12 @@ class TestInstallClaudeCodeHooks:
         assert "Bash" in matchers
         assert "Write|Edit" in matchers
 
+        # PostToolUse is scoped to tools that produce scannable output (shell
+        # output + file writes), not every tool call — avoids firing posttool
+        # on Read/MCP calls that never produce secrets to redact.
+        post_matchers = [e["matcher"] for e in settings["hooks"]["PostToolUse"]]
+        assert post_matchers == ["Bash|Write|Edit|MultiEdit"]
+
     def test_preserves_existing_hooks(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         claude_dir = tmp_path / ".claude"

--- a/shared-docs/PLATFORM_PARITY_AUDIT.md
+++ b/shared-docs/PLATFORM_PARITY_AUDIT.md
@@ -46,7 +46,7 @@ Python mirrors live at the same callsites in `python/rafter_cli/commands/agent.p
 
 ### Claude Code — gold standard
 
-What we ship: skills (`.claude/skills/<name>/SKILL.md`), sub-agent (`.claude/agents/rafter.md`, rf-q7j), hooks (PreToolUse Bash + Write|Edit, PostToolUse `.*`), MCP server, CLAUDE.md instruction block.
+What we ship: skills (`.claude/skills/<name>/SKILL.md`), sub-agent (`.claude/agents/rafter.md`, rf-q7j), hooks (PreToolUse Bash + Write|Edit, PostToolUse `Bash|Write|Edit|MultiEdit`), MCP server, CLAUDE.md instruction block.
 
 Verify check: presence of `rafter hook pretool` in `~/.claude/settings.json` PreToolUse array. Real test of whether hooks fire is implicit — they do, because Claude Code is what we built against.
 


### PR DESCRIPTION
## Problem

`rafter agent init --with-claude-code` (and `rafter agent enable claude-code.hooks`) registered the `rafter hook posttool` secret-redaction hook with a catch-all `.*` matcher. That fires `rafter hook posttool` after **every** Claude Code tool call — including `Read` and MCP tools, which never produce secrets to redact — adding latency to every operation for every rafter-cli user. `posttool` was designed for shell output + file writes.

## Fix

Narrow the Claude Code `PostToolUse` matcher from `.*` to `Bash|Write|Edit|MultiEdit` — the tools whose output is actually worth scanning (shell output + file writes). `PreToolUse` matchers (`Bash`, `Write|Edit`) are unchanged.

Changed in **both** install paths per language for parity:
- Node: `src/commands/agent/init.ts` (init/legacy) + `src/commands/agent/components.ts` (component spec)
- Python: `rafter_cli/commands/agent.py` (legacy) + `rafter_cli/commands/agent_components.py` (component spec)

Docs (`SKILL.md`, `shared-docs/PLATFORM_PARITY_AUDIT.md`, `CHANGELOG.md`) and test expectations updated. A `PostToolUse`-matcher assertion was added to the Python install test to mirror existing Node coverage.

## Scope

**Claude Code only.** Codex (`.*` PostToolUse) and Gemini (`.*` AfterTool) have the same broad-matcher latency issue but need *platform-correct* tool names (Codex `Bash|apply_patch`, Gemini `run_shell_command|write_file|replace|edit`) — tracked separately in **sable-4alt**, not touched here.

## Security review

This is rafter's own install path, so it went through `rafter-code-review`:
- The change is a hardcoded literal-string swap — no user input, no new path/secret/shell handling. No injection/traversal/proto-pollution surface. The new matcher is a flat literal alternation (no ReDoS) and strictly *more* restrictive than `.*`.
- **Tradeoff (deliberate, documented):** the redaction hook no longer fires on `Read`/MCP outputs — a reduction in defense-in-depth *breadth*. Acceptable because the actual security control (PreToolUse command interception) is untouched, and redaction still covers the highest-value channels (shell output + file writes). If MCP-output redaction is later wanted, it should return as a targeted matcher, never `.*`.
- `rafter secrets .` is clean for this diff (the 106 repo hits are intentional test fixtures). Remote `rafter run` (SAST/SCA) was not run here — `RAFTER_API_KEY` is unset in this environment; please let CI / the merger run it.

## Testing

- Affected Node files (`agent-compatibility`, `platform-integration`): **132 passed**.
- Affected Python files (`test_agent_init`, `test_agent_components`, `test_suppression`): **112 passed**.
- TypeScript build (`tsc`): clean. Ruff: zero new errors from this diff.
- Full suites are green **except two pre-existing failures** unrelated to this change (verified via `git stash` — they fail without this diff too), tracked in **sable-6udz**: a Node AuditLogger test (`error-handling-gauntlet.test.ts`) and a Python version-match test that invokes a stale global `rafter` binary.

Closes sable-h0ah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)