### PR TITLE
release: v0.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.10] - 2026-06-28
+
 ### Changed
 
 - **Claude Code `PostToolUse` hook matcher narrowed from `.*` to `Bash|Write|Edit|MultiEdit`** (Node + Python, sable-h0ah). `rafter agent init --with-claude-code` (and `rafter agent enable claude-code.hooks`) previously registered the `rafter hook posttool` redaction hook with a catch-all `.*` matcher, so it fired after **every** Claude Code tool call — including `Read` and MCP tools, which never produce secrets to redact — adding latency to every operation. The matcher now targets only the tools whose output is worth scanning: shell output (`Bash`) and file writes (`Write`/`Edit`/`MultiEdit`). PreToolUse matchers are unchanged. Codex (`.*` PostToolUse) and Gemini (`.*` AfterTool) have the same broad-matcher latency issue and are tracked separately for platform-correct narrow matchers.
+
+### Fixed
+
+- **Hooks tolerate harness-appended flags** (#180). `rafter hook pretool` / `posttool` read their input from **stdin**, so they now ignore unknown options and extra positional arguments that an agent platform appends to the hook command — e.g. Claude Code adds `--hook-json <data>`. Such extras are discarded rather than erroring; declared options like `--format` are still parsed normally.
+
+### Security
+
+- **Dependency CVE updates** (sable-qsig). Bumped vulnerable (mostly transitive) dependencies past their fixed versions via pnpm workspace overrides + a re-lock: axios 1.13.6→1.18.1, hono 4.12.8→4.12.27, tar→7.5.17, js-yaml→4.3.0, plus fast-uri, path-to-regexp, form-data, follow-redirects, ip-address, qs, and brace-expansion. Python direct-dep floors raised (`requests`, `urllib3`, `python-dotenv`); transitive Python bumps tracked separately. No CLI behavior change.
+- **Hardened remote-skill tarball extraction** (sable-qsig). `rafter skill review` / install now extracts only regular files and directories from a fetched npm tarball, skipping symlink/hardlink/device members that a malicious archive could use to redirect a later write outside the destination — defense-in-depth atop the existing zip-slip path check.
 
 ## [0.8.9] - 2026-06-20
 

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "type": "module",
   "repository": {
     "type": "git",

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.9
+version: 0.8.10
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.8.9"
+version = "0.8.10"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.8.9
+version: 0.8.10
 homepage: https://rafter.so
 metadata:
   openclaw:


### PR DESCRIPTION
Patch release bundling the unreleased changes on `main` since 0.8.9.

## Contents
- **#183** — Claude Code `PostToolUse` matcher narrowed `.*` → `Bash|Write|Edit|MultiEdit` (latency fix)
- **#180** — hooks tolerate harness-appended flags (e.g. `--hook-json`)
- **#184** — dependency CVE re-lock (axios, hono, tar, js-yaml, + transitives, ~50 CVEs) and remote-skill tarball extraction hardening

## Release mechanics
- Bumps `node/package.json` + `python/pyproject.toml` → **0.8.10** (parity ✓), the `rafter-security` skill resource version (node + python), and finalizes the CHANGELOG `[0.8.10]` section.
- Version-only change; no source/behavior changes beyond what already merged.

## Validation
- Version parity node==python==0.8.10; `pnpm install --frozen-lockfile` clean; `tsc` build clean; `--version` reports 0.8.10; node version-parity tests pass (10).

After merge, promote `main` → `prod` to trigger the npm + PyPI publish (OIDC). Refs sable-ehb1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)