### PR TITLE
fix(ci): make fixture-detection checks hermetic (unblock v0.8.10 npm publish)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -347,8 +347,17 @@ jobs:
 
       - name: Verify rafter agent scan detects secrets
         run: |
+          # Copy the fixture to a tmpdir OUTSIDE the repo before scanning. The
+          # repo's own .rafter.yml declassifies **/fixtures/** (triaged FPs for
+          # the dogfooding security gate); policy discovery walks cwd -> git
+          # root, so scanning the in-repo path would hit that policy and
+          # suppress the finding (exit 0). This step verifies the PUBLISHED
+          # engine detects secrets, independent of this repo's self-scan policy.
+          SMOKE_DIR=$(mktemp -d)
+          cp .github/fixtures/fake-secret.txt "$SMOKE_DIR/fake-secret.txt"
+          cd "$SMOKE_DIR"
           # Scan fixture file with fake secret — must exit 1 (secrets found)
-          if rafter agent scan .github/fixtures/fake-secret.txt --engine patterns; then
+          if rafter agent scan fake-secret.txt --engine patterns; then
             echo "FAIL: scan should have exited non-zero (secrets found)"
             exit 1
           fi
@@ -398,8 +407,17 @@ jobs:
 
       - name: Verify rafter agent scan detects secrets
         run: |
+          # Copy the fixture to a tmpdir OUTSIDE the repo before scanning. The
+          # repo's own .rafter.yml declassifies **/fixtures/** (triaged FPs for
+          # the dogfooding security gate); policy discovery walks cwd -> git
+          # root, so scanning the in-repo path would hit that policy and
+          # suppress the finding (exit 0). This step verifies the PUBLISHED
+          # engine detects secrets, independent of this repo's self-scan policy.
+          SMOKE_DIR=$(mktemp -d)
+          cp .github/fixtures/fake-secret.txt "$SMOKE_DIR/fake-secret.txt"
+          cd "$SMOKE_DIR"
           # Scan fixture file with fake secret — must exit 1 (secrets found)
-          if /tmp/rafter-smoke/bin/rafter agent scan .github/fixtures/fake-secret.txt --engine patterns; then
+          if /tmp/rafter-smoke/bin/rafter agent scan fake-secret.txt --engine patterns; then
             echo "FAIL: scan should have exited non-zero (secrets found)"
             exit 1
           fi

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -20,11 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Stage the fixture in a neutral temp dir OUTSIDE the fixtures/tests
+      # tree. The action runs `rafter secrets` from the workspace root, where
+      # this repo's own .rafter.yml declassifies **/fixtures/** (triaged FPs
+      # for the dogfooding gate) — scanning the in-repo path would suppress the
+      # finding. This job verifies the ENGINE detects the secret, so we scan a
+      # copy at a path the policy's globs don't match.
+      - name: Stage fixture in a clean temp dir
+        run: |
+          mkdir -p /tmp/rafter-detect
+          cp .github/fixtures/fake-secret.txt /tmp/rafter-detect/fake-secret.txt
+
       - name: Run Rafter action on fixture with known secret
         id: scan
         uses: ./              # test the local action.yml
         with:
-          scan-path: '.github/fixtures'
+          scan-path: '/tmp/rafter-detect'
           format: json
         continue-on-error: true
 
@@ -88,11 +99,18 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Scan a copy outside the fixtures tree so the repo's .rafter.yml does
+      # not suppress the finding (see "detect secrets" job for rationale).
+      - name: Stage fixture in a clean temp dir
+        run: |
+          mkdir -p /tmp/rafter-detect
+          cp .github/fixtures/fake-secret.txt /tmp/rafter-detect/fake-secret.txt
+
       - name: Run Rafter action via pip
         id: scan
         uses: ./
         with:
-          scan-path: '.github/fixtures'
+          scan-path: '/tmp/rafter-detect'
           install-method: pip
           format: json
         continue-on-error: true
@@ -112,11 +130,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Scan a copy outside the fixtures tree so the repo's .rafter.yml does
+      # not suppress the finding (see "detect secrets" job for rationale).
+      - name: Stage fixture in a clean temp dir
+        run: |
+          mkdir -p /tmp/rafter-detect
+          cp .github/fixtures/fake-secret.txt /tmp/rafter-detect/fake-secret.txt
+
       - name: Run published Rafter action @v1
         id: scan
         uses: raftersecurity/rafter-cli@v1
         with:
-          scan-path: '.github/fixtures'
+          scan-path: '/tmp/rafter-detect'
           format: json
         continue-on-error: true
 

--- a/node/tests/github-action.test.ts
+++ b/node/tests/github-action.test.ts
@@ -563,14 +563,31 @@ describe("fixture files for action testing", () => {
   });
 
   it("CLI detects secrets in fixture file", () => {
-    const r = rafter(
-      ["scan", "local", FIXTURES_DIR, "--engine", "patterns", "--format", "json"],
-    );
-    expect(r.exitCode).toBe(1);
-    // stdout or stderr should contain JSON scan results with findings
-    const combined = r.stdout + r.stderr;
-    expect(combined).toContain("AWS");
-    expect(combined).toContain("matches");
+    // Scan an isolated copy OUTSIDE the repo. This repo's own .rafter.yml
+    // declassifies **/fixtures/** (its fixtures are triaged FPs for the
+    // dogfooding security gate), and policy discovery walks cwd -> git root,
+    // so scanning the in-repo fixture would hit that policy and suppress the
+    // finding (exit 0). This test verifies the detection ENGINE, which must be
+    // decoupled from the repo's self-scan policy — so we copy the fixture to a
+    // tmpdir (no .rafter.yml above it) and scan there.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rafter-fixture-"));
+    try {
+      fs.copyFileSync(
+        path.join(FIXTURES_DIR, "fake-secret.txt"),
+        path.join(tmp, "fake-secret.txt"),
+      );
+      const r = rafter(
+        ["scan", "local", tmp, "--engine", "patterns", "--format", "json"],
+        { cwd: tmp },
+      );
+      expect(r.exitCode).toBe(1);
+      // stdout or stderr should contain JSON scan results with findings
+      const combined = r.stdout + r.stderr;
+      expect(combined).toContain("AWS");
+      expect(combined).toContain("matches");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   }, 15000);
 });
 


### PR DESCRIPTION
## Problem

The **v0.8.10 publish failed** ([run 28332931747](https://github.com/Raftersecurity/rafter-cli/actions/runs/28332931747)). `publish-python` succeeded (PyPI → **0.8.10**) but `test-node` failed at `github-action.test.ts` *"CLI detects secrets in fixture file"* (exit 0, expected 1), which gated `publish-node`. Result: **npm is stuck at 0.8.9 while PyPI shipped 0.8.10** — dual-implementation version parity is broken on the registries.

## Root cause

PR #184 added a repo-root `.rafter.yml` that declassifies `**/fixtures/**` and `.github/fixtures/**` as triaged false positives for the dogfooding security gate. **Six** checks scan `.github/fixtures` *expecting* detection, but policy discovery walks `cwd → git root`, finds `.rafter.yml`, and suppresses the finding → exit 0:

1. `node/tests/github-action.test.ts` — *"CLI detects secrets in fixture file"* (the confirmed failure)
2. `publish.yaml` → `smoke-test-node` detection step *(would fail; was skipped)*
3. `publish.yaml` → `smoke-test-python` detection step *(would fail; was skipped)*
4–6. `test-action.yml` → `detect-secrets` / `pip-install` / `published-v1` jobs *(dormant — the path filter didn't fire on #184's root-file change)*

## Fix

Keep `.rafter.yml` **exactly** as the #184 (backend-verified) security review set it. Instead make the detection checks **hermetic** — they verify the detection *engine*, which must be decoupled from the repo's own self-scan policy:

- **Unit + smoke tests**: copy the fixture to a `mktemp -d` dir outside the repo and scan there (no `.rafter.yml` above it).
- **Action jobs**: stage the fixture at a neutral `/tmp` path the policy globs don't match.

The fixture's bytes are copied verbatim, so the engine scans identical content; only the repo's self-scan policy is excluded. `github-action.test.ts:556` still guards the in-repo fixture content via `fs`. Verified locally: isolation restores exit 1 for node file/dir scans + the python file scan; `github-action.test.ts` 81/81.

## Release impact

Version stays **0.8.10**: `twine upload --skip-existing` no-ops the existing PyPI upload, `npm publish` ships 0.8.10 fresh, and `create-release` cuts the `v0.8.10` tag. After this lands on `main`, a `main → prod` merge re-triggers `publish.yaml` to bring npm to parity.

## Review
- `rafter-code-review` walkthrough (CWE-78/CWE-22 on the added CI bash): **clean** — variables quoted, `mktemp` paths, no Actions-expression injection; tests still genuinely assert detection (not vacuous). Remote `rafter run` not executable here (no `RAFTER_API_KEY`); diff is CI/test-only with no product-code surface.

Bead: sable-nfjq

🤖 Generated with [Claude Code](https://claude.com/claude-code)