### PR TITLE
Release v0.8.10 → prod (RETRY: npm publish was blocked by fixture-detection test)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -347,8 +347,17 @@ jobs:
 
       - name: Verify rafter agent scan detects secrets
         run: |
+          # Copy the fixture to a tmpdir OUTSIDE the repo before scanning. The
+          # repo's own .rafter.yml declassifies **/fixtures/** (triaged FPs for
+          # the dogfooding security gate); policy discovery walks cwd -> git
+          # root, so scanning the in-repo path would hit that policy and
+          # suppress the finding (exit 0). This step verifies the PUBLISHED
+          # engine detects secrets, independent of this repo's self-scan policy.
+          SMOKE_DIR=$(mktemp -d)
+          cp .github/fixtures/fake-secret.txt "$SMOKE_DIR/fake-secret.txt"
+          cd "$SMOKE_DIR"
           # Scan fixture file with fake secret — must exit 1 (secrets found)
-          if rafter agent scan .github/fixtures/fake-secret.txt --engine patterns; then
+          if rafter agent scan fake-secret.txt --engine patterns; then
             echo "FAIL: scan should have exited non-zero (secrets found)"
             exit 1
           fi
@@ -398,8 +407,17 @@ jobs:
 
       - name: Verify rafter agent scan detects secrets
         run: |
+          # Copy the fixture to a tmpdir OUTSIDE the repo before scanning. The
+          # repo's own .rafter.yml declassifies **/fixtures/** (triaged FPs for
+          # the dogfooding security gate); policy discovery walks cwd -> git
+          # root, so scanning the in-repo path would hit that policy and
+          # suppress the finding (exit 0). This step verifies the PUBLISHED
+          # engine detects secrets, independent of this repo's self-scan policy.
+          SMOKE_DIR=$(mktemp -d)
+          cp .github/fixtures/fake-secret.txt "$SMOKE_DIR/fake-secret.txt"
+          cd "$SMOKE_DIR"
           # Scan fixture file with fake secret — must exit 1 (secrets found)
-          if /tmp/rafter-smoke/bin/rafter agent scan .github/fixtures/fake-secret.txt --engine patterns; then
+          if /tmp/rafter-smoke/bin/rafter agent scan fake-secret.txt --engine patterns; then
             echo "FAIL: scan should have exited non-zero (secrets found)"
             exit 1
           fi

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -20,11 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Stage the fixture in a neutral temp dir OUTSIDE the fixtures/tests
+      # tree. The action runs `rafter secrets` from the workspace root, where
+      # this repo's own .rafter.yml declassifies **/fixtures/** (triaged FPs
+      # for the dogfooding gate) — scanning the in-repo path would suppress the
+      # finding. This job verifies the ENGINE detects the secret, so we scan a
+      # copy at a path the policy's globs don't match.
+      - name: Stage fixture in a clean temp dir
+        run: |
+          mkdir -p /tmp/rafter-detect
+          cp .github/fixtures/fake-secret.txt /tmp/rafter-detect/fake-secret.txt
+
       - name: Run Rafter action on fixture with known secret
         id: scan
         uses: ./              # test the local action.yml
         with:
-          scan-path: '.github/fixtures'
+          scan-path: '/tmp/rafter-detect'
           format: json
         continue-on-error: true
 
@@ -88,11 +99,18 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Scan a copy outside the fixtures tree so the repo's .rafter.yml does
+      # not suppress the finding (see "detect secrets" job for rationale).
+      - name: Stage fixture in a clean temp dir
+        run: |
+          mkdir -p /tmp/rafter-detect
+          cp .github/fixtures/fake-secret.txt /tmp/rafter-detect/fake-secret.txt
+
       - name: Run Rafter action via pip
         id: scan
         uses: ./
         with:
-          scan-path: '.github/fixtures'
+          scan-path: '/tmp/rafter-detect'
           install-method: pip
           format: json
         continue-on-error: true
@@ -112,11 +130,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Scan a copy outside the fixtures tree so the repo's .rafter.yml does
+      # not suppress the finding (see "detect secrets" job for rationale).
+      - name: Stage fixture in a clean temp dir
+        run: |
+          mkdir -p /tmp/rafter-detect
+          cp .github/fixtures/fake-secret.txt /tmp/rafter-detect/fake-secret.txt
+
       - name: Run published Rafter action @v1
         id: scan
         uses: raftersecurity/rafter-cli@v1
         with:
-          scan-path: '.github/fixtures'
+          scan-path: '/tmp/rafter-detect'
           format: json
         continue-on-error: true
 

--- a/node/tests/github-action.test.ts
+++ b/node/tests/github-action.test.ts
@@ -563,14 +563,31 @@ describe("fixture files for action testing", () => {
   });
 
   it("CLI detects secrets in fixture file", () => {
-    const r = rafter(
-      ["scan", "local", FIXTURES_DIR, "--engine", "patterns", "--format", "json"],
-    );
-    expect(r.exitCode).toBe(1);
-    // stdout or stderr should contain JSON scan results with findings
-    const combined = r.stdout + r.stderr;
-    expect(combined).toContain("AWS");
-    expect(combined).toContain("matches");
+    // Scan an isolated copy OUTSIDE the repo. This repo's own .rafter.yml
+    // declassifies **/fixtures/** (its fixtures are triaged FPs for the
+    // dogfooding security gate), and policy discovery walks cwd -> git root,
+    // so scanning the in-repo fixture would hit that policy and suppress the
+    // finding (exit 0). This test verifies the detection ENGINE, which must be
+    // decoupled from the repo's self-scan policy — so we copy the fixture to a
+    // tmpdir (no .rafter.yml above it) and scan there.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rafter-fixture-"));
+    try {
+      fs.copyFileSync(
+        path.join(FIXTURES_DIR, "fake-secret.txt"),
+        path.join(tmp, "fake-secret.txt"),
+      );
+      const r = rafter(
+        ["scan", "local", tmp, "--engine", "patterns", "--format", "json"],
+        { cwd: tmp },
+      );
+      expect(r.exitCode).toBe(1);
+      // stdout or stderr should contain JSON scan results with findings
+      const combined = r.stdout + r.stderr;
+      expect(combined).toContain("AWS");
+      expect(combined).toContain("matches");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   }, 15000);
 });
 


### PR DESCRIPTION
## Why this is a retry

PR #186 promoted v0.8.10 to prod and triggered [publish run 28332931747](https://github.com/Raftersecurity/rafter-cli/actions/runs/28332931747). **`publish-python` succeeded (PyPI → 0.8.10) but `test-node` failed**, gating `publish-node` → **npm is stuck at 0.8.9**. prod was then rolled back to the 0.8.9 state (current prod HEAD = `992fa49`).

This PR re-promotes `main` (now containing the fix) to complete the release and bring **npm to 0.8.10**, restoring registry parity.

## What was broken & fixed

The `test-node` failure was `github-action.test.ts` *"CLI detects secrets in fixture file"* (exit 0, expected 1). Root cause: the repo-root `.rafter.yml` added in #184 declassifies `**/fixtures/**`, so six fixture-detection checks (the unit test, both `publish.yaml` smoke tests, three `test-action.yml` jobs) had their findings suppressed by the repo's own self-scan policy.

Fixed in #187 (merged to `main`): the detection checks are now **hermetic** — they scan an isolated copy outside the repo, so `.rafter.yml` is untouched (its #184 backend-verified suppressions stay intact) while the checks verify the detection *engine*. The three `test-action.yml` jobs now **pass in CI**; `github-action.test.ts` passes 81/81 locally.

## On merge (publish.yaml)

- `test-node` / `test-package`: now green (fix included)
- `publish-node`: **npm publish 0.8.10** (not yet on npm → publishes) ✅
- `publish-python`: `twine --skip-existing` → 0.8.10 already on PyPI → no-op ✅
- `create-release`: cuts the **`v0.8.10` git tag** (does not exist yet) + GitHub release
- `smoke-test-node` / `smoke-test-python`: now green (fix included)
- `publish-clawhub`: publishes the 0.8.10 skill (was skipped last time)

Version stays **0.8.10** (node + python both at 0.8.10; parity holds).

## ⚠️ Irreversible — needs Rome's approve + merge

Merging this triggers an **irreversible npm publish** and is gated by prod branch protection (REVIEW_REQUIRED). Leaving the final approve+merge to Rome, per sable-ehb1.

Beads: sable-ehb1 (release), sable-nfjq (fix), follow-up sable-8860 (run full tests on PRs→main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)