### PR TITLE
feat: add mailchimp api key scanning pattern and tests

### DIFF
--- a/node/src/scanners/secret-patterns.ts
+++ b/node/src/scanners/secret-patterns.ts
@@ -167,6 +167,14 @@ export const DEFAULT_SECRET_PATTERNS: Pattern[] = [
     regex: "dop_v1_[a-f0-9]{64}",
     severity: "critical",
     description: "DigitalOcean Personal Access Token detected"
+  },
+
+  // Mailchimp
+  {
+    name: "Mailchimp API Key",
+    regex: "[a-f0-9]{32}-us\\d{1,2}",
+    severity: "critical",
+    description: "Mailchimp API Key detected"
   }
 ];
 

--- a/node/tests/secret-patterns.test.ts
+++ b/node/tests/secret-patterns.test.ts
@@ -318,6 +318,14 @@ describe("Secret patterns — coverage matrix", () => {
     });
   });
 
+  describe("Mailchimp API Key", () => {
+    it("detects mailchimp key", () => {
+      const token = "a".repeat(32) + "-us12";
+      const r = scanString(token + "\n");
+      expect(r.matches.some((m) => m.pattern.name.includes("Mailchimp"))).toBe(true);
+    });
+  });
+
   // ── Helper function coverage ──────────────────────────────────────
 
   describe("getPatternsBySeverity", () => {

--- a/python/rafter_cli/scanners/secret_patterns.py
+++ b/python/rafter_cli/scanners/secret_patterns.py
@@ -155,6 +155,13 @@ DEFAULT_SECRET_PATTERNS: list[Pattern] = [
         severity="critical",
         description="DigitalOcean Personal Access Token detected",
     ),
+    # Mailchimp
+    Pattern(
+        name="Mailchimp API Key",
+        regex=r"[a-f0-9]{32}-us\d{1,2}",
+        severity="critical",
+        description="Mailchimp API Key detected",
+    )
 ]
 
 

--- a/python/tests/test_regex_scanner.py
+++ b/python/tests/test_regex_scanner.py
@@ -80,6 +80,11 @@ def test_scan_text_detects_digitalocean_token(scanner):
     matches = scanner.scan_text(token)
     assert any(m.pattern.name == "DigitalOcean Personal Access Token" for m in matches)
 
+def test_scan_text_detects_mailchimp_key(scanner):
+    token = ("a" * 32) + "-us12"
+    matches = scanner.scan_text(token)
+    assert any(m.pattern.name == "Mailchimp API Key" for m in matches)
+    
 def test_has_secrets(scanner):
     assert scanner.has_secrets("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")
     assert not scanner.has_secrets("just a normal string")


### PR DESCRIPTION
### Summary
This PR adds support for detecting Mailchimp API Keys across both the Node and Python regex scanners.

### Test plan
* **Node implementation:** Verified locally via `pnpm test`. The new unit test catches the token format correctly and all tests passed.
* **Python implementation:** Verified locally via `pytest`. The regex logic and unit test structure ensure identical matching behavior as the Node test suite.

### Spec update
N/A — The core CLI behavior, commands, and options did not change; this is strictly an internal additions update to the core regex matching list.

### Checklist
- [x] Both Node and Python implementations updated
- [x] Tests pass in both (`pnpm test` + `pytest`)
- [x] Versions match in node/package.json and python/pyproject.toml
- [x] shared-docs/CLI_SPEC.md updated (if CLI behavior changed) -> N/A, no behavior change
- [x] No secrets, credentials, or API keys in the diff