### PR TITLE
fix(audit): redact secret-named env-assignment prefixes before logging (ob-y5ep)

### DIFF
--- a/node/src/core/pattern-engine.ts
+++ b/node/src/core/pattern-engine.ts
@@ -24,6 +24,24 @@ const VARIABLE_NAME_RE = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/;
 const LOWERCASE_IDENT_RE = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$/;
 const QUOTED_VALUE_RE = /['"]([^'"]+)['"]/;
 
+/**
+ * Matches an environment-assignment prefix in a command line: an identifier
+ * followed immediately by `=` and a run of non-whitespace (the value). Used to
+ * find `NAME=VALUE` tokens like `RAFTER_API_KEY=<secret> rafter ...` so their
+ * value can be redacted before the command is written to the audit log.
+ */
+const ENV_ASSIGN_RE = /(^|\s)([A-Za-z_][A-Za-z0-9_]*)=(\S+)/g;
+
+/**
+ * A `NAME` in a `NAME=VALUE` assignment is treated as secret-bearing when it
+ * ends in a credential-suggesting word (e.g. RAFTER_API_KEY, GITHUB_TOKEN,
+ * DB_PASSWORD, AUTH). Values behind such names are redacted even when they
+ * don't match any known secret pattern (that's the whole point — the value of
+ * a bespoke API key won't match a built-in pattern, but it's still a secret).
+ * Plain names like FOO or NODE_ENV do not match, so `FOO=bar` is left intact.
+ */
+const SECRET_ENV_NAME_RE = /(?:^|_)(KEY|TOKEN|SECRET|SECRETS|PASSWORD|PASSWD|PWD|API[_-]?KEY|ACCESS[_-]?KEY|CREDENTIALS?|AUTH)$/i;
+
 export class PatternEngine {
   private patterns: Pattern[];
 
@@ -85,10 +103,18 @@ export class PatternEngine {
   }
 
   /**
-   * Redact text by replacing sensitive patterns
+   * Redact text by replacing sensitive patterns.
+   *
+   * Two layers, both additive:
+   *  1. Env-assignment redaction: any `NAME=VALUE` whose NAME looks
+   *     secret-bearing has its VALUE masked, even if the VALUE matches no
+   *     known pattern. This catches leaks like `RAFTER_API_KEY=<key> rafter …`
+   *     in a logged command line, where the key's shape is unknown.
+   *  2. Pattern-based redaction: values that match a built-in secret pattern
+   *     are masked wherever they appear.
    */
   redactText(text: string): string {
-    let redacted = text;
+    let redacted = this.redactEnvAssignments(text);
 
     for (const pattern of this.patterns) {
       const regex = this.createRegex(pattern.regex);
@@ -98,6 +124,16 @@ export class PatternEngine {
     }
 
     return redacted;
+  }
+
+  /**
+   * Mask the VALUE of every `NAME=VALUE` token whose NAME looks
+   * secret-bearing. Non-secret names (FOO, NODE_ENV, …) are left untouched.
+   */
+  private redactEnvAssignments(text: string): string {
+    return text.replace(ENV_ASSIGN_RE, (full, prefix: string, name: string, value: string) =>
+      SECRET_ENV_NAME_RE.test(name) ? `${prefix}${name}=${this.redact(value)}` : full
+    );
   }
 
   /**

--- a/node/tests/audit-logger.test.ts
+++ b/node/tests/audit-logger.test.ts
@@ -141,6 +141,30 @@ describe("AuditLogger", () => {
       expect(onDisk).not.toContain(token);
     });
 
+    // ob-y5ep: a RAFTER_API_KEY env-assignment prefix leaked verbatim because
+    // the key's value matches no built-in secret pattern. Redaction must key
+    // off the secret-named env var, not just the value's shape.
+    it("logCommandIntercepted redacts a RAFTER_API_KEY env-assignment prefix", () => {
+      const logger = new AuditLogger(logPath);
+      const key = "sk-deadbeefdeadbeef";
+      logger.logCommandIntercepted(`RAFTER_API_KEY=${key} rafter scan .`, true, "allowed");
+      const entries = logger.read();
+      const logged = entries[0].action?.command as string;
+      expect(logged).not.toContain(key);
+      expect(logged).toContain("RAFTER_API_KEY=");
+      expect(logged).toMatch(/\*/);
+      // and never on disk
+      expect(fs.readFileSync(logPath, "utf-8")).not.toContain(key);
+    });
+
+    it("logCommandIntercepted preserves benign env assignments", () => {
+      const logger = new AuditLogger(logPath);
+      logger.logCommandIntercepted("FOO=bar NODE_ENV=production rafter scan .", true, "allowed");
+      const logged = logger.read()[0].action?.command as string;
+      expect(logged).toContain("FOO=bar");
+      expect(logged).toContain("NODE_ENV=production");
+    });
+
     it("auto-populates cwd and gitRepo on every entry", () => {
       const logger = new AuditLogger(logPath);
       logger.logCommandIntercepted("ls", true, "allowed");

--- a/node/tests/pattern-engine.test.ts
+++ b/node/tests/pattern-engine.test.ts
@@ -240,4 +240,36 @@ line 3`;
     expect(critical.length).toBe(2);
     expect(critical.every(p => p.severity === "critical")).toBe(true);
   });
+
+  // ob-y5ep: env-assignment redaction. A value whose NAME looks secret-bearing
+  // must be masked even when the value matches no known secret pattern.
+  describe("env-assignment redaction (ob-y5ep)", () => {
+    const engine = new PatternEngine(testPatterns);
+
+    it("redacts a RAFTER_API_KEY value that matches no pattern", () => {
+      const out = engine.redactText("RAFTER_API_KEY=sk-deadbeefdeadbeef rafter scan .");
+      expect(out).not.toContain("sk-deadbeefdeadbeef");
+      expect(out).toContain("RAFTER_API_KEY=");
+      expect(out).toContain("rafter scan .");
+    });
+
+    it("redacts values behind common secret-named env vars", () => {
+      for (const name of ["API_KEY", "GITHUB_TOKEN", "DB_PASSWORD", "AWS_SECRET", "AUTH", "PASSWD"]) {
+        const out = engine.redactText(`${name}=supersecretvalue123 next`);
+        expect(out, name).not.toContain("supersecretvalue123");
+      }
+    });
+
+    it("leaves benign assignments untouched", () => {
+      expect(engine.redactText("FOO=bar")).toBe("FOO=bar");
+      expect(engine.redactText("NODE_ENV=production")).toBe("NODE_ENV=production");
+      expect(engine.redactText("PATH=/usr/bin rafter scan .")).toBe("PATH=/usr/bin rafter scan .");
+    });
+
+    it("redacts only the secret assignment in a mixed command", () => {
+      const out = engine.redactText("FOO=bar SECRET_TOKEN=abcdef1234567890 rafter");
+      expect(out).toContain("FOO=bar");
+      expect(out).not.toContain("abcdef1234567890");
+    });
+  });
 });

--- a/python/rafter_cli/core/pattern_engine.py
+++ b/python/rafter_cli/core/pattern_engine.py
@@ -33,6 +33,23 @@ _VARIABLE_NAME_RE = re.compile(r"^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$")
 _LOWERCASE_IDENT_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$")
 _QUOTED_VALUE_RE = re.compile(r"""['\"]([^'\"]+)['\"]""")
 
+# Matches an environment-assignment prefix in a command line: an identifier
+# followed immediately by ``=`` and a run of non-whitespace (the value). Used
+# to find ``NAME=VALUE`` tokens like ``RAFTER_API_KEY=<secret> rafter ...`` so
+# their value can be redacted before the command is written to the audit log.
+_ENV_ASSIGN_RE = re.compile(r"(^|\s)([A-Za-z_][A-Za-z0-9_]*)=(\S+)")
+
+# A ``NAME`` in a ``NAME=VALUE`` assignment is treated as secret-bearing when
+# it ends in a credential-suggesting word (RAFTER_API_KEY, GITHUB_TOKEN,
+# DB_PASSWORD, AUTH, ...). Values behind such names are redacted even when they
+# don't match any known secret pattern -- the value of a bespoke API key won't
+# match a built-in pattern, but it's still a secret. Plain names like FOO or
+# NODE_ENV do not match, so ``FOO=bar`` is left intact.
+_SECRET_ENV_NAME_RE = re.compile(
+    r"(?:^|_)(KEY|TOKEN|SECRET|SECRETS|PASSWORD|PASSWD|PWD|API[_-]?KEY|ACCESS[_-]?KEY|CREDENTIALS?|AUTH)$",
+    re.IGNORECASE,
+)
+
 
 class PatternEngine:
     def __init__(self, patterns: Sequence[Pattern]):
@@ -76,8 +93,18 @@ class PatternEngine:
         return matches
 
     def redact_text(self, text: str) -> str:
-        """Replace all pattern matches in *text* with redacted versions."""
-        result = text
+        """Replace all pattern matches in *text* with redacted versions.
+
+        Two layers, both additive:
+          1. Env-assignment redaction: any ``NAME=VALUE`` whose NAME looks
+             secret-bearing has its VALUE masked, even if the VALUE matches no
+             known pattern. This catches leaks like
+             ``RAFTER_API_KEY=<key> rafter ...`` in a logged command line,
+             where the key's shape is unknown.
+          2. Pattern-based redaction: values matching a built-in secret
+             pattern are masked wherever they appear.
+        """
+        result = self._redact_env_assignments(text)
         for pattern in self._patterns:
             compiled = self._compile(pattern.regex)
             if compiled is None:
@@ -87,6 +114,18 @@ class PatternEngine:
                 result,
             )
         return result
+
+    @staticmethod
+    def _redact_env_assignments(text: str) -> str:
+        """Mask the VALUE of every ``NAME=VALUE`` token whose NAME looks
+        secret-bearing. Non-secret names (FOO, NODE_ENV, ...) are untouched."""
+        def _sub(m: re.Match) -> str:
+            prefix, name, value = m.group(1), m.group(2), m.group(3)
+            if _SECRET_ENV_NAME_RE.search(name):
+                return f"{prefix}{name}={PatternEngine._redact(value)}"
+            return m.group(0)
+
+        return _ENV_ASSIGN_RE.sub(_sub, text)
 
     def has_matches(self, text: str) -> bool:
         return len(self.scan(text)) > 0

--- a/python/tests/test_audit_logger_redaction.py
+++ b/python/tests/test_audit_logger_redaction.py
@@ -55,6 +55,37 @@ def test_log_command_intercepted_redacts_github_token(audit_path, enabled_config
     assert entry["eventType"] == "command_intercepted"
 
 
+def test_log_command_intercepted_redacts_rafter_api_key_env_prefix(audit_path, enabled_config):
+    """ob-y5ep: a RAFTER_API_KEY=<val> env prefix leaked verbatim because the
+    key's value matches no built-in pattern. It must be redacted anyway."""
+    logger = AuditLogger(log_path=audit_path)
+    key = "sk-deadbeefdeadbeef"
+    logger.log_command_intercepted(
+        f"RAFTER_API_KEY={key} rafter scan .",
+        passed=True,
+        action_taken="allowed",
+    )
+    on_disk = audit_path.read_text()
+    assert key not in on_disk, "raw RAFTER_API_KEY leaked into audit.jsonl"
+    entry = json.loads(on_disk.strip())
+    assert "RAFTER_API_KEY=" in entry["action"]["command"]
+    assert "*" in entry["action"]["command"]
+
+
+def test_log_command_intercepted_preserves_benign_env_assignments(audit_path, enabled_config):
+    """ob-y5ep: non-secret env assignments must survive redaction intact."""
+    logger = AuditLogger(log_path=audit_path)
+    logger.log_command_intercepted(
+        "FOO=bar NODE_ENV=production rafter scan .",
+        passed=True,
+        action_taken="allowed",
+    )
+    entry = json.loads(audit_path.read_text().strip())
+    command = entry["action"]["command"]
+    assert "FOO=bar" in command
+    assert "NODE_ENV=production" in command
+
+
 def test_log_command_intercepted_preserves_risk_assessment(audit_path, enabled_config):
     logger = AuditLogger(log_path=audit_path)
     logger.log_command_intercepted("rm -rf /", passed=False, action_taken="blocked")

--- a/python/tests/test_pattern_engine.py
+++ b/python/tests/test_pattern_engine.py
@@ -299,3 +299,33 @@ def test_all_patterns_present():
     assert len(DEFAULT_SECRET_PATTERNS) >= 22
     names = [p.name for p in DEFAULT_SECRET_PATTERNS]
     assert len(names) == len(set(names)), "pattern names must be unique"
+
+
+# -- Env-assignment redaction (ob-y5ep) --------------------------------------
+# A value whose NAME looks secret-bearing must be masked even when the value
+# matches no known secret pattern (e.g. a bespoke RAFTER_API_KEY).
+
+def test_env_redaction_masks_rafter_api_key_value():
+    out = _engine().redact_text("RAFTER_API_KEY=sk-deadbeefdeadbeef rafter scan .")
+    assert "sk-deadbeefdeadbeef" not in out
+    assert "RAFTER_API_KEY=" in out
+    assert "rafter scan ." in out
+
+
+def test_env_redaction_masks_common_secret_named_vars():
+    for name in ("API_KEY", "GITHUB_TOKEN", "DB_PASSWORD", "AWS_SECRET", "AUTH", "PASSWD"):
+        out = _engine().redact_text(f"{name}=supersecretvalue123 next")
+        assert "supersecretvalue123" not in out, name
+
+
+def test_env_redaction_preserves_benign_assignments():
+    engine = _engine()
+    assert engine.redact_text("FOO=bar") == "FOO=bar"
+    assert engine.redact_text("NODE_ENV=production") == "NODE_ENV=production"
+    assert engine.redact_text("PATH=/usr/bin rafter scan .") == "PATH=/usr/bin rafter scan ."
+
+
+def test_env_redaction_only_touches_secret_assignment_in_mixed_command():
+    out = _engine().redact_text("FOO=bar SECRET_TOKEN=abcdef1234567890 rafter")
+    assert "FOO=bar" in out
+    assert "abcdef1234567890" not in out


### PR DESCRIPTION
## Bug (ob-y5ep)

`~/.rafter/audit.jsonl` captured real `RAFTER_API_KEY` values in **plaintext** despite config `redact_secrets: true`.

When a command is run as `RAFTER_API_KEY=<value> rafter ...`, the audit interceptor logs the full command line via `scanner.redact(command)`. But `redact()` only replaced substrings matching a known secret **pattern**. A `NAME=VALUE` env-assignment prefix whose value doesn't match any built-in pattern (like a bespoke Rafter API key) was **not** redacted — so it leaked into the log.

## Fix

Env-assignment redaction is added to the **shared** redaction path — `PatternEngine.redactText()` (Node) / `redact_text()` (Python) — which `RegexScanner.redact()` delegates to. This means every command-logging call site benefits (`logCommandIntercepted` and `logPolicyOverride`).

Any `NAME=VALUE` token whose NAME looks secret-bearing has its VALUE masked with the codebase's **existing** char-mask, even when the value matches no pattern:

```
/(?:^|_)(KEY|TOKEN|SECRET|SECRETS|PASSWORD|PASSWD|PWD|API[_-]?KEY|ACCESS[_-]?KEY|CREDENTIALS?|AUTH)$/i
```

`RAFTER_API_KEY` matches (via the `_KEY` boundary). This is **additive** to the existing pattern-based redaction — it catches values behind a secret-named env var that no pattern would catch. Benign assignments are left untouched:

- `RAFTER_API_KEY=sk-… rafter scan .` → value masked ✅
- `FOO=bar`, `NODE_ENV=production` → **preserved** ✅

## Dual-implementation parity

Both Node and Python updated in lockstep — identical regex, identical ordering (env-assignment redaction runs before pattern-based redaction), identical char-mask reuse. No version files touched.

Files: `node/src/core/pattern-engine.ts`, `python/rafter_cli/core/pattern_engine.py`, plus tests in both suites.

## Tests

Added in **both** suites (unit-level in `pattern-engine` + integration-level through the audit logger):

- A `RAFTER_API_KEY=sk-deadbeefdeadbeef rafter scan .` command must **not** contain the raw value on disk, and must keep `RAFTER_API_KEY=` + a mask.
- A benign `FOO=bar` / `NODE_ENV=production` assignment must be **preserved**.

**Results**

- **Node** (`pnpm test`): the two edited files pass (62/62). Full suite: 1938 passed. The 2 failures are **pre-existing and environmental**, not from this diff:
  - `error-handling-gauntlet > log() writes valid JSONL entry` — depends on the machine's real `~/.rafter` config `logAllActions` (confirmed still fails on clean `origin/main` with my source reverted); doesn't invoke redaction at all.
  - `cross-runtime-parity > both report the same semver` — a **stale installed** `rafter_cli` (reports `0.8.7`) vs source (`0.8.10`); this diff touches no version files.
- **Python** (`PYTHONPATH=. pytest`): the two edited files pass (58/58). Full suite: 1454 passed, 1 skipped. The 1 failure is the same stale-install artifact (`test_version_matches_pyproject`: `'0.8.10' in 'rafter 0.8.7'`).

## Security gate

- **`rafter-code-review`** (CWE Top 25 walk, JS/TS + Python): **PASS** — no HIGH/CRITICAL.
  - No ReDoS in the two new regexes (no nested quantifiers, bounded char classes, linear scan).
  - The `/g` regex is used only in `.replace()` (no `lastIndex` statefulness bug); the name regex is non-global so `.test()`/`.search()` is stateless.
  - Over-redaction correctly gated: `FOO`/`NODE_ENV` untouched (asserted by test).
  - Node/Python parity verified.
  - **LOW / informational (non-blocking):** (a) the primary `NAME=VALUE ` token vector is fully closed, but a value that is quoted-with-spaces or immediately adjacent to a shell separator (`;`/`&`) is only partially redacted — still strictly better than before, where nothing was redacted; (b) the char-mask reveals first-4/last-4 by the codebase's established convention (values ≤ 8 chars are fully masked).
- **`rafter secrets`** on the changed source files: clean.
- **`rafter run`** (remote SAST/SCA): **skipped** — `RAFTER_API_KEY` was not set in the environment.

## Out of scope (follow-up)

The bead also notes ~8 already-exposed lines in the real `~/.rafter/audit.jsonl` to purge. That is a **separate operational task**: it requires key rotation first, and the file is a SHA-256 hash chain (no blind `sed`). This PR does not read, print, or modify the real audit file or any real secret. Track the purge + rotation separately.

---

Per the repo AI Policy: this PR was **AI-assisted** (authored with Claude Opus 4.8).