### PR TITLE
test(scan): Mailchimp negative-case tests + whitespace tidy (follow-up to #190)

### DIFF
--- a/node/tests/secret-patterns.test.ts
+++ b/node/tests/secret-patterns.test.ts
@@ -324,6 +324,12 @@ describe("Secret patterns — coverage matrix", () => {
       const r = scanString(token + "\n");
       expect(r.matches.some((m) => m.pattern.name.includes("Mailchimp"))).toBe(true);
     });
+
+    it("does not match a bare 32-char hex string without the -us datacenter suffix", () => {
+      const notAKey = "a".repeat(32);
+      const r = scanString(notAKey + "\n");
+      expect(r.matches.some((m) => m.pattern.name.includes("Mailchimp"))).toBe(false);
+    });
   });
 
   // ── Helper function coverage ──────────────────────────────────────

--- a/python/tests/test_regex_scanner.py
+++ b/python/tests/test_regex_scanner.py
@@ -84,7 +84,12 @@ def test_scan_text_detects_mailchimp_key(scanner):
     token = ("a" * 32) + "-us12"
     matches = scanner.scan_text(token)
     assert any(m.pattern.name == "Mailchimp API Key" for m in matches)
-    
+
+def test_scan_text_ignores_bare_hex_without_datacenter_suffix(scanner):
+    token = "a" * 32
+    matches = scanner.scan_text(token)
+    assert not any(m.pattern.name == "Mailchimp API Key" for m in matches)
+
 def test_has_secrets(scanner):
     assert scanner.has_secrets("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")
     assert not scanner.has_secrets("just a normal string")


### PR DESCRIPTION
Follow-up polish to #190 (@Minh-Nguyen-2k7's Mailchimp API key pattern), applied by maintainers so nothing was blocked on the contributor.

## What
- Adds a **negative-case test** in both Node and Python: a bare 32-char hex string with no `-us<dc>` datacenter suffix must **not** match the Mailchimp pattern (guards against over-broad matching).
- Removes trailing whitespace on the Python test added in #190.

**Test-only** — the pattern itself is unchanged from #190.

## Verification
- Node: `secret-patterns.test.ts` **58 passed**
- Python: `test_regex_scanner.py` **16 passed**

AI-assisted per the repo AI Policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)