### PR TITLE
docs(skills): scope rafter security skills by surface, not task label

### DIFF
--- a/node/resources/skills/rafter-code-review/SKILL.md
+++ b/node/resources/skills/rafter-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rafter-code-review
-description: "REQUIRED before declaring a task done when the diff touches user input, SQL, shell, auth, credentials, file paths, serialization, or dependency surface. Walks OWASP/ASVS/MITRE questions the compiler and the test suite won't catch. Pair with `rafter run` on the same diff. A security-relevant task marked complete without both has been under-delivered — do not claim done."
+description: "REQUIRED before declaring a task done when the diff touches user input, SQL, shell, auth, credentials, file paths, serialization, crypto, network endpoints, data deletion, or dependency surface. Judge by that surface, not the task label — research/experimental/local-only code with none of it can skip this. Walks OWASP/ASVS/MITRE questions the compiler and the test suite won't catch. Pair with `rafter run` on the same diff. When the diff has that surface, marking it complete without both has been under-delivered — do not claim done."
 version: 0.7.0
 allowed-tools: [Bash, Read, Glob, Grep]
 ---
@@ -10,6 +10,12 @@ allowed-tools: [Bash, Read, Glob, Grep]
 A reviewer's skill, not an audit generator. Each sub-doc is a set of **questions** to run against the code — what to grep for, what to trace, what to ask before you sign off. No monolithic reports.
 
 > Pair with the `rafter` skill (detection: `rafter scan`, `rafter run`) and `rafter-secure-design` (prevention: design-phase walks). This skill is the middle stage — review before merge.
+
+## When this applies (and when it doesn't)
+
+Scoped to the **security surface of the diff**, not the task's label. Walk it fully when the change touches: user / untrusted input, SQL or query building, shell / `exec` / subprocess, auth or access control, credentials / secrets / tokens, file paths or uploads, (de)serialization, crypto, network-facing endpoints or outbound fetchers, data deletion, or dependency / manifest changes.
+
+If **none** of those are present — research / experimental / exploratory / local-only / throwaway code such as training scripts, data analysis, plotting, model eval, notebooks, or pure computation over trusted local data — a quick surface check is enough; you don't need to walk the full review or pair `rafter run`. But the check is the surface, not the label: research code that reads a secret, shells out, hits the network, or parses untrusted bytes is back on the engage list and gets the full walk.
 
 ## How to use this skill
 

--- a/node/resources/skills/rafter-secure-design/SKILL.md
+++ b/node/resources/skills/rafter-secure-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rafter-secure-design
-description: "REQUIRED before writing code for any feature touching auth, payments, credentials, tokens, sessions, file upload, user data, or data deletion. Invoke it, record answers inline in the design doc or PR description, then write the code. Skipping this is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. If the feature touches any of those surfaces and this hasn't run, the design is incomplete — do not proceed to implementation."
+description: "REQUIRED before writing code for any feature touching auth, payments, credentials, tokens, sessions, file upload, user data, untrusted input, deserialization, network endpoints, or data deletion. Scope by that surface, not the task label — a research/experimental/local-only feature with none of it doesn't need this. Invoke it, record answers inline in the design doc or PR description, then write the code. Skipping this is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. If the feature touches any of those surfaces and this hasn't run, the design is incomplete — do not proceed to implementation."
 version: 0.1.0
 allowed-tools: [Read, Glob, Grep]
 ---
@@ -10,6 +10,12 @@ allowed-tools: [Read, Glob, Grep]
 A designer's skill, not a scanner. The goal is to catch the flaw in the whiteboard sketch, not three weeks later in a PR. Each sub-doc asks the questions a security engineer would ask at kickoff — "which primitive, which boundary, which default?"
 
 > Pair with `rafter-code-review` (structured review *during* PR) and the `rafter` skill (automated detection of what slipped through). This skill is the earliest stage — prevention before the code exists.
+
+## When this applies (and when it doesn't)
+
+Engage this design walk when the feature you're about to build touches a real security surface: auth or access control, credentials / secrets / tokens / sessions, user or untrusted input, SQL or query construction, shell / `exec`, file paths or uploads, (de)serialization, crypto, network-facing endpoints or outbound fetchers, data deletion, or new dependencies.
+
+If the thing you're designing has **none** of that — a research / experimental / local-only / throwaway piece such as a training script, analysis pipeline, plot, model-eval harness, notebook, or pure computation over trusted local data — a quick surface check is enough and you can proceed to implementation without the full walk. Judge by the surface, not by whether the work is called "research": a research feature that stores user data, handles a token, or opens a network endpoint is back on the engage list.
 
 ## How to use this skill
 

--- a/node/resources/skills/rafter/SKILL.md
+++ b/node/resources/skills/rafter/SKILL.md
@@ -1,11 +1,35 @@
 ---
 name: rafter
-description: "Entry point for rafter. Invoke when a sub-skill is unclear, or when the task needs `rafter run` (remote SAST+SCA), `rafter secrets` (local secrets-only), `rafter audit`, policy checks, or command-risk evaluation. If a task is security-relevant and no rafter skill or CLI call has been made, invoke this before handing the task off — an un-evaluated \"done\" on security-relevant work is not done."
+description: "Entry point for rafter. Invoke when a sub-skill is unclear, or when the task needs `rafter run` (remote SAST+SCA), `rafter secrets` (local secrets-only), `rafter audit`, policy checks, or command-risk evaluation. Scope by security surface, not task label: engage when the diff touches auth, credentials/secrets/tokens, untrusted input, SQL, shell/exec, file paths, deserialization, crypto, network endpoints, data deletion, or dependencies; for research/experimental/local-only code with none of that, a quick surface check is enough. When such surface IS present and no rafter skill or CLI call has been made, invoke this before handing the task off — an un-evaluated \"done\" on genuine security surface is not done."
 version: 0.7.0
 allowed-tools: [Bash, Read]
 ---
 
 # Rafter — Security Toolkit for AI Workflows
+
+## When Rafter applies (and when it doesn't)
+
+Rafter is a **surface-driven** gate, not a task-label gate. Before you engage — or decide not to — do a 10-second read of the diff's actual security surface. Let that answer, not whether the work is called "research", pick the branch.
+
+**Engage fully** (walk the review + run `rafter run`) when the change touches any of:
+
+- auth, sessions, or access control
+- credentials, secrets, tokens, or keys
+- user-supplied or otherwise untrusted input
+- SQL or any other query / command construction
+- shell, `exec`, or subprocess invocation
+- file paths — reads, writes, uploads, traversal
+- deserialization or parsing of untrusted data
+- crypto (choosing or using primitives)
+- network-facing endpoints or outbound fetchers (SSRF surface)
+- data deletion or other destructive mutations
+- dependency, lockfile, or manifest changes
+
+**Back off** when the change has **none** of the above — research / experimental / exploratory / local-only / throwaway code: training scripts, data analysis, plotting, model eval, notebooks, pure computation over trusted local data. A quick surface check is enough, and if there is genuinely no security surface it is fine to proceed **without** the full `rafter-code-review` + `rafter run`.
+
+**The rule that decides it:** the "research" label buys nothing. Research code that reads a secret, shells out, hits the network, parses untrusted input, or bumps a dependency is on the engage list and gets the full gate. Judge by the surface of the diff, not by what the task is called.
+
+---
 
 ## Picking the right tier — DO NOT stop at "local"
 

--- a/python/rafter_cli/resources/skills/rafter-code-review/SKILL.md
+++ b/python/rafter_cli/resources/skills/rafter-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rafter-code-review
-description: "REQUIRED before declaring a task done when the diff touches user input, SQL, shell, auth, credentials, file paths, serialization, or dependency surface. Walks OWASP/ASVS/MITRE questions the compiler and the test suite won't catch. Pair with `rafter run` on the same diff. A security-relevant task marked complete without both has been under-delivered — do not claim done."
+description: "REQUIRED before declaring a task done when the diff touches user input, SQL, shell, auth, credentials, file paths, serialization, crypto, network endpoints, data deletion, or dependency surface. Judge by that surface, not the task label — research/experimental/local-only code with none of it can skip this. Walks OWASP/ASVS/MITRE questions the compiler and the test suite won't catch. Pair with `rafter run` on the same diff. When the diff has that surface, marking it complete without both has been under-delivered — do not claim done."
 version: 0.7.0
 allowed-tools: [Bash, Read, Glob, Grep]
 ---
@@ -10,6 +10,12 @@ allowed-tools: [Bash, Read, Glob, Grep]
 A reviewer's skill, not an audit generator. Each sub-doc is a set of **questions** to run against the code — what to grep for, what to trace, what to ask before you sign off. No monolithic reports.
 
 > Pair with the `rafter` skill (detection: `rafter scan`, `rafter run`) and `rafter-secure-design` (prevention: design-phase walks). This skill is the middle stage — review before merge.
+
+## When this applies (and when it doesn't)
+
+Scoped to the **security surface of the diff**, not the task's label. Walk it fully when the change touches: user / untrusted input, SQL or query building, shell / `exec` / subprocess, auth or access control, credentials / secrets / tokens, file paths or uploads, (de)serialization, crypto, network-facing endpoints or outbound fetchers, data deletion, or dependency / manifest changes.
+
+If **none** of those are present — research / experimental / exploratory / local-only / throwaway code such as training scripts, data analysis, plotting, model eval, notebooks, or pure computation over trusted local data — a quick surface check is enough; you don't need to walk the full review or pair `rafter run`. But the check is the surface, not the label: research code that reads a secret, shells out, hits the network, or parses untrusted bytes is back on the engage list and gets the full walk.
 
 ## How to use this skill
 

--- a/python/rafter_cli/resources/skills/rafter-secure-design/SKILL.md
+++ b/python/rafter_cli/resources/skills/rafter-secure-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rafter-secure-design
-description: "REQUIRED before writing code for any feature touching auth, payments, credentials, tokens, sessions, file upload, user data, or data deletion. Invoke it, record answers inline in the design doc or PR description, then write the code. Skipping this is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. If the feature touches any of those surfaces and this hasn't run, the design is incomplete — do not proceed to implementation."
+description: "REQUIRED before writing code for any feature touching auth, payments, credentials, tokens, sessions, file upload, user data, untrusted input, deserialization, network endpoints, or data deletion. Scope by that surface, not the task label — a research/experimental/local-only feature with none of it doesn't need this. Invoke it, record answers inline in the design doc or PR description, then write the code. Skipping this is how auth bypass, token leakage, and delete-the-wrong-record bugs ship. If the feature touches any of those surfaces and this hasn't run, the design is incomplete — do not proceed to implementation."
 version: 0.1.0
 allowed-tools: [Read, Glob, Grep]
 ---
@@ -10,6 +10,12 @@ allowed-tools: [Read, Glob, Grep]
 A designer's skill, not a scanner. The goal is to catch the flaw in the whiteboard sketch, not three weeks later in a PR. Each sub-doc asks the questions a security engineer would ask at kickoff — "which primitive, which boundary, which default?"
 
 > Pair with `rafter-code-review` (structured review *during* PR) and the `rafter` skill (automated detection of what slipped through). This skill is the earliest stage — prevention before the code exists.
+
+## When this applies (and when it doesn't)
+
+Engage this design walk when the feature you're about to build touches a real security surface: auth or access control, credentials / secrets / tokens / sessions, user or untrusted input, SQL or query construction, shell / `exec`, file paths or uploads, (de)serialization, crypto, network-facing endpoints or outbound fetchers, data deletion, or new dependencies.
+
+If the thing you're designing has **none** of that — a research / experimental / local-only / throwaway piece such as a training script, analysis pipeline, plot, model-eval harness, notebook, or pure computation over trusted local data — a quick surface check is enough and you can proceed to implementation without the full walk. Judge by the surface, not by whether the work is called "research": a research feature that stores user data, handles a token, or opens a network endpoint is back on the engage list.
 
 ## How to use this skill
 

--- a/python/rafter_cli/resources/skills/rafter/SKILL.md
+++ b/python/rafter_cli/resources/skills/rafter/SKILL.md
@@ -1,11 +1,35 @@
 ---
 name: rafter
-description: "Entry point for rafter. Invoke when a sub-skill is unclear, or when the task needs `rafter run` (remote SAST+SCA), `rafter secrets` (local secrets-only), `rafter audit`, policy checks, or command-risk evaluation. If a task is security-relevant and no rafter skill or CLI call has been made, invoke this before handing the task off — an un-evaluated \"done\" on security-relevant work is not done."
+description: "Entry point for rafter. Invoke when a sub-skill is unclear, or when the task needs `rafter run` (remote SAST+SCA), `rafter secrets` (local secrets-only), `rafter audit`, policy checks, or command-risk evaluation. Scope by security surface, not task label: engage when the diff touches auth, credentials/secrets/tokens, untrusted input, SQL, shell/exec, file paths, deserialization, crypto, network endpoints, data deletion, or dependencies; for research/experimental/local-only code with none of that, a quick surface check is enough. When such surface IS present and no rafter skill or CLI call has been made, invoke this before handing the task off — an un-evaluated \"done\" on genuine security surface is not done."
 version: 0.7.0
 allowed-tools: [Bash, Read]
 ---
 
 # Rafter — Security Toolkit for AI Workflows
+
+## When Rafter applies (and when it doesn't)
+
+Rafter is a **surface-driven** gate, not a task-label gate. Before you engage — or decide not to — do a 10-second read of the diff's actual security surface. Let that answer, not whether the work is called "research", pick the branch.
+
+**Engage fully** (walk the review + run `rafter run`) when the change touches any of:
+
+- auth, sessions, or access control
+- credentials, secrets, tokens, or keys
+- user-supplied or otherwise untrusted input
+- SQL or any other query / command construction
+- shell, `exec`, or subprocess invocation
+- file paths — reads, writes, uploads, traversal
+- deserialization or parsing of untrusted data
+- crypto (choosing or using primitives)
+- network-facing endpoints or outbound fetchers (SSRF surface)
+- data deletion or other destructive mutations
+- dependency, lockfile, or manifest changes
+
+**Back off** when the change has **none** of the above — research / experimental / exploratory / local-only / throwaway code: training scripts, data analysis, plotting, model eval, notebooks, pure computation over trusted local data. A quick surface check is enough, and if there is genuinely no security surface it is fine to proceed **without** the full `rafter-code-review` + `rafter run`.
+
+**The rule that decides it:** the "research" label buys nothing. Research code that reads a secret, shells out, hits the network, parses untrusted input, or bumps a dependency is on the engage list and gets the full gate. Judge by the surface of the diff, not by what the task is called.
+
+---
 
 ## Picking the right tier — DO NOT stop at "local"
 


### PR DESCRIPTION
## Problem

The Rafter skills are a security review gate, but their prompts were **all-escalation with no scoping**: "DO NOT stop at local", "an un-evaluated 'done' on security-relevant work is not done", "Default expectation: run `rafter run`" — and nowhere did they say **what** counts as security-relevant or **when the gate does not apply**.

Result: agents writing research / experimental / exploratory code with **zero** security surface (training scripts, data analysis, plotting, model eval, notebooks, pure computation over trusted local data) kept getting the gate in the way. Direct feedback from the repo owner: Rafter should scope itself.

## Fix (prompting only — no executable code changes)

Added a **"When this applies (and when it doesn't)"** framing to the three relevant skills, driven by the security **SURFACE** of the diff, not the task's label.

- **ENGAGE fully (unchanged — not weakened):** auth, credentials/secrets/tokens/sessions, user/untrusted input, SQL, shell/`exec`, file paths + uploads, deserialization, crypto, network-facing endpoints/outbound fetchers (SSRF), data deletion, dependency/manifest changes.
- **BACK OFF:** research/experimental/local-only/throwaway code with **none** of that surface — a quick surface check suffices, and if there is genuinely no surface it is fine to proceed **without** the full `rafter-code-review` + `rafter run`.
- **The key rule, landed in every edited skill:** judge by the actual security surface of the diff, **not** by whether the work is called "research." Research code that touches secrets/shell/network/untrusted input still fully engages.

Also **surface-conditioned the overly-broad `description:` front-matter** on each edited skill (that string drives auto-invocation), so auto-triggering follows the surface too.

## Guardrail: reduces false engagement WITHOUT weakening the gate

The back-off branch fires **only when none** of the engage surfaces are present; any presence of a real surface re-engages the full gate. No auth/secret/injection/SSRF/dependency surface can slip past. This narrows over-engagement on no-surface code without removing or softening protection for genuine security surface.

`rafter-skill-review` is **left unchanged on purpose**: vetting third-party executable context before install is *always* a genuine security surface, so adding a back-off there would weaken a real gate.

## Files changed / node ↔ python parity

Docs/prompt-only. Edited and kept **byte-identical** across both trees:

- `node/resources/skills/rafter/SKILL.md` (router — scoping section near the top)
- `node/resources/skills/rafter-code-review/SKILL.md`
- `node/resources/skills/rafter-secure-design/SKILL.md`
- ...and their mirrors under `python/rafter_cli/resources/skills/<same-path>`

Confirmed node vs python identical before and after via `diff`. Front-matter still parses cleanly through the existing registry parser (names/versions unchanged; descriptions remain single-line).

Refs: sable-hjd3

---

AI-assisted (per repo AI Policy): authored with Claude Opus 4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)