### PR TITLE
fix(agent): scope injected instruction block by surface, not task label

### DIFF
--- a/node/src/commands/agent/components.ts
+++ b/node/src/commands/agent/components.ts
@@ -346,9 +346,11 @@ function codexHooks(): ComponentSpec {
         cfg.hooks.PostToolUse,
         (e) => hookEntryMatchesRafter(e, "rafter hook posttool"),
       );
-      // Bash + apply_patch per Codex hook docs (rf-ovql verification).
+      // Bash + apply_patch per Codex hook docs (rf-ovql verification). PostToolUse
+      // mirrors that write/exec surface (narrowed from `.*` to skip Read/MCP log
+      // noise), matching claude-code posttool scoping (sable-h0ah).
       cfg.hooks.PreToolUse.push({ matcher: "Bash|apply_patch", hooks: [pre] });
-      cfg.hooks.PostToolUse.push({ matcher: ".*", hooks: [post] });
+      cfg.hooks.PostToolUse.push({ matcher: "Bash|apply_patch", hooks: [post] });
       writeJson(hooksPath, cfg);
     },
     uninstall: () => {

--- a/node/src/commands/agent/init.ts
+++ b/node/src/commands/agent/init.ts
@@ -108,7 +108,7 @@ function printDryRunPlan(plan: {
   if (plan.wantCodex) {
     console.log();
     console.log("Codex CLI (--with-codex):");
-    W(path.join(plan.root, ".codex", "hooks.json"), "PreToolUse: Bash|apply_patch, PostToolUse: .*");
+    W(path.join(plan.root, ".codex", "hooks.json"), "PreToolUse: Bash|apply_patch, PostToolUse: Bash|apply_patch");
     for (const s of AGENT_SKILLS) {
       W(path.join(plan.root, ".agents", "skills", s.name, "SKILL.md"));
     }
@@ -383,10 +383,11 @@ function installCodexHooks(root: string): void {
   config.hooks.PreToolUse.push(
     { matcher: "Bash|apply_patch", hooks: [preHook] },
   );
-  // PostToolUse fires for the same tool surface; .* keeps all events in the
-  // audit log without filtering.
+  // PostToolUse mirrors the same write/exec surface (Bash + apply_patch);
+  // narrowed from `.*` so posttool doesn't fire on every Read/MCP call
+  // (log noise + latency), matching the claude-code posttool scoping (sable-h0ah).
   config.hooks.PostToolUse.push(
-    { matcher: ".*", hooks: [postHook] },
+    { matcher: "Bash|apply_patch", hooks: [postHook] },
   );
 
   fs.writeFileSync(hooksPath, JSON.stringify(config, null, 2), "utf-8");

--- a/node/src/commands/agent/instruction-block.ts
+++ b/node/src/commands/agent/instruction-block.ts
@@ -6,18 +6,28 @@ export const RAFTER_MARKER_END = "<!-- rafter:end -->";
 
 /** Rafter security context block for agent instruction files (CLAUDE.md, AGENTS.md, etc.) */
 export const RAFTER_INSTRUCTION_BLOCK = `${RAFTER_MARKER_START}
-## Security: Rafter (required review gate)
+## Security: Rafter (surface-driven review gate)
 
-Rafter is this project's security review gate. A security-relevant task is
-**not complete** until a rafter skill (or \`rafter run\`) has reviewed it.
-Don't mark done, don't hand off, don't open a PR without that pass.
+Rafter is this project's security review gate — driven by the change's **security
+surface**, not by the task label. When a diff touches a real surface (below), it is
+**not complete** until a rafter skill (or \`rafter run\`) has reviewed it: don't mark
+done, don't hand off, don't open a PR without that pass. When it touches **none** of
+that surface — research / experimental / local-only / throwaway code (training
+scripts, data analysis, plotting, model eval, notebooks, pure computation over
+trusted local data) — a quick surface check is enough; proceed without the full
+gate. Judge by the diff's actual surface, not the "research" label: research code
+that reads a secret, shells out, hits the network, parses untrusted input, or bumps
+a dependency still gets the full gate.
 
-**Stop and invoke before continuing:**
+**Stop and invoke when the change touches that surface:**
 
 - Designing auth, payments, credentials, tokens, sessions, file upload,
-  user data, or data deletion → **\`rafter-secure-design\`** (before writing code).
-- Diff touches user input, SQL, shell, auth, credentials, file paths, or
-  serialization → **\`rafter-code-review\`** + \`rafter run\` (before declaring done).
+  user/untrusted data, deserialization, network endpoints, or data deletion
+  → **\`rafter-secure-design\`** (before writing code).
+- Diff touches user/untrusted input, SQL/query building, shell/exec, auth,
+  credentials, file paths, (de)serialization, crypto, network endpoints/outbound
+  fetchers (SSRF), data deletion, or dependencies → **\`rafter-code-review\`** +
+  \`rafter run\` (before declaring done).
 - About to install or forward a third-party SKILL.md, MCP manifest, Cursor
   rule, or agent config → **\`rafter-skill-review\`** (before copying anywhere).
 - Security-adjacent but the angle isn't clear → **\`rafter\`** (the router skill,

--- a/node/tests/platform-integration.test.ts
+++ b/node/tests/platform-integration.test.ts
@@ -1367,12 +1367,13 @@ describe("Platform Integration — MCP Installs via CLI", () => {
 
       // Codex matchers per developers.openai.com/codex/hooks (rf-ovql verified):
       // PreToolUse intercepts Bash + apply_patch (file edits via apply_patch).
-      // PostToolUse is catch-all so all completed events land in audit.jsonl.
+      // PostToolUse mirrors that write/exec surface (narrowed from `.*` to skip
+      // Read/MCP log noise), matching claude-code posttool scoping (sable-h0ah).
       const preMatchers = config.hooks.PreToolUse.map((e: any) => e.matcher);
       expect(preMatchers).toContain("Bash|apply_patch");
 
       const postMatchers = config.hooks.PostToolUse.map((e: any) => e.matcher);
-      expect(postMatchers).toContain(".*");
+      expect(postMatchers).toContain("Bash|apply_patch");
     });
 
     it("should deduplicate hooks on repeated installs", () => {

--- a/python/rafter_cli/commands/agent_components.py
+++ b/python/rafter_cli/commands/agent_components.py
@@ -31,18 +31,28 @@ RAFTER_MARKER_START = "<!-- rafter:start -->"
 RAFTER_MARKER_END = "<!-- rafter:end -->"
 
 RAFTER_INSTRUCTION_BLOCK = f"""{RAFTER_MARKER_START}
-## Security: Rafter (required review gate)
+## Security: Rafter (surface-driven review gate)
 
-Rafter is this project's security review gate. A security-relevant task is
-**not complete** until a rafter skill (or `rafter run`) has reviewed it.
-Don't mark done, don't hand off, don't open a PR without that pass.
+Rafter is this project's security review gate — driven by the change's **security
+surface**, not by the task label. When a diff touches a real surface (below), it is
+**not complete** until a rafter skill (or `rafter run`) has reviewed it: don't mark
+done, don't hand off, don't open a PR without that pass. When it touches **none** of
+that surface — research / experimental / local-only / throwaway code (training
+scripts, data analysis, plotting, model eval, notebooks, pure computation over
+trusted local data) — a quick surface check is enough; proceed without the full
+gate. Judge by the diff's actual surface, not the "research" label: research code
+that reads a secret, shells out, hits the network, parses untrusted input, or bumps
+a dependency still gets the full gate.
 
-**Stop and invoke before continuing:**
+**Stop and invoke when the change touches that surface:**
 
 - Designing auth, payments, credentials, tokens, sessions, file upload,
-  user data, or data deletion → **`rafter-secure-design`** (before writing code).
-- Diff touches user input, SQL, shell, auth, credentials, file paths, or
-  serialization → **`rafter-code-review`** + `rafter run` (before declaring done).
+  user/untrusted data, deserialization, network endpoints, or data deletion
+  → **`rafter-secure-design`** (before writing code).
+- Diff touches user/untrusted input, SQL/query building, shell/exec, auth,
+  credentials, file paths, (de)serialization, crypto, network endpoints/outbound
+  fetchers (SSRF), data deletion, or dependencies → **`rafter-code-review`** +
+  `rafter run` (before declaring done).
 - About to install or forward a third-party SKILL.md, MCP manifest, Cursor
   rule, or agent config → **`rafter-skill-review`** (before copying anywhere).
 - Security-adjacent but the angle isn't clear → **`rafter`** (the router skill,
@@ -353,9 +363,11 @@ def _codex_hooks() -> ComponentSpec:
         post = {"type": "command", "command": "rafter hook posttool"}
         h["PreToolUse"] = _filter_hooks(h["PreToolUse"], lambda e: _hook_entry_has_rafter(e, "rafter hook pretool"))
         h["PostToolUse"] = _filter_hooks(h["PostToolUse"], lambda e: _hook_entry_has_rafter(e, "rafter hook posttool"))
-        # Bash + apply_patch per Codex hook docs (rf-ovql verification).
+        # Bash + apply_patch per Codex hook docs (rf-ovql verification). PostToolUse
+        # mirrors that write/exec surface (narrowed from ".*" to skip Read/MCP log
+        # noise), matching claude-code posttool scoping (sable-h0ah).
         h["PreToolUse"].append({"matcher": "Bash|apply_patch", "hooks": [pre]})
-        h["PostToolUse"].append({"matcher": ".*", "hooks": [post]})
+        h["PostToolUse"].append({"matcher": "Bash|apply_patch", "hooks": [post]})
         _write_json(hooks_path, cfg)
 
     def uninstall() -> None:


### PR DESCRIPTION
## Root cause — instruction-level hijacking

`rafter agent init` injects `RAFTER_INSTRUCTION_BLOCK` into agents' instruction files — including `~/.codex/AGENTS.md`, which Codex reads as its **global** instructions file. The block was a blanket gate:

> A security-relevant task is **not complete** until a rafter skill (or `rafter run`) has reviewed it. … **Stop and invoke before continuing.**

With no scoping, every Codex session was effectively ordered to treat its task as rafter-gated. Agents went off to read rafter's `SKILL.md` instead of building the requested code — which was frequently no-surface research work (training scripts, data analysis, plotting, model eval). That's instruction-level hijacking of unrelated work.

## The fix — surface-based scoping (consistent with #195)

Sibling PR **#195** already fixed the analogous problem in the *skill* prompts (`resources/skills/*/SKILL.md`) by making them surface-driven. This PR applies the **same** scoping and framing to the injected instruction block, so the block and the skills tell one story:

- **Engage the gate** when the change touches a real security surface: auth/sessions/access-control, credentials/secrets/tokens, user/untrusted input, SQL/query construction, shell/exec/subprocess, file paths, (de)serialization, crypto, network endpoints/outbound fetchers (SSRF), data deletion, dependency/manifest changes.
- **Back off** when **none** of those are present — research / experimental / local-only / throwaway code (training scripts, data analysis, plotting, model eval, notebooks, pure computation over trusted local data): a quick surface check is enough; proceed without the full `rafter-code-review` + `rafter run`.
- **Decisive rule:** judge by the diff's actual security surface, not the "research" label. Research code that reads a secret, shells out, hits the network, parses untrusted input, or bumps a dependency still gets the full gate.

The block stays tight (markers and CLI list unchanged); only the intro framing and the two routing bullets changed.

## Guardrail — reduces false engagement without weakening the gate

This change is designed to cut false engagement on no-surface code, **not** to soften protection for any listed surface. The routing bullets were in fact **expanded** (added crypto, network/SSRF, data deletion, dependencies), so surface coverage strengthens rather than weakens.

## Parity

`node/src/commands/agent/instruction-block.ts` and `python/rafter_cli/commands/agent_components.py` `RAFTER_INSTRUCTION_BLOCK` were byte-identical before this change and remain byte-identical after (verified by extracting and diffing the rendered block bodies).

## Secondary — Codex PostToolUse matcher (sable-h0ah)

Narrows the Codex `.codex/hooks.json` PostToolUse matcher from `.*` to `Bash|apply_patch`, so posttool stops firing on every Read/MCP call (log noise + latency). This mirrors Codex's own PreToolUse surface and the already-narrowed claude-code posttool scoping (`Bash|Write|Edit|MultiEdit`). `Bash|apply_patch` is used (rather than adding `Write|Edit`, which aren't Codex tool names) to stay consistent with Codex's documented tool surface. Applied in `init.ts`, `components.ts`, and the python mirror; the one test asserting the old value is updated. Pretool (the actual command gate) is unchanged, so audit coverage of scannable output is preserved.

## Testing

Verified by reasoning (shared box under heavy load — load avg ~18 — so the full node suite wasn't run here; CI will run it):
- The instruction block is a template string; the edit preserves the `rafter:start`/`rafter:end` markers, which are the only thing existing tests assert. `python -m py_compile` passes on the edited python file, and the rendered node body was diffed byte-for-byte against the rendered python body.
- The Codex matcher change is a mechanical string swap across all call sites; `platform-integration.test.ts` (the only test asserting the old `.*` value) was updated, and grep confirms no other node/python test asserts the Codex posttool matcher.

AI-assisted (Claude Opus 4.8) per the repo AI Policy.

Refs: sable-m9n6, sable-h0ah