### PR TITLE
fix(agent): correct Codex hooks dry-run plan string (PostToolUse parity with #196)

### DIFF
--- a/python/rafter_cli/commands/agent.py
+++ b/python/rafter_cli/commands/agent.py
@@ -332,7 +332,7 @@ def _print_dry_run_plan(
     if want_codex:
         print()
         print("Codex CLI (--with-codex):")
-        W(root / ".codex" / "hooks.json", "PreToolUse: Bash|apply_patch, PostToolUse: .*")
+        W(root / ".codex" / "hooks.json", "PreToolUse: Bash|apply_patch, PostToolUse: Bash|apply_patch")
         for s in _AGENT_SKILLS:
             W(root / ".agents" / "skills" / s["name"] / "SKILL.md")
         agents_md = root / ".codex" / "AGENTS.md" if scope == "user" else root / "AGENTS.md"


### PR DESCRIPTION
Tiny follow-up to #196. Python's `agent init` dry-run preview still printed `PostToolUse: .*` for `.codex/hooks.json`, but the actual installed matcher was already narrowed to `Bash|apply_patch` in that same PR (and Node's plan string was updated). This corrects the stale Python plan string only — no behavior change.

AI-assisted per the repo AI Policy.