### PR TITLE
fix(skills): restore rafter SKILL.md line budget broken by #195

### DIFF
--- a/node/resources/skills/rafter/SKILL.md
+++ b/node/resources/skills/rafter/SKILL.md
@@ -9,23 +9,11 @@ allowed-tools: [Bash, Read]
 
 ## When Rafter applies (and when it doesn't)
 
-Rafter is a **surface-driven** gate, not a task-label gate. Before you engage — or decide not to — do a 10-second read of the diff's actual security surface. Let that answer, not whether the work is called "research", pick the branch.
+Rafter is a **surface-driven** gate, not a task-label gate. Read the diff's actual security surface first; let that — not whether the work is called "research" — pick the branch.
 
-**Engage fully** (walk the review + run `rafter run`) when the change touches any of:
+**Engage fully** (walk the review + run `rafter run`) when the change touches any of: auth / sessions / access control · credentials, secrets, tokens, keys · user-supplied or otherwise untrusted input · SQL or any other query / command construction · shell, `exec`, or subprocess invocation · file paths (read, write, upload, traversal) · deserialization or parsing of untrusted data · crypto primitives · network-facing endpoints or outbound fetchers (SSRF surface) · data deletion or other destructive mutations · dependency, lockfile, or manifest changes.
 
-- auth, sessions, or access control
-- credentials, secrets, tokens, or keys
-- user-supplied or otherwise untrusted input
-- SQL or any other query / command construction
-- shell, `exec`, or subprocess invocation
-- file paths — reads, writes, uploads, traversal
-- deserialization or parsing of untrusted data
-- crypto (choosing or using primitives)
-- network-facing endpoints or outbound fetchers (SSRF surface)
-- data deletion or other destructive mutations
-- dependency, lockfile, or manifest changes
-
-**Back off** when the change has **none** of the above — research / experimental / exploratory / local-only / throwaway code: training scripts, data analysis, plotting, model eval, notebooks, pure computation over trusted local data. A quick surface check is enough, and if there is genuinely no security surface it is fine to proceed **without** the full `rafter-code-review` + `rafter run`.
+**Back off** when the change touches **none** of those — research / experimental / exploratory / local-only / throwaway code: training scripts, data analysis, plotting, model eval, notebooks, pure computation over trusted local data. A quick surface check is enough; with no security surface, proceed **without** the full `rafter-code-review` + `rafter run`.
 
 **The rule that decides it:** the "research" label buys nothing. Research code that reads a secret, shells out, hits the network, parses untrusted input, or bumps a dependency is on the engage list and gets the full gate. Judge by the surface of the diff, not by what the task is called.
 
@@ -33,15 +21,13 @@ Rafter is a **surface-driven** gate, not a task-label gate. Before you engage �
 
 ## Picking the right tier — DO NOT stop at "local"
 
-Rafter ships three tiers. **They are not interchangeable.** The local tier is narrow; skipping remote analysis is the #1 way agents under-use rafter.
+Three tiers, **not interchangeable**. The local tier is narrow; skipping remote analysis is the #1 way agents under-use rafter.
 
-1. **Local (`rafter secrets`)** — secrets only. Regex + betterleaks for hardcoded API keys, tokens, private keys. Fast, offline, no key. **This is NOT a code security scan.** It will not find SQL injection, SSRF, auth bugs, insecure deserialization, logic flaws, or dependency vulns. If an agent's entire rafter interaction was `rafter secrets .` and it exited clean, the agent has done secret-hygiene only — not security review.
-2. **Remote fast (`rafter run`, default mode)** — SAST + SCA + secrets via the Rafter API. This is the real code-analysis pass: dataflow, taint, known-vulnerable dependencies, crypto misuse, injection sinks. Needs `RAFTER_API_KEY`.
-3. **Remote plus (`rafter run --mode plus`)** — agentic deep-dive: LLM-guided investigation of suspicious patterns the rules engine flags. Slower, higher signal. Code is deleted server-side after the run.
+1. **`rafter secrets`** — hardcoded credentials only (regex + betterleaks). Fast, offline, no key. **NOT a code security scan** — it finds no SQL injection, SSRF, auth bugs, insecure deserialization, logic flaws, or dependency vulns. A clean `rafter secrets .` is secret-hygiene, not security review.
+2. **`rafter run`** (default mode) — the real code-analysis pass: SAST + SCA + secrets (dataflow, taint, known-vulnerable deps, crypto misuse, injection sinks). Needs `RAFTER_API_KEY`.
+3. **`rafter run --mode plus`** — agentic deep-dive: LLM-guided investigation of what the rules engine flags. Slower, higher signal; code is deleted server-side after the run.
 
-**Default expectation for a security-relevant task**: run `rafter run`. Fall back to `rafter secrets` only when no API key is available or you specifically need offline secret-hygiene. If you've only run the local scanner, say so explicitly — don't claim the code was "scanned" without qualification.
-
-Stable exit codes, stable JSON shapes, deterministic findings. Safe to chain in CI and in agent loops.
+**Default for a security-relevant task: `rafter run`.** Fall back to `rafter secrets` only when no API key is available — and say so explicitly; don't claim the code was "scanned" without qualification. Deterministic findings, stable exit codes and JSON shapes — safe to chain in CI and in agent loops.
 
 ---
 

--- a/node/tests/brief.test.ts
+++ b/node/tests/brief.test.ts
@@ -145,15 +145,21 @@ describe("brief command — setup guides", () => {
 });
 
 describe("rafter skill — CYOA hierarchy", () => {
-  it("top-level SKILL.md parses and stays under 120 lines", () => {
+  it("top-level SKILL.md parses and stays under 130 lines", () => {
     const skillPath = path.join(RAFTER_SKILL_DIR, "SKILL.md");
     const raw = readFileSync(skillPath, "utf-8");
     expect(raw.startsWith("---")).toBe(true);
     // frontmatter closes (two `---` markers)
     expect(raw.match(/^---$/gm)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    // 130-line budget, matching the Python suite. The limits had drifted apart:
+    // Python was bumped 120 -> 130 for the scanner-scope section, Node never was.
+    // The surface-scoping section ("when Rafter applies") has to live in the
+    // router itself — it decides whether the skill is entered at all — so it
+    // can't be pushed into a sub-doc. Budget is tight on purpose: trim before
+    // you add.
     const lines = raw.split("\n").length;
-    expect(lines, `SKILL.md is ${lines} lines; keep under 120`).toBeLessThan(
-      120,
+    expect(lines, `SKILL.md is ${lines} lines; keep under 130`).toBeLessThan(
+      130,
     );
   });
 

--- a/python/rafter_cli/resources/skills/rafter/SKILL.md
+++ b/python/rafter_cli/resources/skills/rafter/SKILL.md
@@ -9,23 +9,11 @@ allowed-tools: [Bash, Read]
 
 ## When Rafter applies (and when it doesn't)
 
-Rafter is a **surface-driven** gate, not a task-label gate. Before you engage — or decide not to — do a 10-second read of the diff's actual security surface. Let that answer, not whether the work is called "research", pick the branch.
+Rafter is a **surface-driven** gate, not a task-label gate. Read the diff's actual security surface first; let that — not whether the work is called "research" — pick the branch.
 
-**Engage fully** (walk the review + run `rafter run`) when the change touches any of:
+**Engage fully** (walk the review + run `rafter run`) when the change touches any of: auth / sessions / access control · credentials, secrets, tokens, keys · user-supplied or otherwise untrusted input · SQL or any other query / command construction · shell, `exec`, or subprocess invocation · file paths (read, write, upload, traversal) · deserialization or parsing of untrusted data · crypto primitives · network-facing endpoints or outbound fetchers (SSRF surface) · data deletion or other destructive mutations · dependency, lockfile, or manifest changes.
 
-- auth, sessions, or access control
-- credentials, secrets, tokens, or keys
-- user-supplied or otherwise untrusted input
-- SQL or any other query / command construction
-- shell, `exec`, or subprocess invocation
-- file paths — reads, writes, uploads, traversal
-- deserialization or parsing of untrusted data
-- crypto (choosing or using primitives)
-- network-facing endpoints or outbound fetchers (SSRF surface)
-- data deletion or other destructive mutations
-- dependency, lockfile, or manifest changes
-
-**Back off** when the change has **none** of the above — research / experimental / exploratory / local-only / throwaway code: training scripts, data analysis, plotting, model eval, notebooks, pure computation over trusted local data. A quick surface check is enough, and if there is genuinely no security surface it is fine to proceed **without** the full `rafter-code-review` + `rafter run`.
+**Back off** when the change touches **none** of those — research / experimental / exploratory / local-only / throwaway code: training scripts, data analysis, plotting, model eval, notebooks, pure computation over trusted local data. A quick surface check is enough; with no security surface, proceed **without** the full `rafter-code-review` + `rafter run`.
 
 **The rule that decides it:** the "research" label buys nothing. Research code that reads a secret, shells out, hits the network, parses untrusted input, or bumps a dependency is on the engage list and gets the full gate. Judge by the surface of the diff, not by what the task is called.
 
@@ -33,15 +21,13 @@ Rafter is a **surface-driven** gate, not a task-label gate. Before you engage �
 
 ## Picking the right tier — DO NOT stop at "local"
 
-Rafter ships three tiers. **They are not interchangeable.** The local tier is narrow; skipping remote analysis is the #1 way agents under-use rafter.
+Three tiers, **not interchangeable**. The local tier is narrow; skipping remote analysis is the #1 way agents under-use rafter.
 
-1. **Local (`rafter secrets`)** — secrets only. Regex + betterleaks for hardcoded API keys, tokens, private keys. Fast, offline, no key. **This is NOT a code security scan.** It will not find SQL injection, SSRF, auth bugs, insecure deserialization, logic flaws, or dependency vulns. If an agent's entire rafter interaction was `rafter secrets .` and it exited clean, the agent has done secret-hygiene only — not security review.
-2. **Remote fast (`rafter run`, default mode)** — SAST + SCA + secrets via the Rafter API. This is the real code-analysis pass: dataflow, taint, known-vulnerable dependencies, crypto misuse, injection sinks. Needs `RAFTER_API_KEY`.
-3. **Remote plus (`rafter run --mode plus`)** — agentic deep-dive: LLM-guided investigation of suspicious patterns the rules engine flags. Slower, higher signal. Code is deleted server-side after the run.
+1. **`rafter secrets`** — hardcoded credentials only (regex + betterleaks). Fast, offline, no key. **NOT a code security scan** — it finds no SQL injection, SSRF, auth bugs, insecure deserialization, logic flaws, or dependency vulns. A clean `rafter secrets .` is secret-hygiene, not security review.
+2. **`rafter run`** (default mode) — the real code-analysis pass: SAST + SCA + secrets (dataflow, taint, known-vulnerable deps, crypto misuse, injection sinks). Needs `RAFTER_API_KEY`.
+3. **`rafter run --mode plus`** — agentic deep-dive: LLM-guided investigation of what the rules engine flags. Slower, higher signal; code is deleted server-side after the run.
 
-**Default expectation for a security-relevant task**: run `rafter run`. Fall back to `rafter secrets` only when no API key is available or you specifically need offline secret-hygiene. If you've only run the local scanner, say so explicitly — don't claim the code was "scanned" without qualification.
-
-Stable exit codes, stable JSON shapes, deterministic findings. Safe to chain in CI and in agent loops.
+**Default for a security-relevant task: `rafter run`.** Fall back to `rafter secrets` only when no API key is available — and say so explicitly; don't claim the code was "scanned" without qualification. Deterministic findings, stable exit codes and JSON shapes — safe to chain in CI and in agent loops.
 
 ---
 


### PR DESCRIPTION
## The bug
#195 added the surface-scoping section and grew the rafter router `SKILL.md` **118 → 142 lines**, blowing **both** budgets (node `<120`, python `<130`). The repo has no CI, so those two tests have been **red on main** since #195 merged — caught only when a full python run was done for #198.

## Fix
- **Condense `SKILL.md` 142 → 128 lines.** The 11-bullet engage list becomes a compact inline list (**every surface kept**) and the tier section is tightened against duplication with branch (a)/Fast Path. No scoping content dropped — the rule has to stay in the router, since it decides whether the skill is entered *at all* and can't be pushed into a sub-doc.
- **Align node's budget 120 → 130** to match python's. The limits had drifted apart: python was bumped 120→130 for the scanner-scope section, node never was — a latent dual-impl inconsistency.

## Verification
- node `brief.test.ts`: **28 passed**
- python `test_brief.py`: **35 passed**
- node/python `SKILL.md` **byte-identical**

AI-assisted per the repo AI Policy.