### PR TITLE
feat(scan): add SendGrid API key secret pattern (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SendGrid API Key secret pattern** (#24). New `SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}` detection pattern (severity `critical`) added to the built-in regex scanner in both Node and Python, with tests in each suite. Thanks to @perez-eduardo for the contribution.
 ## [0.9.0] - 2026-07-08
 
 ### Added

--- a/node/src/scanners/secret-patterns.ts
+++ b/node/src/scanners/secret-patterns.ts
@@ -175,6 +175,13 @@ export const DEFAULT_SECRET_PATTERNS: Pattern[] = [
     regex: "[a-f0-9]{32}-us\\d{1,2}",
     severity: "critical",
     description: "Mailchimp API Key detected"
+  },
+  // SendGrid
+  {
+    name: "SendGrid API Key",
+    regex: "SG\\.[a-zA-Z0-9_-]{22}\\.[a-zA-Z0-9_-]{43}",
+    severity: "critical",
+    description: "SendGrid API Key detected"
   }
 ];
 

--- a/node/tests/secret-patterns.test.ts
+++ b/node/tests/secret-patterns.test.ts
@@ -332,6 +332,20 @@ describe("Secret patterns — coverage matrix", () => {
     });
   });
 
+  describe("SendGrid API Key", () => {
+    it("detects SG. token", () => {
+      const token = "SG." + "A".repeat(22) + "." + "A".repeat(43);
+      const r = scanString(token + "\n");
+      expect(r.matches.some((m) => m.pattern.name.includes("SendGrid"))).toBe(true);
+    });
+
+    it("does not match an SG. token with wrong segment lengths", () => {
+      const token = "SG." + "A".repeat(10) + "." + "A".repeat(20);
+      const r = scanString(token + "\n");
+      expect(r.matches.some((m) => m.pattern.name.includes("SendGrid"))).toBe(false);
+    });
+  });
+
   // ── Helper function coverage ──────────────────────────────────────
 
   describe("getPatternsBySeverity", () => {

--- a/python/rafter_cli/scanners/secret_patterns.py
+++ b/python/rafter_cli/scanners/secret_patterns.py
@@ -161,7 +161,14 @@ DEFAULT_SECRET_PATTERNS: list[Pattern] = [
         regex=r"[a-f0-9]{32}-us\d{1,2}",
         severity="critical",
         description="Mailchimp API Key detected",
-    )
+    ),
+    # SendGrid
+    Pattern(
+        name="SendGrid API Key",
+        regex=r"SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}",
+        severity="critical",
+        description="SendGrid API Key detected",
+    ),
 ]
 
 

--- a/python/tests/test_regex_scanner.py
+++ b/python/tests/test_regex_scanner.py
@@ -89,6 +89,15 @@ def test_scan_text_ignores_bare_hex_without_datacenter_suffix(scanner):
     token = "a" * 32
     matches = scanner.scan_text(token)
     assert not any(m.pattern.name == "Mailchimp API Key" for m in matches)
+def test_scan_text_detects_sendgrid_key(scanner):
+    token = "SG." + ("A" * 22) + "." + ("A" * 43)
+    matches = scanner.scan_text(token)
+    assert any(m.pattern.name == "SendGrid API Key" for m in matches)
+
+def test_scan_text_ignores_short_sendgrid_like_string(scanner):
+    token = "SG." + ("A" * 10) + "." + ("A" * 20)
+    matches = scanner.scan_text(token)
+    assert not any(m.pattern.name == "SendGrid API Key" for m in matches)
 
 def test_has_secrets(scanner):
     assert scanner.has_secrets("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")


### PR DESCRIPTION
## Summary

Adds a SendGrid API key detection pattern to the built-in regex scanner in both the Node and Python implementations, closing #24. SendGrid keys (the `SG.` prefixed format) were not detected by the scanner; they now match at `critical` severity, consistent with the other provider API keys.

Pattern (identical in both implementations):
`SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}`

Mirrors the recently merged Mailchimp (#190/#194) and DigitalOcean (#189) provider-key patterns in placement, naming, severity, and test shape.

## Test plan

- Added a positive and a negative test in each suite (`node/tests/secret-patterns.test.ts`, `python/tests/test_regex_scanner.py`), with fake tokens built at runtime. The negative test follows the `some(...).toBe(false)` style established in #194.
- `cd node && pnpm test`: secret-patterns suite green (58 tests).
- `cd python && pytest`: regex scanner suite green (16 tests).
- Manual: `rafter secrets` on a file with a fake SendGrid key now reports a `SendGrid API Key` (`critical`) match in both implementations, where it previously reported none. A fake DigitalOcean key still detects (control).

## Spec update

No CLI behavior change, so no `shared-docs/CLI_SPEC.md` update needed. This adds a detection pattern only.

## Checklist

- [x] Implemented in both Node and Python with identical regex
- [x] Tests pass in both suites
- [x] Versions in `node/package.json` and `python/pyproject.toml` unchanged
- [x] No spec change required (no CLI behavior change)
- [x] No real secrets committed (test values are fake, built at runtime)

---

Written with Claude Code.
