### PR TITLE
Add npm script

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,10 @@
     "build": "tsc -p tsconfig.json",
     "prepublishOnly": "pnpm run build",
     "postinstall": "echo '\n  Run: rafter agent init --all\n  Sets up secret scanning for Claude Code, Codex CLI, and git hooks.\n'",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "clean": "rm -rf dist/ node_modules/.cache/"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
### Summary
This PR adds helpful utility scripts to `node/package.json` to streamline the local development workflow, resolving the requested issue. 

Specifically, this adds:
* `test:watch`: Runs tests interactively in watch mode (using `vitest`).
* `test:coverage`: Runs unit tests with a coverage report.
* `clean`: Easily wipes out builds and cached files (`dist/`, `node_modules/.cache/`).

To align with standard monorepo workflows, the main `"test"` script has been updated to run a single execution (`vitest run`), while `"test:watch"` now handles the continuous interactive testing loop.

### Test plan
Verify that the new scripts execute correctly locally using your package manager:
* Run `pnpm test` (Runs tests once and exits).
* Run `pnpm test:watch` (Launches interactive watch mode).
* Run `pnpm test:coverage` (Generates test coverage details).
* Run `pnpm clean` (Wipes the target build and cache directories).

### Spec update
N/A — Internal package development scripts only.

### Checklist
- [x] Both Node and Python implementations updated -> (N/A, Node scripts only)
- [x] Tests pass in both (`pnpm test` + `pytest`)
- [x] Versions match in node/package.json and python/pyproject.toml -> N/A
- [x] shared-docs/CLI_SPEC.md updated (if CLI behavior changed) -> N/A
- [x] No secrets, credentials, or API keys in the diff