### PR TITLE
feat(scan): opt-in approval gate for paid Plus scans (sable-9ddf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in approval gate for paid Plus scans** (sable-9ddf). New `scan.plus_requires_approval` config flag (`.rafter.yml` or global `~/.rafter/config.json`), **off by default** so existing behavior is unchanged. When enabled, `rafter run --mode plus` (and the `rafter scan` / `rafter scan remote` aliases) requires explicit confirmation before spending credits: it prompts `[y/N]` on a TTY and refuses in a non-interactive/agent context with new exit code `5` unless `--yes` (`-y`) or `RAFTER_CONFIRM=1` is passed. Fast scans are never gated. Precedence is additive (OR) — a project `.rafter.yml` can turn the gate *on* but can never turn *off* a gate the machine owner enabled globally, so a hostile repo can't silently re-open the credit-burn hole. The rafter agent skill and injected instruction block now tell agents Plus is a paid tier and to ask the user before running it. Node + Python, tests in both suites. Addresses an external user whose agent auto-ran a Plus scan and consumed credits without asking.
 - **SendGrid API Key secret pattern** (#24). New `SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}` detection pattern (severity `critical`) added to the built-in regex scanner in both Node and Python, with tests in each suite. Thanks to @perez-eduardo for the contribution.
 
 ## [0.9.0] - 2026-07-08

--- a/node/resources/skills/rafter/SKILL.md
+++ b/node/resources/skills/rafter/SKILL.md
@@ -25,7 +25,7 @@ Three tiers, **not interchangeable**. The local tier is narrow; skipping remote 
 
 1. **`rafter secrets`** — hardcoded credentials only (regex + betterleaks). Fast, offline, no key. **NOT a code security scan** — it finds no SQL injection, SSRF, auth bugs, insecure deserialization, logic flaws, or dependency vulns. A clean `rafter secrets .` is secret-hygiene, not security review.
 2. **`rafter run`** (default mode) — the real code-analysis pass: SAST + SCA + secrets (dataflow, taint, known-vulnerable deps, crypto misuse, injection sinks). Needs `RAFTER_API_KEY`.
-3. **`rafter run --mode plus`** — agentic deep-dive: LLM-guided investigation of what the rules engine flags. Slower, higher signal; code is deleted server-side after the run.
+3. **`rafter run --mode plus`** — agentic deep-dive: LLM-guided investigation of what the rules engine flags. Slower, higher signal; code is deleted server-side after the run. **PAID tier — consumes the user's credits; ask before running it.** If `scan.plus_requires_approval` is set, Plus refuses without `--yes` / `RAFTER_CONFIRM=1`.
 
 **Default for a security-relevant task: `rafter run`.** Fall back to `rafter secrets` only when no API key is available — and say so explicitly; don't claim the code was "scanned" without qualification. Deterministic findings, stable exit codes and JSON shapes — safe to chain in CI and in agent loops.
 

--- a/node/src/commands/agent/instruction-block.ts
+++ b/node/src/commands/agent/instruction-block.ts
@@ -38,7 +38,9 @@ a dependency still gets the full gate.
 - \`rafter run\` — remote SAST + SCA + secrets (real code analysis, needs \`RAFTER_API_KEY\`)
 - \`rafter secrets .\` — local secrets only (offline; NOT a code-security scan)
 - \`rafter run --mode plus\` — everything in default (\`--mode fast\`) plus
-  powerful agentic deep-dives (needs \`RAFTER_API_KEY\`)
+  powerful agentic deep-dives (needs \`RAFTER_API_KEY\`). **Plus is a PAID tier
+  and consumes the user's credits — ask the user before running it.** Enforced
+  when \`scan.plus_requires_approval\` is set (then pass \`--yes\` to confirm).
 ${RAFTER_MARKER_END}`;
 
 /**

--- a/node/src/commands/backend/run.ts
+++ b/node/src/commands/backend/run.ts
@@ -7,8 +7,12 @@ import {
   resolveKey,
   EXIT_GENERAL_ERROR,
   EXIT_QUOTA_EXHAUSTED,
+  EXIT_CONFIRMATION_REQUIRED,
   handle403
 } from "../../utils/api.js";
+import { ConfigManager } from "../../core/config-manager.js";
+import { loadPolicy } from "../../core/policy-loader.js";
+import { askYesNo } from "../../utils/prompt.js";
 import { handleScanStatus } from "./scan-status.js";
 
 export interface RunOpts {
@@ -22,12 +26,72 @@ export interface RunOpts {
   githubToken?: string;
   provider?: string;
   repoUrl?: string;
+  yes?: boolean;
+}
+
+/**
+ * sable-9ddf — is the Plus-scan approval gate enabled?
+ *
+ * OR semantics across the machine-owner's global config and the project's
+ * `.rafter.yml`: if EITHER opts in, approval is required. A project policy can
+ * turn the gate ON but can NEVER turn it OFF — a hostile repo must not be able
+ * to silently re-open the credit-burn hole a user closed globally.
+ *
+ * Fails open (returns false) if config/policy can't be read, consistent with
+ * the OFF-by-default product behavior and the codebase's config-load fallback.
+ */
+export function plusApprovalGateEnabled(): boolean {
+  let globalFlag = false;
+  try {
+    globalFlag = new ConfigManager().load().agent?.scan?.plusRequiresApproval === true;
+  } catch { /* fail open */ }
+  let policyFlag = false;
+  try {
+    policyFlag = loadPolicy()?.scan?.plusRequiresApproval === true;
+  } catch { /* fail open */ }
+  return globalFlag || policyFlag;
+}
+
+/**
+ * Gate a paid Plus scan behind explicit confirmation when the switch is on.
+ * Returns normally if the scan may proceed; calls process.exit otherwise.
+ * No-op for non-plus modes and when the gate is disabled (the default).
+ */
+export async function confirmPlusScan(opts: RunOpts): Promise<void> {
+  if ((opts.mode ?? "fast") !== "plus") return;
+  if (!plusApprovalGateEnabled()) return;
+
+  const envConfirm = process.env.RAFTER_CONFIRM;
+  const confirmed = opts.yes === true || envConfirm === "1" || envConfirm === "true";
+  if (confirmed) return;
+
+  if (process.stdin.isTTY) {
+    const ok = await askYesNo(
+      "Plus is a PAID scan tier and will consume your credits. Proceed?",
+      false
+    );
+    if (ok) return;
+    console.error("Plus scan cancelled.");
+    process.exit(EXIT_CONFIRMATION_REQUIRED);
+  }
+
+  console.error(
+    "Refusing to run a paid Plus scan: approval is required " +
+      "(scan.plus_requires_approval is enabled).\n" +
+      "Re-run with --yes (or set RAFTER_CONFIRM=1) to confirm the credit spend, " +
+      "or use the free --mode fast scan."
+  );
+  process.exit(EXIT_CONFIRMATION_REQUIRED);
 }
 
 /**
  * Shared handler for the remote backend scan (used by both `rafter run` and `rafter scan` / `rafter scan remote`).
  */
 export async function runRemoteScan(opts: RunOpts): Promise<void> {
+  // sable-9ddf — gate paid Plus scans before doing any work (key resolution,
+  // repo detection, or the billable API call).
+  await confirmPlusScan(opts);
+
   const key = resolveKey(opts.apiKey);
   const ghToken = opts.githubToken || process.env.RAFTER_GITHUB_TOKEN;
   let repo: string | undefined, branch: string | undefined;
@@ -134,6 +198,7 @@ function addRunOptions(cmd: Command): Command {
     .option("--provider <provider>", "git provider: gitlab | gitea | bitbucket (default: auto-detected; github requires nothing)")
     .option("--repo-url <url>", "full https clone URL for non-github remotes (default: auto-detected)")
     .option("--skip-interactive", "do not wait for scan to complete")
+    .option("-y, --yes", "confirm a paid Plus scan without prompting (when scan.plus_requires_approval is on)")
     .option("--quiet", "suppress status messages");
 }
 

--- a/node/src/commands/scan/index.ts
+++ b/node/src/commands/scan/index.ts
@@ -28,6 +28,7 @@ export function createScanGroupCommand(): Command {
     .option("--provider <provider>", "git provider: gitlab | gitea | bitbucket (default: auto-detected; github requires nothing)")
     .option("--repo-url <url>", "full https clone URL for non-github remotes (default: auto-detected)")
     .option("--skip-interactive", "do not wait for scan to complete")
+    .option("-y, --yes", "confirm a paid Plus scan without prompting (when scan.plus_requires_approval is on)")
     .option("--quiet", "suppress status messages")
     .action(async (opts) => {
       await runRemoteScan(opts);
@@ -46,6 +47,7 @@ export function createScanGroupCommand(): Command {
     .option("--provider <provider>", "git provider: gitlab | gitea | bitbucket (default: auto-detected; github requires nothing)")
     .option("--repo-url <url>", "full https clone URL for non-github remotes (default: auto-detected)")
     .option("--skip-interactive", "do not wait for scan to complete")
+    .option("-y, --yes", "confirm a paid Plus scan without prompting (when scan.plus_requires_approval is on)")
     .option("--quiet", "suppress status messages");
 
   scanGroup.addCommand(localCmd, { hidden: true });

--- a/node/src/core/config-manager.ts
+++ b/node/src/core/config-manager.ts
@@ -141,6 +141,10 @@ function validateConfig(raw: any): RafterConfig {
         console.error('Warning: config "agent.scan.autoUpdateBetterleaks" must be a boolean — using default.');
         delete scan.autoUpdateBetterleaks;
       }
+      if (scan.plusRequiresApproval !== undefined && typeof scan.plusRequiresApproval !== "boolean") {
+        console.error('Warning: config "agent.scan.plusRequiresApproval" must be a boolean — using default.');
+        delete scan.plusRequiresApproval;
+      }
     }
   }
 
@@ -334,6 +338,11 @@ export class ConfigManager {
       }
       if (policy.scan.autoUpdateBetterleaks !== undefined) {
         config.agent.scan.autoUpdateBetterleaks = policy.scan.autoUpdateBetterleaks;
+      }
+      // sable-9ddf — OR merge: a project policy may turn the Plus-approval gate
+      // ON, but must never turn OFF a gate the machine owner set globally.
+      if (policy.scan.plusRequiresApproval === true) {
+        config.agent.scan.plusRequiresApproval = true;
       }
     }
 

--- a/node/src/core/config-schema.ts
+++ b/node/src/core/config-schema.ts
@@ -117,6 +117,19 @@ export interface RafterConfig {
        * to opt out, e.g. in CI that provisions its own binary.
        */
       autoUpdateBetterleaks?: boolean;
+      /**
+       * sable-9ddf — require explicit confirmation before a paid Plus scan
+       * (`rafter run --mode plus`). Default false (undefined) — existing
+       * behavior is unchanged unless opted in. When true, a Plus scan refuses
+       * in a non-interactive/agent context unless `--yes` or `RAFTER_CONFIRM=1`
+       * is present, and prompts when a TTY is attached.
+       *
+       * SECURITY: honored additively (OR) across global config and project
+       * `.rafter.yml` — a project policy can turn this ON but can NEVER turn OFF
+       * a gate the machine owner enabled globally. See runRemoteScan.
+       * YAML key: `scan.plus_requires_approval`.
+       */
+      plusRequiresApproval?: boolean;
     };
     /**
      * Fine-grained per-component install state. Keys are component IDs like

--- a/node/src/core/policy-loader.ts
+++ b/node/src/core/policy-loader.ts
@@ -41,6 +41,7 @@ export interface PolicyFile {
     excludePaths?: string[];
     customPatterns?: PolicyCustomPattern[];
     autoUpdateBetterleaks?: boolean;
+    plusRequiresApproval?: boolean;
   };
   ignore?: PolicyIgnoreRule[];
   audit?: {
@@ -150,6 +151,9 @@ function mapPolicy(raw: Record<string, any>): PolicyFile {
     }
     if (typeof raw.scan.auto_update_betterleaks === "boolean") {
       policy.scan.autoUpdateBetterleaks = raw.scan.auto_update_betterleaks;
+    }
+    if (typeof raw.scan.plus_requires_approval === "boolean") {
+      policy.scan.plusRequiresApproval = raw.scan.plus_requires_approval;
     }
   }
 
@@ -360,6 +364,12 @@ function validatePolicy(policy: PolicyFile, raw: Record<string, any>): PolicyFil
         raw.scan.auto_update_betterleaks !== undefined &&
         typeof raw.scan.auto_update_betterleaks !== "boolean") {
       console.error(`Warning: "scan.auto_update_betterleaks" must be a boolean — ignoring.`);
+    }
+    // sable-9ddf — only a boolean reaches policy.scan (mapping guards the type).
+    if (raw.scan && typeof raw.scan === "object" &&
+        raw.scan.plus_requires_approval !== undefined &&
+        typeof raw.scan.plus_requires_approval !== "boolean") {
+      console.error(`Warning: "scan.plus_requires_approval" must be a boolean — ignoring.`);
     }
   }
 

--- a/node/src/utils/api.ts
+++ b/node/src/utils/api.ts
@@ -8,6 +8,9 @@ export const EXIT_GENERAL_ERROR = 1;
 export const EXIT_SCAN_NOT_FOUND = 2;
 export const EXIT_QUOTA_EXHAUSTED = 3;
 export const EXIT_INSUFFICIENT_SCOPE = 4;
+// sable-9ddf — a paid Plus scan was refused because approval is required and no
+// explicit confirmation (--yes / RAFTER_CONFIRM=1 / interactive yes) was given.
+export const EXIT_CONFIRMATION_REQUIRED = 5;
 
 /**
  * Detect a 403 error from the API and print a helpful message.

--- a/node/tests/plus-scan-approval.test.ts
+++ b/node/tests/plus-scan-approval.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * sable-9ddf — the opt-in approval gate for paid Plus scans.
+ *
+ * Covers:
+ * - plusApprovalGateEnabled: OR semantics across global config + project policy,
+ *   the security-critical "policy can tighten but never loosen" property, and
+ *   fail-open on a config/policy read error.
+ * - confirmPlusScan: mode gating, the --yes / RAFTER_CONFIRM overrides, the TTY
+ *   prompt path, and the non-interactive refusal (exit 5).
+ * - runRemoteScan: the gate fires before the billable API call.
+ */
+
+// ── Mutable mock state (hoisted so the vi.mock factories can read it) ────
+const state = vi.hoisted(() => ({
+  globalFlag: undefined as boolean | undefined,
+  policyFlag: undefined as boolean | undefined,
+  configThrows: false,
+  promptAnswer: false,
+}));
+
+vi.mock("../src/core/config-manager.js", () => ({
+  ConfigManager: class {
+    load() {
+      if (state.configThrows) throw new Error("corrupt config");
+      return { agent: { scan: { plusRequiresApproval: state.globalFlag } } };
+    }
+  },
+}));
+
+vi.mock("../src/core/policy-loader.js", () => ({
+  loadPolicy: () =>
+    state.policyFlag === undefined
+      ? null
+      : { scan: { plusRequiresApproval: state.policyFlag } },
+}));
+
+vi.mock("../src/utils/prompt.js", () => ({
+  askYesNo: vi.fn(async () => state.promptAnswer),
+}));
+
+vi.mock("axios");
+vi.mock("ora", () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  }),
+}));
+
+import axios from "axios";
+import {
+  plusApprovalGateEnabled,
+  confirmPlusScan,
+  runRemoteScan,
+} from "../src/commands/backend/run.js";
+import { EXIT_CONFIRMATION_REQUIRED } from "../src/utils/api.js";
+
+const mockedAxios = vi.mocked(axios, true);
+
+function resetState() {
+  state.globalFlag = undefined;
+  state.policyFlag = undefined;
+  state.configThrows = false;
+  state.promptAnswer = false;
+}
+
+// ── plusApprovalGateEnabled ─────────────────────────────────────────────
+
+describe("plusApprovalGateEnabled", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("is off by default (neither source opts in)", () => {
+    expect(plusApprovalGateEnabled()).toBe(false);
+  });
+
+  it("is on when only global config opts in", () => {
+    state.globalFlag = true;
+    expect(plusApprovalGateEnabled()).toBe(true);
+  });
+
+  it("is on when only project policy opts in", () => {
+    state.policyFlag = true;
+    expect(plusApprovalGateEnabled()).toBe(true);
+  });
+
+  it("SECURITY: project policy cannot loosen a global opt-in", () => {
+    // Machine owner enabled it globally; a hostile repo sets it false.
+    state.globalFlag = true;
+    state.policyFlag = false;
+    expect(plusApprovalGateEnabled()).toBe(true);
+  });
+
+  it("fails open (off) when the global config cannot be read", () => {
+    state.configThrows = true;
+    expect(plusApprovalGateEnabled()).toBe(false);
+  });
+});
+
+// ── confirmPlusScan ─────────────────────────────────────────────────────
+
+describe("confirmPlusScan", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  const origTTY = process.stdin.isTTY;
+  const origConfirm = process.env.RAFTER_CONFIRM;
+
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    delete process.env.RAFTER_CONFIRM;
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as any);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    (process.stdin as any).isTTY = origTTY;
+    if (origConfirm === undefined) delete process.env.RAFTER_CONFIRM;
+    else process.env.RAFTER_CONFIRM = origConfirm;
+  });
+
+  it("is a no-op for a fast scan even when the gate is on", async () => {
+    state.globalFlag = true;
+    await expect(confirmPlusScan({ mode: "fast" })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for a plus scan when the gate is off", async () => {
+    await expect(confirmPlusScan({ mode: "plus" })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when --yes is passed", async () => {
+    state.globalFlag = true;
+    await expect(confirmPlusScan({ mode: "plus", yes: true })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when RAFTER_CONFIRM=1", async () => {
+    state.globalFlag = true;
+    process.env.RAFTER_CONFIRM = "1";
+    await expect(confirmPlusScan({ mode: "plus" })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses with exit 5 in a non-interactive context without confirmation", async () => {
+    state.globalFlag = true;
+    (process.stdin as any).isTTY = false;
+    await expect(confirmPlusScan({ mode: "plus" })).rejects.toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(EXIT_CONFIRMATION_REQUIRED);
+  });
+
+  it("proceeds when the interactive prompt is answered yes", async () => {
+    state.globalFlag = true;
+    state.promptAnswer = true;
+    (process.stdin as any).isTTY = true;
+    await expect(confirmPlusScan({ mode: "plus" })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses with exit 5 when the interactive prompt is answered no", async () => {
+    state.globalFlag = true;
+    state.promptAnswer = false;
+    (process.stdin as any).isTTY = true;
+    await expect(confirmPlusScan({ mode: "plus" })).rejects.toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(EXIT_CONFIRMATION_REQUIRED);
+  });
+});
+
+// ── runRemoteScan integration — gate fires before the API call ───────────
+
+describe("runRemoteScan gate integration", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  const origTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as any);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    (process.stdin as any).isTTY = origTTY;
+  });
+
+  it("refuses a gated plus scan without ever calling the backend", async () => {
+    state.globalFlag = true;
+    (process.stdin as any).isTTY = false;
+    await expect(
+      runRemoteScan({
+        apiKey: "test-key",
+        repo: "owner/repo",
+        branch: "main",
+        mode: "plus",
+        skipInteractive: true,
+        quiet: true,
+      })
+    ).rejects.toThrow("process.exit");
+
+    expect(exitSpy).toHaveBeenCalledWith(EXIT_CONFIRMATION_REQUIRED);
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it("submits a gated plus scan when --yes confirms it", async () => {
+    state.globalFlag = true;
+    mockedAxios.post.mockResolvedValueOnce({ data: { scan_id: "scan-abc" } });
+
+    await runRemoteScan({
+      apiKey: "test-key",
+      repo: "owner/repo",
+      branch: "main",
+      mode: "plus",
+      yes: true,
+      skipInteractive: true,
+      quiet: true,
+    });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ scan_mode: "plus" }),
+      expect.any(Object)
+    );
+  });
+});

--- a/python/rafter_cli/commands/agent_components.py
+++ b/python/rafter_cli/commands/agent_components.py
@@ -63,7 +63,9 @@ a dependency still gets the full gate.
 - `rafter run` — remote SAST + SCA + secrets (real code analysis, needs `RAFTER_API_KEY`)
 - `rafter secrets .` — local secrets only (offline; NOT a code-security scan)
 - `rafter run --mode plus` — everything in default (`--mode fast`) plus
-  powerful agentic deep-dives (needs `RAFTER_API_KEY`)
+  powerful agentic deep-dives (needs `RAFTER_API_KEY`). **Plus is a PAID tier
+  and consumes the user's credits — ask the user before running it.** Enforced
+  when `scan.plus_requires_approval` is set (then pass `--yes` to confirm).
 {RAFTER_MARKER_END}"""
 
 

--- a/python/rafter_cli/commands/backend.py
+++ b/python/rafter_cli/commands/backend.py
@@ -12,6 +12,7 @@ from ..utils.api import (
     API_BASE,
     API_TIMEOUT,
     API_TIMEOUT_SHORT,
+    EXIT_CONFIRMATION_REQUIRED,
     EXIT_GENERAL_ERROR,
     EXIT_QUOTA_EXHAUSTED,
     EXIT_SCAN_NOT_FOUND,
@@ -21,6 +22,70 @@ from ..utils.api import (
     write_payload,
 )
 from ..utils.git import detect_repo
+
+
+def _plus_approval_gate_enabled() -> bool:
+    """sable-9ddf — is the Plus-scan approval gate enabled?
+
+    OR semantics across the machine-owner's global config and the project's
+    ``.rafter.yml``: if EITHER opts in, approval is required. A project policy
+    can turn the gate ON but can NEVER turn it OFF — a hostile repo must not be
+    able to silently re-open the credit-burn hole a user closed globally.
+
+    Fails open (returns False) if config/policy can't be read, consistent with
+    the OFF-by-default product behavior and the codebase's config-load fallback.
+    """
+    from ..core.config_manager import ConfigManager
+    from ..core.policy_loader import load_policy
+
+    global_flag = False
+    try:
+        global_flag = ConfigManager().load().agent.scan.plus_requires_approval is True
+    except Exception:
+        pass  # fail open
+    policy_flag = False
+    try:
+        policy = load_policy()
+        policy_flag = bool(policy and policy.get("scan", {}).get("plus_requires_approval") is True)
+    except Exception:
+        pass  # fail open
+    return global_flag or policy_flag
+
+
+def _confirm_plus_scan(mode: str, yes: bool) -> None:
+    """Gate a paid Plus scan behind explicit confirmation when the switch is on.
+
+    Returns normally if the scan may proceed; raises ``typer.Exit`` otherwise.
+    No-op for non-plus modes and when the gate is disabled (the default).
+    """
+    import os as _os
+
+    if (mode or "fast") != "plus":
+        return
+    if not _plus_approval_gate_enabled():
+        return
+
+    env_confirm = _os.environ.get("RAFTER_CONFIRM")
+    if yes or env_confirm in ("1", "true"):
+        return
+
+    if sys.stdin.isatty():
+        answer = input(
+            "  Plus is a PAID scan tier and will consume your credits. Proceed? [y/N] "
+        ).strip().lower()
+        if answer in ("y", "yes"):
+            return
+        print("Plus scan cancelled.", file=sys.stderr)
+        raise typer.Exit(code=EXIT_CONFIRMATION_REQUIRED)
+
+    print(
+        "Refusing to run a paid Plus scan: approval is required "
+        "(scan.plus_requires_approval is enabled).\n"
+        "Re-run with --yes (or set RAFTER_CONFIRM=1) to confirm the credit spend, "
+        "or use the free --mode fast scan.",
+        file=sys.stderr,
+    )
+    raise typer.Exit(code=EXIT_CONFIRMATION_REQUIRED)
 
 
 def _handle_scan_status_interactive(
@@ -93,9 +158,14 @@ def _do_remote_scan(
     github_token: "str | None" = None,
     provider: "str | None" = None,
     repo_url: "str | None" = None,
+    yes: bool = False,
 ) -> None:
     """Shared implementation for remote backend scan — used by both `rafter run` and `rafter scan`."""
     import os as _os
+
+    # sable-9ddf — gate paid Plus scans before doing any work (key resolution,
+    # repo detection, or the billable API call).
+    _confirm_plus_scan(mode, yes)
 
     key = resolve_key(api_key)
     gh_token = github_token or _os.environ.get("RAFTER_GITHUB_TOKEN")
@@ -166,10 +236,11 @@ def register_backend_commands(app: typer.Typer) -> None:
         provider: str = typer.Option(None, "--provider", help="git provider: gitlab | gitea | bitbucket (default: auto-detected; github requires nothing)"),
         repo_url: str = typer.Option(None, "--repo-url", help="full https clone URL for non-github remotes (default: auto-detected)"),
         skip_interactive: bool = typer.Option(False, "--skip-interactive", help="do not wait for scan to complete"),
+        yes: bool = typer.Option(False, "--yes", "-y", help="confirm a paid Plus scan without prompting (when scan.plus_requires_approval is on)"),
         quiet: bool = typer.Option(False, "--quiet", help="suppress status messages"),
     ):
         """Trigger a security scan."""
-        _do_remote_scan(repo, branch, api_key, fmt, skip_interactive, quiet, mode, github_token=github_token, provider=provider, repo_url=repo_url)
+        _do_remote_scan(repo, branch, api_key, fmt, skip_interactive, quiet, mode, github_token=github_token, provider=provider, repo_url=repo_url, yes=yes)
 
     @app.command()
     def get(

--- a/python/rafter_cli/commands/scan.py
+++ b/python/rafter_cli/commands/scan.py
@@ -53,12 +53,13 @@ def scan_default(
     provider: Optional[str] = typer.Option(None, "--provider", help="git provider: gitlab | gitea | bitbucket (default: auto-detected; github requires nothing)"),
     repo_url: Optional[str] = typer.Option(None, "--repo-url", help="full https clone URL for non-github remotes (default: auto-detected)"),
     skip_interactive: bool = typer.Option(False, "--skip-interactive", help="do not wait for scan to complete"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="confirm a paid Plus scan without prompting (when scan.plus_requires_approval is on)"),
     quiet: bool = typer.Option(False, "--quiet", help="suppress status messages"),
 ):
     """Scan for security issues. Defaults to remote scan."""
     if ctx.invoked_subcommand is None:
         # No subcommand — run remote scan
-        _run_remote_scan(repo, branch, api_key, fmt_, skip_interactive, quiet, mode, github_token, provider, repo_url)
+        _run_remote_scan(repo, branch, api_key, fmt_, skip_interactive, quiet, mode, github_token, provider, repo_url, yes)
 
 
 # ── rafter scan remote ────────────────────────────────────────────────
@@ -74,16 +75,17 @@ def scan_remote(
     provider: Optional[str] = typer.Option(None, "--provider", help="git provider: gitlab | gitea | bitbucket (default: auto-detected; github requires nothing)"),
     repo_url: Optional[str] = typer.Option(None, "--repo-url", help="full https clone URL for non-github remotes (default: auto-detected)"),
     skip_interactive: bool = typer.Option(False, "--skip-interactive", help="do not wait for scan to complete"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="confirm a paid Plus scan without prompting (when scan.plus_requires_approval is on)"),
     quiet: bool = typer.Option(False, "--quiet", help="suppress status messages"),
 ):
     """Trigger a remote backend security scan (explicit alias for 'rafter run')."""
-    _run_remote_scan(repo, branch, api_key, fmt_, skip_interactive, quiet, mode, github_token, provider, repo_url)
+    _run_remote_scan(repo, branch, api_key, fmt_, skip_interactive, quiet, mode, github_token, provider, repo_url, yes)
 
 
-def _run_remote_scan(repo, branch, api_key, fmt_, skip_interactive, quiet, mode="fast", github_token=None, provider=None, repo_url=None):
+def _run_remote_scan(repo, branch, api_key, fmt_, skip_interactive, quiet, mode="fast", github_token=None, provider=None, repo_url=None, yes=False):
     """Shared handler: invoke remote scan (same logic as `rafter run`)."""
     from ..commands.backend import _do_remote_scan
-    _do_remote_scan(repo, branch, api_key, fmt_, skip_interactive, quiet, mode, github_token=github_token, provider=provider, repo_url=repo_url)
+    _do_remote_scan(repo, branch, api_key, fmt_, skip_interactive, quiet, mode, github_token=github_token, provider=provider, repo_url=repo_url, yes=yes)
 
 
 # ── rafter scan local ─────────────────────────────────────────────────

--- a/python/rafter_cli/core/config_manager.py
+++ b/python/rafter_cli/core/config_manager.py
@@ -246,6 +246,10 @@ class ConfigManager:
                 if key in scan and not isinstance(scan[key], bool):
                     print(f'rafter: config "scan.{key}" must be a boolean — using default.', file=sys.stderr)
                     del scan[key]
+            for key in ("plusRequiresApproval", "plus_requires_approval"):
+                if key in scan and not isinstance(scan[key], bool):
+                    print(f'rafter: config "scan.{key}" must be a boolean — using default.', file=sys.stderr)
+                    del scan[key]
 
     # ------------------------------------------------------------------
     # Policy-merged config
@@ -284,6 +288,11 @@ class ConfigManager:
                 ]
             if scan.get("auto_update_betterleaks") is not None:
                 config.agent.scan.auto_update_betterleaks = scan["auto_update_betterleaks"]
+            # sable-9ddf — OR merge: a project policy may turn the Plus-approval
+            # gate ON, but must never turn OFF a gate the machine owner set
+            # globally.
+            if scan.get("plus_requires_approval") is True:
+                config.agent.scan.plus_requires_approval = True
 
         if policy.get("ignore"):
             from .config_schema import ScanIgnoreRule

--- a/python/rafter_cli/core/config_schema.py
+++ b/python/rafter_cli/core/config_schema.py
@@ -74,6 +74,17 @@ class ScanConfig:
     # time. Default True. Set False (YAML: ``scan.auto_update_betterleaks``) to
     # opt out, e.g. in CI that provisions its own binary.
     auto_update_betterleaks: bool = True
+    # sable-9ddf — require explicit confirmation before a paid Plus scan
+    # (``rafter run --mode plus``). Default False — existing behavior is
+    # unchanged unless opted in. When True, a Plus scan refuses in a
+    # non-interactive/agent context unless ``--yes`` or ``RAFTER_CONFIRM=1`` is
+    # present, and prompts when a TTY is attached.
+    #
+    # SECURITY: honored additively (OR) across global config and project
+    # ``.rafter.yml`` — a project policy can turn this ON but can NEVER turn OFF
+    # a gate the machine owner enabled globally. YAML key:
+    # ``scan.plus_requires_approval``.
+    plus_requires_approval: bool = False
 
 
 @dataclass

--- a/python/rafter_cli/core/policy_loader.py
+++ b/python/rafter_cli/core/policy_loader.py
@@ -107,6 +107,8 @@ def _map_policy(raw: dict) -> dict:
             ]
         if isinstance(scan.get("auto_update_betterleaks"), bool):
             policy["scan"]["auto_update_betterleaks"] = scan["auto_update_betterleaks"]
+        if isinstance(scan.get("plus_requires_approval"), bool):
+            policy["scan"]["plus_requires_approval"] = scan["plus_requires_approval"]
 
     # sable-c1c — backend flat-shape compat. rafter-backend reads
     # exclude_paths / custom_patterns at the top level (no `scan:` nesting),
@@ -287,6 +289,9 @@ def _validate_policy(policy: dict, raw: dict) -> dict:
     raw_scan = raw.get("scan")
     if isinstance(raw_scan, dict) and "auto_update_betterleaks" in raw_scan and not isinstance(raw_scan["auto_update_betterleaks"], bool):
         print('Warning: "scan.auto_update_betterleaks" must be a boolean — ignoring.', file=sys.stderr)
+    # sable-9ddf — same guard for the Plus-approval flag.
+    if isinstance(raw_scan, dict) and "plus_requires_approval" in raw_scan and not isinstance(raw_scan["plus_requires_approval"], bool):
+        print('Warning: "scan.plus_requires_approval" must be a boolean — ignoring.', file=sys.stderr)
 
     ignore = policy.get("ignore")
     if ignore is not None:

--- a/python/rafter_cli/resources/skills/rafter/SKILL.md
+++ b/python/rafter_cli/resources/skills/rafter/SKILL.md
@@ -25,7 +25,7 @@ Three tiers, **not interchangeable**. The local tier is narrow; skipping remote 
 
 1. **`rafter secrets`** — hardcoded credentials only (regex + betterleaks). Fast, offline, no key. **NOT a code security scan** — it finds no SQL injection, SSRF, auth bugs, insecure deserialization, logic flaws, or dependency vulns. A clean `rafter secrets .` is secret-hygiene, not security review.
 2. **`rafter run`** (default mode) — the real code-analysis pass: SAST + SCA + secrets (dataflow, taint, known-vulnerable deps, crypto misuse, injection sinks). Needs `RAFTER_API_KEY`.
-3. **`rafter run --mode plus`** — agentic deep-dive: LLM-guided investigation of what the rules engine flags. Slower, higher signal; code is deleted server-side after the run.
+3. **`rafter run --mode plus`** — agentic deep-dive: LLM-guided investigation of what the rules engine flags. Slower, higher signal; code is deleted server-side after the run. **PAID tier — consumes the user's credits; ask before running it.** If `scan.plus_requires_approval` is set, Plus refuses without `--yes` / `RAFTER_CONFIRM=1`.
 
 **Default for a security-relevant task: `rafter run`.** Fall back to `rafter secrets` only when no API key is available — and say so explicitly; don't claim the code was "scanned" without qualification. Deterministic findings, stable exit codes and JSON shapes — safe to chain in CI and in agent loops.
 

--- a/python/rafter_cli/utils/api.py
+++ b/python/rafter_cli/utils/api.py
@@ -16,6 +16,9 @@ EXIT_GENERAL_ERROR = 1
 EXIT_SCAN_NOT_FOUND = 2
 EXIT_QUOTA_EXHAUSTED = 3
 EXIT_INSUFFICIENT_SCOPE = 4
+# sable-9ddf — a paid Plus scan was refused because approval is required and no
+# explicit confirmation (--yes / RAFTER_CONFIRM=1 / interactive yes) was given.
+EXIT_CONFIRMATION_REQUIRED = 5
 
 
 def handle_403(resp: "requests.Response") -> int:

--- a/python/tests/test_plus_scan_approval.py
+++ b/python/tests/test_plus_scan_approval.py
@@ -1,0 +1,198 @@
+"""sable-9ddf — the opt-in approval gate for paid Plus scans.
+
+Covers:
+- _plus_approval_gate_enabled: OR semantics across global config + project
+  policy, the security-critical "policy can tighten but never loosen" property,
+  and fail-open on a config/policy read error.
+- _confirm_plus_scan: mode gating, the --yes / RAFTER_CONFIRM overrides, the TTY
+  prompt path, and the non-interactive refusal (exit 5).
+- _do_remote_scan: the gate fires before the billable API call.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from rafter_cli.commands.backend import (
+    _confirm_plus_scan,
+    _do_remote_scan,
+    _plus_approval_gate_enabled,
+)
+from rafter_cli.utils.api import EXIT_CONFIRMATION_REQUIRED
+
+
+def _config_manager_returning(plus_flag):
+    """A stand-in ConfigManager instance whose load().agent.scan
+    .plus_requires_approval is `plus_flag`."""
+    cfg = MagicMock()
+    cfg.agent.scan.plus_requires_approval = plus_flag
+    mgr = MagicMock()
+    mgr.load.return_value = cfg
+    return mgr
+
+
+def _patch_sources(global_flag, policy_flag, config_raises=False):
+    """Patch ConfigManager + load_policy where _plus_approval_gate_enabled
+    imports them (the core modules)."""
+    if config_raises:
+        cm = patch(
+            "rafter_cli.core.config_manager.ConfigManager",
+            side_effect=RuntimeError("corrupt config"),
+        )
+    else:
+        cm = patch(
+            "rafter_cli.core.config_manager.ConfigManager",
+            return_value=_config_manager_returning(global_flag),
+        )
+    policy = (
+        None if policy_flag is None else {"scan": {"plus_requires_approval": policy_flag}}
+    )
+    lp = patch("rafter_cli.core.policy_loader.load_policy", return_value=policy)
+    return cm, lp
+
+
+# ── _plus_approval_gate_enabled ─────────────────────────────────────────
+
+
+class TestGateEnabled:
+    def test_off_by_default(self):
+        cm, lp = _patch_sources(global_flag=False, policy_flag=None)
+        with cm, lp:
+            assert _plus_approval_gate_enabled() is False
+
+    def test_on_when_only_global_config(self):
+        cm, lp = _patch_sources(global_flag=True, policy_flag=None)
+        with cm, lp:
+            assert _plus_approval_gate_enabled() is True
+
+    def test_on_when_only_project_policy(self):
+        cm, lp = _patch_sources(global_flag=False, policy_flag=True)
+        with cm, lp:
+            assert _plus_approval_gate_enabled() is True
+
+    def test_policy_cannot_loosen_global_optin(self):
+        # SECURITY: machine owner enabled it globally; a hostile repo sets it
+        # false. The gate must stay on.
+        cm, lp = _patch_sources(global_flag=True, policy_flag=False)
+        with cm, lp:
+            assert _plus_approval_gate_enabled() is True
+
+    def test_fails_open_on_config_read_error(self):
+        cm, lp = _patch_sources(global_flag=None, policy_flag=None, config_raises=True)
+        with cm, lp:
+            assert _plus_approval_gate_enabled() is False
+
+
+# ── _confirm_plus_scan ──────────────────────────────────────────────────
+
+
+class TestConfirmPlusScan:
+    def test_noop_for_fast_scan_even_when_gate_on(self, monkeypatch):
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=True
+        ):
+            # Should not raise.
+            _confirm_plus_scan("fast", yes=False)
+
+    def test_noop_for_plus_when_gate_off(self):
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=False
+        ):
+            _confirm_plus_scan("plus", yes=False)
+
+    def test_proceeds_with_yes(self):
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=True
+        ):
+            _confirm_plus_scan("plus", yes=True)
+
+    def test_proceeds_with_rafter_confirm_env(self, monkeypatch):
+        monkeypatch.setenv("RAFTER_CONFIRM", "1")
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=True
+        ):
+            _confirm_plus_scan("plus", yes=False)
+
+    def test_refuses_exit_5_non_interactive(self, monkeypatch):
+        monkeypatch.delenv("RAFTER_CONFIRM", raising=False)
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=True
+        ), patch("sys.stdin.isatty", return_value=False):
+            with pytest.raises(typer.Exit) as exc:
+                _confirm_plus_scan("plus", yes=False)
+            assert exc.value.exit_code == EXIT_CONFIRMATION_REQUIRED
+
+    def test_proceeds_when_prompt_answered_yes(self, monkeypatch):
+        monkeypatch.delenv("RAFTER_CONFIRM", raising=False)
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=True
+        ), patch("sys.stdin.isatty", return_value=True), patch(
+            "builtins.input", return_value="y"
+        ):
+            _confirm_plus_scan("plus", yes=False)
+
+    def test_refuses_exit_5_when_prompt_answered_no(self, monkeypatch):
+        monkeypatch.delenv("RAFTER_CONFIRM", raising=False)
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=True
+        ), patch("sys.stdin.isatty", return_value=True), patch(
+            "builtins.input", return_value="n"
+        ):
+            with pytest.raises(typer.Exit) as exc:
+                _confirm_plus_scan("plus", yes=False)
+            assert exc.value.exit_code == EXIT_CONFIRMATION_REQUIRED
+
+
+# ── _do_remote_scan integration — gate fires before the API call ─────────
+
+
+class TestGateIntegration:
+    @patch("rafter_cli.commands.backend.requests.post")
+    def test_refuses_gated_plus_without_calling_backend(self, mock_post, monkeypatch):
+        monkeypatch.delenv("RAFTER_CONFIRM", raising=False)
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=True
+        ), patch("sys.stdin.isatty", return_value=False):
+            with pytest.raises(typer.Exit) as exc:
+                _do_remote_scan(
+                    repo="owner/repo",
+                    branch="main",
+                    api_key="test-key",
+                    fmt="json",
+                    skip_interactive=True,
+                    quiet=True,
+                    mode="plus",
+                )
+            assert exc.value.exit_code == EXIT_CONFIRMATION_REQUIRED
+        mock_post.assert_not_called()
+
+    @patch("rafter_cli.commands.backend.requests.post")
+    @patch(
+        "rafter_cli.commands.backend.detect_repo",
+        return_value=("owner/repo", "main", "github", None),
+    )
+    def test_submits_gated_plus_when_yes(self, _mock_repo, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"scan_id": "s-abc"}
+        mock_post.return_value = resp
+
+        with patch(
+            "rafter_cli.commands.backend._plus_approval_gate_enabled", return_value=True
+        ):
+            _do_remote_scan(
+                repo="owner/repo",
+                branch="main",
+                api_key="test-key",
+                fmt="json",
+                skip_interactive=True,
+                quiet=True,
+                mode="plus",
+                yes=True,
+            )
+
+        assert mock_post.call_args is not None
+        body = mock_post.call_args.kwargs["json"]
+        assert body["scan_mode"] == "plus"

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -26,6 +26,7 @@ The CLI follows UNIX principles:
 | 2 | Scan not found (HTTP 404) |
 | 3 | Quota exhausted (HTTP 429 or 403 scan-mode limit) |
 | 4 | Insufficient scope / forbidden (HTTP 403) |
+| 5 | Paid Plus scan refused — approval required (`scan.plus_requires_approval` on) and no `--yes`/`RAFTER_CONFIRM=1`/interactive confirmation |
 
 ### Local Secret Scan (`rafter secrets`)
 
@@ -68,13 +69,19 @@ Trigger a new security scan for a repository.
 - `-r, --repo TEXT` — org/repo (default: auto-detected from git remote)
 - `-b, --branch TEXT` — branch (default: current branch or 'main')
 - `-f, --format [json|md]` — output format (default: md)
-- `-m, --mode [fast|plus]` — scan mode (default: fast). Fast runs SAST, secret detection, and dependency checks. Plus adds agentic deep-dive analysis that examines your codebase the way a professional cybersecurity auditor would — tracing data flows and reasoning about business logic on top of the full SAST/SCA toolchain.
+- `-m, --mode [fast|plus]` — scan mode (default: fast). Fast runs SAST, secret detection, and dependency checks. Plus adds agentic deep-dive analysis that examines your codebase the way a professional cybersecurity auditor would — tracing data flows and reasoning about business logic on top of the full SAST/SCA toolchain. **Plus is a paid tier that consumes credits.**
 - `--github-token TEXT` — GitHub PAT for private repos (or `RAFTER_GITHUB_TOKEN` env var)
 - `--provider [gitlab|gitea|bitbucket]` — git provider for non-GitHub remotes. Default: auto-detected from the git remote host. GitHub requires nothing — leave unset. Overrides the inferred provider when set.
 - `--repo-url TEXT` — full HTTPS clone URL for non-GitHub remotes (e.g. `https://gitlab.com/owner/repo`). Default: auto-detected and normalized from the git remote. Overrides the inferred URL when set.
 - `--skip-interactive` — fire-and-forget mode (don't poll for completion)
+- `-y, --yes` — confirm a paid Plus scan without an interactive prompt. Only consulted when the Plus-approval gate is on (`scan.plus_requires_approval`); `RAFTER_CONFIRM=1` is an equivalent env-var form. Ignored for `--mode fast`.
 - `--quiet` — suppress status messages on stderr
 - `-h, --help`
+
+**Plus-scan approval gate.** Plus scans spend credits, so an agent running one unprompted can burn a user's balance. Set `scan.plus_requires_approval: true` (in project `.rafter.yml` or global `~/.rafter/config.json`) to require explicit confirmation before any `--mode plus` scan. Default is **off** — existing behavior is unchanged unless enabled. When on:
+- With a TTY: rafter prompts `[y/N]` before submitting.
+- Without a TTY (agent/CI): rafter refuses with exit code `5` unless `--yes` or `RAFTER_CONFIRM=1` is present.
+- Precedence is **additive (OR)**: a project `.rafter.yml` can turn the gate *on*, but cannot turn *off* a gate the machine owner enabled in global config. `fast` scans are never gated.
 
 #### Scan request body (provider fields)
 
@@ -1185,6 +1192,12 @@ scan:
   # rafter then falls back to the patterns engine instead. Equivalent to passing
   # --no-auto-update on every scan. See `rafter secrets --no-auto-update`.
   auto_update_betterleaks: true
+  # Default: false. Set true to require explicit confirmation before a paid
+  # `rafter run --mode plus` scan (which consumes credits). When on, Plus
+  # refuses in a non-interactive/agent context unless `--yes` or
+  # `RAFTER_CONFIRM=1` is present, and prompts when a TTY is attached. Additive
+  # (OR) with the global config: a project file can turn this ON but never OFF.
+  plus_requires_approval: false
 ignore:
   - paths: ["tests/fixtures/**", "*.example.env"]
     rules: ["AWS Access Key", "Generic API Key"]


### PR DESCRIPTION
## Problem

An external rafter-cli user reported that their AI coding agent ran a paid **Plus scan** (`rafter run --mode plus`) on its own, potentially consuming ~$10 of their credits — with no way to stop the agent from doing it. They want to reserve Plus for areas they choose and can't safely top up credits while an agent can burn them unprompted.

## What this does

Adds an **opt-in** config flag `scan.plus_requires_approval`, **OFF by default** — existing behavior is unchanged unless a user enables it. When enabled, a Plus scan (through `rafter run`, `rafter scan`, or `rafter scan remote` — all funnel through one choke point) must be confirmed before it spends credits:

- **TTY present** → prompts `[y/N]` before submitting.
- **Non-interactive / agent / CI** → refuses with new **exit code 5** unless `--yes`/`-y` or `RAFTER_CONFIRM=1` is present.
- **Fast scans are never gated.**

The gate runs *before* key resolution, repo detection, and the billable API call.

### Security: precedence is additive (OR)

The gate fires if **either** global `~/.rafter/config.json` **or** the project `.rafter.yml` sets the flag `true`. A project policy can **tighten** (turn the gate on) but can **never loosen** it — a hostile repo cannot ship `plus_requires_approval: false` to silently re-open the credit-burn hole a user closed globally. This mirrors the existing `hooks`-field rule. Fails open (gate off) on a config/policy read error, matching the OFF-by-default posture.

This was validated with an adversarial security review of the diff (secure-design pass + code review): the "policy can tighten but never loosen" property holds on all paths, and Node/Python are at parity on the flag read, env-var parsing, exit code, and TTY handling.

### Agent guidance ("encourage approval" half)

The rafter agent skill (`SKILL.md`) and injected instruction block now tell agents Plus is a paid tier that consumes credits and to ask the user before running it — stronger when the switch is on.

## Immediate workaround for the user (no new code needed)

Until this ships, a user can add `rafter run` with `--mode plus` to `agent.commandPolicy.requireApproval` (or `blockedPatterns`) in their project `.rafter.yml` so the pretool hook prompts/refuses. The new flag is the clean, Plus-specific version of that.

## Not in scope (separate thread)

The billing/accounting confusion the user also reported (\$20 balance vs "\$10 used"; whether *failed* Plus scans that couldn't connect to their repos were charged) is a **hosted-backend** concern, not this repo. It should be routed to the securable/billing side — flagging separately.

## Tests

- New suites: `node/tests/plus-scan-approval.test.ts` (14) + `python/tests/test_plus_scan_approval.py` (14) — OR semantics, the "policy can't loosen global" security property, fail-open, mode gating, `--yes`/`RAFTER_CONFIRM` overrides, TTY prompt yes/no, non-interactive refusal (exit 5), and the gate firing before the API call.
- All affected existing suites pass in both impls (config-manager, policy-loader/merge/validation, scan-remote).

### Pre-existing failures (NOT introduced here)

This local checkout has 4 red tests unrelated to this change, all confirmed present on the clean tree and none touching the changed files — they stem from a **stale editable install** of `rafter-cli` in this environment (CLI reports an old version; missing the newly-merged `opencode` component): `cross-runtime-parity` (version), `error-handling-gauntlet` (AuditLogger), `test_agent_components` (opencode.mcp), `test_e2e_cli` (version-matches-pyproject). A fresh `pip install -e python/` clears the version/opencode ones.

## AI-assisted

Implemented with AI assistance (Claude), per the repo AI Policy.