### PR TITLE
docs: expand Aider setup recipe

### DIFF
--- a/recipes/aider.md
+++ b/recipes/aider.md
@@ -12,6 +12,12 @@ Rafter ships a `RAFTER.md` context file and adds it to that `read:` list.
 > ignored it. That install was pruned in `rf-du2o`. Reinstalling on top of an
 > old layout strips the legacy line.
 
+## Prerequisites
+
+- Rafter installed as either `@rafter-security/cli` or `rafter-cli`
+- A project directory where `RAFTER.md` and `.aider.conf.yml` may be written
+- Aider itself is optional during setup; install it before starting an Aider session
+
 ## Automatic setup
 
 ```sh
@@ -64,3 +70,30 @@ material per session, also run:
 ```sh
 rafter brief commands    # quick command reference
 ```
+
+## MCP tools reference
+
+Aider does not expose native MCP support, so Rafter's MCP tools
+(`scan_secrets`, `evaluate_command`, `read_audit_log`, and `get_config`)
+are not available inside Aider. The installed `RAFTER.md` gives Aider the
+security guidance it can consume; run the equivalent Rafter CLI commands in a
+separate terminal when you need active scanning or policy checks.
+
+## Troubleshooting
+
+- **`RAFTER.md` is not loaded:** Run Aider from the directory containing
+  `.aider.conf.yml`, and confirm its `read:` list contains `RAFTER.md`.
+- **Existing read-only files disappeared:** Do not replace the `read:` block
+  manually. Re-run `rafter agent init --local --with-aider`; the installer
+  preserves existing entries.
+- **A stale `mcp-server-command` line remains:** Re-run the automatic setup
+  with the current Rafter release. It removes the obsolete, ignored key.
+- **Rafter commands are not found:** Check that the npm or Python scripts
+  directory is on `PATH`, then confirm with `rafter --version`.
+
+## Uninstall
+
+Remove `RAFTER.md` from the `read:` list in `.aider.conf.yml`. Then delete
+`RAFTER.md` only if it contains no project-specific content outside the
+`<!-- rafter:start -->` / `<!-- rafter:end -->` managed block. At user scope,
+make the same change in `~/.aider.conf.yml`.


### PR DESCRIPTION
## Summary
- add prerequisites for project-local and user-scoped Aider setup
- explicitly document that Aider has no native MCP support instead of presenting unavailable Rafter tools
- add common troubleshooting steps and a safe uninstall procedure
- preserve the current `RAFTER.md` and `read:` integration model

## Test plan
- checked all six requested recipe sections are present
- checked the recipe does not present the obsolete `mcp-server-command` key as current configuration
- `git diff --check`

## Spec update
Not applicable; this is documentation-only and does not change CLI behavior.

Part of #33 (Aider recipe slice only).

AI-assisted contribution prepared with Codex.

Co-authored-by: Codex <noreply@openai.com>
