### PR TITLE
test: cover brief agent-mode output

### DIFF
--- a/node/tests/brief.test.ts
+++ b/node/tests/brief.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { execFileSync } from "child_process";
+import { execFileSync, spawnSync } from "child_process";
 import { readFileSync, existsSync } from "fs";
 import path from "path";
 
@@ -15,25 +15,24 @@ const RAFTER_SUBDOCS = [
   "shift-left",
   "finding-triage",
 ];
+const emojiRe =
+  /(?:[\u2600-\u27BF\u{1F1E6}-\u{1F1FF}\u{1F300}-\u{1FAFF}]|[0-9#*]\uFE0F?\u20E3)/u;
 
 function rafter(
   args: string | string[],
+  env?: NodeJS.ProcessEnv,
 ): { stdout: string; stderr: string; exitCode: number } {
   const argList = Array.isArray(args) ? args : args.split(/\s+/);
-  try {
-    const result = execFileSync("node", [CLI, ...argList], {
-      encoding: "utf-8",
-      env: { ...process.env },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    return { stdout: result, stderr: "", exitCode: 0 };
-  } catch (e: any) {
-    return {
-      stdout: e.stdout || "",
-      stderr: e.stderr || "",
-      exitCode: e.status ?? 1,
-    };
-  }
+  const result = spawnSync("node", [CLI, ...argList], {
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return {
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    exitCode: result.status ?? 1,
+  };
 }
 
 beforeAll(() => {
@@ -85,6 +84,19 @@ describe("brief command — topic listing", () => {
 });
 
 describe("brief command — topic rendering", () => {
+  it("renders agent-mode output without terminal formatting", () => {
+    const r = rafter(["--agent", "brief", "scanning"], {
+      CI: "1",
+      FORCE_COLOR: "1",
+    });
+    const output = r.stdout + r.stderr;
+
+    expect(r.exitCode).toBe(0);
+    expect(output).toContain("# Rafter");
+    expect(output).not.toContain("\u001b");
+    expect(output).not.toMatch(emojiRe);
+  });
+
   it("renders scanning topic from skill file", () => {
     const r = rafter("brief scanning");
     expect(r.exitCode).toBe(0);

--- a/python/tests/test_brief.py
+++ b/python/tests/test_brief.py
@@ -1,6 +1,8 @@
 """Tests for the brief command — knowledge delivery."""
 from __future__ import annotations
 
+import re
+
 import pytest
 from typer.testing import CliRunner
 
@@ -18,8 +20,22 @@ from rafter_cli.commands.brief import (
     PLATFORM_GUIDES,
     TOPIC_DESCRIPTIONS,
 )
+from rafter_cli.utils.formatter import set_agent_mode
 
 runner = CliRunner()
+EMOJI_RE = re.compile(
+    "[\u2600-\u27BF\U0001F1E6-\U0001F1FF\U0001F300-\U0001FAFF]"
+    "|[0-9#*]\ufe0f?\u20e3"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agent_mode():
+    set_agent_mode(False)
+    try:
+        yield
+    finally:
+        set_agent_mode(False)
 
 
 class TestTopicListing:
@@ -53,6 +69,14 @@ class TestTopicListing:
 
 
 class TestTopicRendering:
+    def test_agent_mode_has_no_terminal_formatting(self):
+        result = runner.invoke(app, ["--agent", "brief", "scanning"], color=True)
+
+        assert result.exit_code == 0
+        assert "# Rafter" in result.output
+        assert "\x1b" not in result.output
+        assert EMOJI_RE.search(result.output) is None
+
     def test_scanning_topic_loads_skill(self):
         result = runner.invoke(app, ["brief", "scanning"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

This adds matching regression tests for `rafter --agent brief scanning` in Node and Python. The Node test uses `spawnSync` to capture both output streams, while the Python test invokes the root Typer app with `color=True`. Both cases require a successful exit and real Rafter content, then reject escape characters and emoji so agent mode stays plain.

## Why

Issue #28 originally listed broader `brief` coverage, but most of that coverage landed before this change. In the issue discussion, the maintainer identified agent-mode output as the highest-priority remaining gap. Both CLIs already produce plain output; this PR adds mirrored regression coverage so a later formatting change cannot silently break that contract.

## Related issue

Addresses the agent-mode portion of #28. The Node internal-helper parity work remains a separate follow-up.

## Test plan

- `pnpm run build`
- `pnpm exec vitest run tests/brief.test.ts` (29 passed)
- `.\.venv\Scripts\pytest.exe tests\test_brief.py -v` (36 passed)
- Linux Node 20: `pnpm test` (1,986 passed, 53 skipped)
- Linux Python 3.11: `python -m pytest tests/ -v` (1,540 passed, 9 skipped)
- `git diff --check upstream/main...HEAD`
- `node .\node\dist\index.js secrets . --diff upstream/main --engine patterns --no-auto-update --format json` (zero findings)
- `rafter run --mode fast` (scan `77e6f82e-ebd7-422a-bc14-1f54ab73e68d`): no findings in either changed test file. Those files remained byte-identical after the conflict-free rebase. The repository-wide scan also reported 20 errors, 32 warnings, and 54 notes in unmodified files.

## Spec update

None. This is a test-only change and does not alter CLI behavior.

## Checklist

- [x] Both Node and Python implementations updated
- [x] Tests pass in both (`pnpm test` + `pytest`)
- [x] Versions match in `node/package.json` and `python/pyproject.toml`
- [x] `shared-docs/CLI_SPEC.md` updated (not required because CLI behavior did not change)
- [x] No secrets, credentials, or API keys in the diff
- [x] AI assistance disclosed and included in the commit trailer

Prepared with OpenAI Codex. The commit includes a `Co-Authored-By` trailer.
