### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-29
+
+### Added
+
+- **Rafter Sites CLI + MCP** (Rome-1/securable-bolt#151). New `rafter sites create|scan|list|get` commands and matching MCP tools (`sites_create`/`sites_scan`/`sites_list`/`sites_get`) for Rafter Sites — live-application security monitoring (exposed backends, DNS misconfig, SEO, accessibility) — calling the new API-key-authenticated `/api/static/sites*` endpoints. `sites scan` accepts either a project id or a URL. Node + Python parity, MCP tools resolve the API key from `RAFTER_API_KEY` or stored config rather than exiting, so a missing key fails the one tool call instead of the whole server.
+- Live-tested against production before release, which surfaced and fixed: `--format md` now fails with a clear error instead of silently returning JSON (the Sites API has no markdown representation yet); MCP `sites_scan` now rejects being given both `projectId` and `url` instead of silently preferring `projectId`; a double-slash in constructed request URLs; and unreachable per-status default error messages.
+
 ## [0.9.1] - 2026-07-21
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.9.1
+version: 0.10.0
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/node/src/commands/mcp/server.ts
+++ b/node/src/commands/mcp/server.ts
@@ -15,6 +15,9 @@ import { AuditLogger } from "../../core/audit-logger.js";
 import { ConfigManager, redactConfigSecrets, isSecretConfigKey, maskSecretValue } from "../../core/config-manager.js";
 import { listDocs, resolveDocSelector, fetchDoc } from "../../core/docs-loader.js";
 import { writeSuppression } from "../../core/suppression-writer.js";
+import { apiUrl } from "../../utils/api.js";
+import { describeSitesError, resolveMcpApiKey } from "../sites/errors.js";
+import axios from "axios";
 import { createRequire } from "module";
 
 const _require = createRequire(import.meta.url);
@@ -155,6 +158,56 @@ export function createServer(): Server {
             reason: { type: "string", description: "Why this is a false positive — persisted with the rule. Strongly recommended." },
           },
           required: ["path"],
+        },
+      },
+      {
+        name: "sites_create",
+        description: "Register a URL as a Rafter Site for live-application security monitoring (exposed backends, DNS misconfig, SEO, accessibility) and kick off its first scan. Use when asked to start monitoring a domain/site.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            url: { type: "string", description: "URL of the site to monitor" },
+          },
+          required: ["url"],
+        },
+      },
+      {
+        name: "sites_scan",
+        description: "Trigger a re-scan of an existing Rafter Site. Identify the site by projectId OR url (exactly one required). Use when asked to re-scan or refresh a site's findings.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            projectId: { type: "string", description: "The site's project id (use this or url, not both)" },
+            url: { type: "string", description: "The site's URL (use this or projectId, not both)" },
+            sections: {
+              type: "array",
+              items: { type: "string", enum: ["flight", "security", "dns"] },
+              description: "Subset of scan sections to run. Omit to run all.",
+            },
+          },
+        },
+      },
+      {
+        name: "sites_list",
+        description: "List Rafter Sites registered for monitoring, paginated. Use when asked 'what sites are being monitored?' or to browse before calling sites_get.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            limit: { type: "number", description: "Results per page, 1-100 (default: 25)" },
+            offset: { type: "number", description: "Pagination offset (default: 0)" },
+            include_archived: { type: "boolean", description: "Include archived sites (default: false)" },
+          },
+        },
+      },
+      {
+        name: "sites_get",
+        description: "Get a Rafter Site's status, latest scan run, and findings summary by its project id. Use after sites_list or sites_create to check a specific site's results.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            id: { type: "string", description: "The site's project id" },
+          },
+          required: ["id"],
         },
       },
     ],
@@ -299,6 +352,64 @@ export function createServer(): Server {
           });
         } catch (err: any) {
           return errorResult(`Failed to write suppression: ${err.message || err}`);
+        }
+      }
+
+      case "sites_create": {
+        const url = args?.url as string | undefined;
+        if (!url) return errorResult("url is required");
+        const key = resolveMcpApiKey();
+        if (!key) return errorResult("No API key configured. Set RAFTER_API_KEY or run 'rafter agent config set backend.apiKey <key>'.");
+        try {
+          const { data } = await axios.post(apiUrl("static/sites"), { url }, { headers: { "x-api-key": key } });
+          return textResult(data);
+        } catch (e: any) {
+          return errorResult(describeSitesError(e).message);
+        }
+      }
+
+      case "sites_scan": {
+        const projectId = args?.projectId as string | undefined;
+        const url = args?.url as string | undefined;
+        if (!projectId && !url) return errorResult("Provide exactly one of projectId or url");
+        if (projectId && url) return errorResult("Provide exactly one of projectId or url, not both");
+        const key = resolveMcpApiKey();
+        if (!key) return errorResult("No API key configured. Set RAFTER_API_KEY or run 'rafter agent config set backend.apiKey <key>'.");
+        const body: Record<string, unknown> = projectId ? { projectId } : { url };
+        if (Array.isArray(args?.sections)) body.sections = (args!.sections as unknown[]).map((s) => String(s));
+        try {
+          const { data } = await axios.post(apiUrl("static/sites/scan"), body, { headers: { "x-api-key": key } });
+          return textResult(data);
+        } catch (e: any) {
+          return errorResult(describeSitesError(e).message);
+        }
+      }
+
+      case "sites_list": {
+        const key = resolveMcpApiKey();
+        if (!key) return errorResult("No API key configured. Set RAFTER_API_KEY or run 'rafter agent config set backend.apiKey <key>'.");
+        const params: Record<string, string> = {};
+        if (args?.limit !== undefined) params.limit = String(args.limit);
+        if (args?.offset !== undefined) params.offset = String(args.offset);
+        if (args?.include_archived) params.include_archived = "true";
+        try {
+          const { data } = await axios.get(apiUrl("static/sites"), { params, headers: { "x-api-key": key } });
+          return textResult(data);
+        } catch (e: any) {
+          return errorResult(describeSitesError(e).message);
+        }
+      }
+
+      case "sites_get": {
+        const id = args?.id as string | undefined;
+        if (!id) return errorResult("id is required");
+        const key = resolveMcpApiKey();
+        if (!key) return errorResult("No API key configured. Set RAFTER_API_KEY or run 'rafter agent config set backend.apiKey <key>'.");
+        try {
+          const { data } = await axios.get(apiUrl(`static/sites/${encodeURIComponent(id)}`), { headers: { "x-api-key": key } });
+          return textResult(data);
+        } catch (e: any) {
+          return errorResult(describeSitesError(e).message);
         }
       }
 

--- a/node/src/commands/sites/create.ts
+++ b/node/src/commands/sites/create.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+import axios from "axios";
+import { apiUrl, resolveKey, writePayload, EXIT_GENERAL_ERROR } from "../../utils/api.js";
+import { describeSitesError, rejectUnsupportedFormat } from "./errors.js";
+
+export interface SitesCreateOpts {
+  apiKey?: string;
+  format?: string;
+  quiet?: boolean;
+}
+
+/** Register a URL as a Site and kick off its first scan. Returns the process exit code. */
+export async function runSitesCreate(url: string, opts: SitesCreateOpts): Promise<number> {
+  if (rejectUnsupportedFormat(opts.format)) return EXIT_GENERAL_ERROR;
+  const key = resolveKey(opts.apiKey);
+  try {
+    const { data } = await axios.post(
+      apiUrl("static/sites"),
+      { url },
+      { headers: { "x-api-key": key } }
+    );
+    return writePayload(data, opts.format, opts.quiet);
+  } catch (e: any) {
+    const { message, exitCode } = describeSitesError(e);
+    console.error(`Error: ${message}`);
+    return exitCode;
+  }
+}
+
+export function createSitesCreateCommand(): Command {
+  return new Command("create")
+    .description("Register a site for live monitoring and kick off its first scan")
+    .argument("<url>", "URL of the site to monitor")
+    .option("-k, --api-key <key>", "API key or RAFTER_API_KEY env var")
+    .option("-f, --format <format>", "json | md", "json")
+    .option("--quiet", "suppress status messages")
+    .action(async (url, opts) => {
+      process.exit(await runSitesCreate(url, opts));
+    });
+}

--- a/node/src/commands/sites/errors.ts
+++ b/node/src/commands/sites/errors.ts
@@ -1,0 +1,86 @@
+import {
+  EXIT_GENERAL_ERROR,
+  EXIT_QUOTA_EXHAUSTED,
+  EXIT_INSUFFICIENT_SCOPE,
+  EXIT_SCAN_NOT_FOUND,
+} from "../../utils/api.js";
+import { ConfigManager } from "../../core/config-manager.js";
+
+/**
+ * Resolve the Rafter API key for a context with no CLI flag (e.g. an MCP tool
+ * call). Same precedence as resolveKey() in utils/api.ts (env > stored config)
+ * minus the --api-key flag, but returns undefined instead of calling
+ * process.exit — killing the whole MCP server over one tool's missing key
+ * would take every other tool down with it.
+ */
+export function resolveMcpApiKey(): string | undefined {
+  if (process.env.RAFTER_API_KEY) return process.env.RAFTER_API_KEY;
+  try {
+    const stored = new ConfigManager().get("backend.apiKey");
+    if (typeof stored === "string" && stored.trim()) return stored.trim();
+  } catch {
+    // Config unreadable — fall through.
+  }
+  return undefined;
+}
+
+/** Extract a human-readable message from a Sites API error response body. */
+function errorBodyMessage(e: any): string {
+  const body = e?.response?.data;
+  if (typeof body === "string" && body.trim()) return body;
+  if (body && typeof body === "object") {
+    if (typeof body.error === "string" && body.error) return body.error;
+    if (typeof body.message === "string" && body.message) return body.message;
+  }
+  // Deliberately no non-empty fallback here — an unconditional default (e.g.
+  // "Unknown error") would make every `msg || "<status-specific default>"`
+  // check in describeSitesError() below unreachable, since msg would never
+  // be falsy. Let describeSitesError()'s own per-status defaults apply.
+  return e?.message || "";
+}
+
+export interface SitesErrorResult {
+  message: string;
+  exitCode: number;
+}
+
+/**
+ * The Sites API never returns a `markdown` field, so `--format md` has nothing
+ * to render. Rather than silently falling back to JSON (which looks like
+ * success but produces the wrong format), reject up front with a clear error.
+ * Returns true (and prints the error) when `fmt` is unsupported.
+ */
+export function rejectUnsupportedFormat(fmt: string | undefined): boolean {
+  if (fmt !== "md") return false;
+  console.error("Error: Sites does not support --format md yet, use --format json");
+  return true;
+}
+
+/**
+ * Map a Sites API (/api/static/sites*) error to a CLI-friendly message + exit code.
+ *
+ * Unlike the remote-scan API (see handle403 in utils/api.ts, which infers "quota"
+ * from a `scan_mode` field), the Sites API returns 403 for BOTH wrong API-key
+ * scope and plan/site limits — the only signal is the free-text `error` string.
+ * Never assume 403 == quota here. 404 means "not found or not owned by this
+ * account" — the Sites API deliberately does not distinguish the two.
+ */
+export function describeSitesError(e: any): SitesErrorResult {
+  const status = e?.response?.status;
+  const msg = errorBodyMessage(e);
+
+  switch (status) {
+    case 400:
+      return { message: `Bad request — ${msg}`, exitCode: EXIT_GENERAL_ERROR };
+    case 401:
+      return { message: `Unauthorized — ${msg || "invalid or missing API key"}`, exitCode: EXIT_GENERAL_ERROR };
+    case 403:
+      return { message: `Forbidden — ${msg || "access denied"}`, exitCode: EXIT_INSUFFICIENT_SCOPE };
+    case 404:
+      return { message: `Not found — ${msg || "site not found, or not owned by this account"}`, exitCode: EXIT_SCAN_NOT_FOUND };
+    case 429:
+      return { message: `Rate limited — ${msg || "too many requests, try again later"}`, exitCode: EXIT_QUOTA_EXHAUSTED };
+    default:
+      return { message: msg || "Request failed", exitCode: EXIT_GENERAL_ERROR };
+  }
+}

--- a/node/src/commands/sites/get.ts
+++ b/node/src/commands/sites/get.ts
@@ -1,0 +1,39 @@
+import { Command } from "commander";
+import axios from "axios";
+import { apiUrl, resolveKey, writePayload, EXIT_GENERAL_ERROR } from "../../utils/api.js";
+import { describeSitesError, rejectUnsupportedFormat } from "./errors.js";
+
+export interface SitesGetOpts {
+  apiKey?: string;
+  format?: string;
+  quiet?: boolean;
+}
+
+/** Get a site's status, latest run, and findings summary. Returns the process exit code. */
+export async function runSitesGet(id: string, opts: SitesGetOpts): Promise<number> {
+  if (rejectUnsupportedFormat(opts.format)) return EXIT_GENERAL_ERROR;
+  const key = resolveKey(opts.apiKey);
+  try {
+    const { data } = await axios.get(
+      apiUrl(`static/sites/${encodeURIComponent(id)}`),
+      { headers: { "x-api-key": key } }
+    );
+    return writePayload(data, opts.format, opts.quiet);
+  } catch (e: any) {
+    const { message, exitCode } = describeSitesError(e);
+    console.error(`Error: ${message}`);
+    return exitCode;
+  }
+}
+
+export function createSitesGetCommand(): Command {
+  return new Command("get")
+    .description("Get a site's status, latest run, and findings summary")
+    .argument("<id>", "site's project id")
+    .option("-k, --api-key <key>", "API key or RAFTER_API_KEY env var")
+    .option("-f, --format <format>", "json | md", "json")
+    .option("--quiet", "suppress status messages")
+    .action(async (id, opts) => {
+      process.exit(await runSitesGet(id, opts));
+    });
+}

--- a/node/src/commands/sites/index.ts
+++ b/node/src/commands/sites/index.ts
@@ -1,0 +1,31 @@
+/**
+ * rafter sites — live-application security monitoring ("Sites").
+ *
+ * Subcommands:
+ *   rafter sites create <url>              Register a site, kick off its first scan
+ *   rafter sites scan <projectId-or-url>   Trigger a re-scan of an existing site
+ *   rafter sites list                       List registered sites
+ *   rafter sites get <id>                   Get a site's status + latest run + findings summary
+ */
+import { Command } from "commander";
+import { createSitesCreateCommand } from "./create.js";
+import { createSitesScanCommand } from "./scan.js";
+import { createSitesListCommand } from "./list.js";
+import { createSitesGetCommand } from "./get.js";
+
+export function createSitesCommand(): Command {
+  const sitesGroup = new Command("sites")
+    .description("Manage Rafter Sites — live-application security monitoring");
+
+  sitesGroup.addCommand(createSitesCreateCommand());
+  sitesGroup.addCommand(createSitesScanCommand());
+  sitesGroup.addCommand(createSitesListCommand());
+  sitesGroup.addCommand(createSitesGetCommand());
+
+  // Default action for `rafter sites` with no subcommand — show help.
+  sitesGroup.action(() => {
+    sitesGroup.help();
+  });
+
+  return sitesGroup;
+}

--- a/node/src/commands/sites/list.ts
+++ b/node/src/commands/sites/list.ts
@@ -1,0 +1,49 @@
+import { Command } from "commander";
+import axios from "axios";
+import { apiUrl, resolveKey, writePayload, EXIT_GENERAL_ERROR } from "../../utils/api.js";
+import { describeSitesError, rejectUnsupportedFormat } from "./errors.js";
+
+export interface SitesListOpts {
+  apiKey?: string;
+  format?: string;
+  limit?: string | number;
+  offset?: string | number;
+  includeArchived?: boolean;
+  quiet?: boolean;
+}
+
+/** List registered sites, paginated. Returns the process exit code. */
+export async function runSitesList(opts: SitesListOpts): Promise<number> {
+  if (rejectUnsupportedFormat(opts.format)) return EXIT_GENERAL_ERROR;
+  const key = resolveKey(opts.apiKey);
+  const params: Record<string, string> = {};
+  if (opts.limit !== undefined) params.limit = String(opts.limit);
+  if (opts.offset !== undefined) params.offset = String(opts.offset);
+  if (opts.includeArchived) params.include_archived = "true";
+
+  try {
+    const { data } = await axios.get(
+      apiUrl("static/sites"),
+      { params, headers: { "x-api-key": key } }
+    );
+    return writePayload(data, opts.format, opts.quiet);
+  } catch (e: any) {
+    const { message, exitCode } = describeSitesError(e);
+    console.error(`Error: ${message}`);
+    return exitCode;
+  }
+}
+
+export function createSitesListCommand(): Command {
+  return new Command("list")
+    .description("List registered sites")
+    .option("-k, --api-key <key>", "API key or RAFTER_API_KEY env var")
+    .option("-f, --format <format>", "json | md", "json")
+    .option("--limit <limit>", "results per page, 1-100 (default: 25)")
+    .option("--offset <offset>", "pagination offset (default: 0)")
+    .option("--include-archived", "include archived sites")
+    .option("--quiet", "suppress status messages")
+    .action(async (opts) => {
+      process.exit(await runSitesList(opts));
+    });
+}

--- a/node/src/commands/sites/scan.ts
+++ b/node/src/commands/sites/scan.ts
@@ -1,0 +1,69 @@
+import { Command } from "commander";
+import axios from "axios";
+import { apiUrl, resolveKey, writePayload, EXIT_GENERAL_ERROR } from "../../utils/api.js";
+import { describeSitesError, rejectUnsupportedFormat } from "./errors.js";
+
+const VALID_SECTIONS = new Set(["flight", "security", "dns"]);
+
+/** True when the argument parses as an absolute URL (has a scheme); false → treat as a project id. */
+function looksLikeUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface SitesScanOpts {
+  apiKey?: string;
+  format?: string;
+  sections?: string;
+  quiet?: boolean;
+}
+
+/** Trigger a re-scan of an existing site, identified by project id or URL. Returns the process exit code. */
+export async function runSitesScan(projectIdOrUrl: string, opts: SitesScanOpts): Promise<number> {
+  if (rejectUnsupportedFormat(opts.format)) return EXIT_GENERAL_ERROR;
+  const key = resolveKey(opts.apiKey);
+
+  const body: Record<string, unknown> = looksLikeUrl(projectIdOrUrl)
+    ? { url: projectIdOrUrl }
+    : { projectId: projectIdOrUrl };
+
+  if (opts.sections) {
+    const sections = String(opts.sections).split(",").map((s) => s.trim()).filter(Boolean);
+    const invalid = sections.filter((s) => !VALID_SECTIONS.has(s));
+    if (invalid.length > 0) {
+      console.error(`Error: invalid --sections value(s): ${invalid.join(", ")} (expected: flight, security, dns)`);
+      return 1;
+    }
+    body.sections = sections;
+  }
+
+  try {
+    const { data } = await axios.post(
+      apiUrl("static/sites/scan"),
+      body,
+      { headers: { "x-api-key": key } }
+    );
+    return writePayload(data, opts.format, opts.quiet);
+  } catch (e: any) {
+    const { message, exitCode } = describeSitesError(e);
+    console.error(`Error: ${message}`);
+    return exitCode;
+  }
+}
+
+export function createSitesScanCommand(): Command {
+  return new Command("scan")
+    .description("Trigger a re-scan of an existing site")
+    .argument("<projectIdOrUrl>", "site's project id, or its URL")
+    .option("-k, --api-key <key>", "API key or RAFTER_API_KEY env var")
+    .option("-f, --format <format>", "json | md", "json")
+    .option("--sections <sections>", "comma-separated subset of flight,security,dns (default: all)")
+    .option("--quiet", "suppress status messages")
+    .action(async (projectIdOrUrl, opts) => {
+      process.exit(await runSitesScan(projectIdOrUrl, opts));
+    });
+}

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -18,6 +18,7 @@ import { createNotifyCommand } from "./commands/notify.js";
 import { createCompletionCommand } from "./commands/completion.js";
 import { createIssuesCommand } from "./commands/issues/index.js";
 import { createReportCommand } from "./commands/report.js";
+import { createSitesCommand } from "./commands/sites/index.js";
 import { checkForUpdate } from "./utils/update-checker.js";
 import { setAgentMode } from "./utils/formatter.js";
 import { createRequire } from "module";
@@ -44,6 +45,9 @@ const program = new Command()
 program.addCommand(createRunCommand());
 program.addCommand(createGetCommand());
 program.addCommand(createUsageCommand());
+
+// Sites — live-application security monitoring
+program.addCommand(createSitesCommand());
 
 // Scan command group (default: remote scan; subcommands: local, remote)
 program.addCommand(createScanGroupCommand());

--- a/node/src/utils/api.ts
+++ b/node/src/utils/api.ts
@@ -2,6 +2,11 @@ import { ConfigManager } from "../core/config-manager.js";
 
 export const API = "https://rafter.so/api/";
 
+/** Join API with a path segment without producing a double slash, regardless of leading/trailing slashes on either side. */
+export function apiUrl(path: string): string {
+  return `${API.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
 // Exit codes
 export const EXIT_SUCCESS = 0;
 export const EXIT_GENERAL_ERROR = 1;

--- a/node/tests/brief.test.ts
+++ b/node/tests/brief.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { execFileSync } from "child_process";
+import { execFileSync, spawnSync } from "child_process";
 import { readFileSync, existsSync } from "fs";
 import path from "path";
 
@@ -15,25 +15,24 @@ const RAFTER_SUBDOCS = [
   "shift-left",
   "finding-triage",
 ];
+const emojiRe =
+  /(?:[\u2600-\u27BF\u{1F1E6}-\u{1F1FF}\u{1F300}-\u{1FAFF}]|[0-9#*]\uFE0F?\u20E3)/u;
 
 function rafter(
   args: string | string[],
+  env?: NodeJS.ProcessEnv,
 ): { stdout: string; stderr: string; exitCode: number } {
   const argList = Array.isArray(args) ? args : args.split(/\s+/);
-  try {
-    const result = execFileSync("node", [CLI, ...argList], {
-      encoding: "utf-8",
-      env: { ...process.env },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    return { stdout: result, stderr: "", exitCode: 0 };
-  } catch (e: any) {
-    return {
-      stdout: e.stdout || "",
-      stderr: e.stderr || "",
-      exitCode: e.status ?? 1,
-    };
-  }
+  const result = spawnSync("node", [CLI, ...argList], {
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return {
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    exitCode: result.status ?? 1,
+  };
 }
 
 beforeAll(() => {
@@ -85,6 +84,19 @@ describe("brief command — topic listing", () => {
 });
 
 describe("brief command — topic rendering", () => {
+  it("renders agent-mode output without terminal formatting", () => {
+    const r = rafter(["--agent", "brief", "scanning"], {
+      CI: "1",
+      FORCE_COLOR: "1",
+    });
+    const output = r.stdout + r.stderr;
+
+    expect(r.exitCode).toBe(0);
+    expect(output).toContain("# Rafter");
+    expect(output).not.toContain("\u001b");
+    expect(output).not.toMatch(emojiRe);
+  });
+
   it("renders scanning topic from skill file", () => {
     const r = rafter("brief scanning");
     expect(r.exitCode).toBe(0);

--- a/node/tests/error-handling-gauntlet.test.ts
+++ b/node/tests/error-handling-gauntlet.test.ts
@@ -277,7 +277,7 @@ describe("ConfigManager — Error Handling", () => {
     const manager = new ConfigManager(configPath);
     const config = manager.load();
     expect(config.agent?.riskLevel).toBe("moderate");
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes("not a JSON object"),
     );
     expect(warningMsg).toBeDefined();
@@ -292,7 +292,7 @@ describe("ConfigManager — Error Handling", () => {
     const manager = new ConfigManager(configPath);
     const config = manager.load();
     expect(config.agent?.riskLevel).toBe("moderate");
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes("agent.riskLevel"),
     );
     expect(warningMsg).toBeDefined();
@@ -309,7 +309,7 @@ describe("ConfigManager — Error Handling", () => {
     const manager = new ConfigManager(configPath);
     const config = manager.load();
     expect(config.agent?.commandPolicy.mode).toBe("approve-dangerous");
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes("agent.commandPolicy.mode"),
     );
     expect(warningMsg).toBeDefined();
@@ -328,7 +328,7 @@ describe("ConfigManager — Error Handling", () => {
     expect(Array.isArray(config.agent?.commandPolicy.blockedPatterns)).toBe(
       true,
     );
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes("blockedPatterns"),
     );
     expect(warningMsg).toBeDefined();
@@ -345,7 +345,7 @@ describe("ConfigManager — Error Handling", () => {
     const manager = new ConfigManager(configPath);
     const config = manager.load();
     expect(typeof config.agent?.audit.retentionDays).toBe("number");
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes("retentionDays"),
     );
     expect(warningMsg).toBeDefined();
@@ -409,7 +409,7 @@ describe("ConfigManager — Error Handling", () => {
     const patterns = config.agent?.scan?.customPatterns ?? [];
     expect(patterns.length).toBe(1);
     expect(patterns[0].name).toBe("valid");
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes("invalid regex"),
     );
     expect(warningMsg).toBeDefined();
@@ -426,7 +426,7 @@ describe("ConfigManager — Error Handling", () => {
     const manager = new ConfigManager(configPath);
     const config = manager.load();
     expect(config.agent?.scan?.excludePaths).toBeUndefined();
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes("excludePaths"),
     );
     expect(warningMsg).toBeDefined();
@@ -448,7 +448,7 @@ describe("ConfigManager — Error Handling", () => {
     const manager = new ConfigManager(configPath);
     const config = manager.load();
     expect(typeof config.agent?.outputFiltering.redactSecrets).toBe("boolean");
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes("redactSecrets"),
     );
     expect(warningMsg).toBeDefined();
@@ -459,7 +459,7 @@ describe("ConfigManager — Error Handling", () => {
     fs.writeFileSync(configPath, JSON.stringify({ version: 42 }));
     const manager = new ConfigManager(configPath);
     manager.load();
-    const warningMsg = stderrSpy.mock.calls.find((c) =>
+    const warningMsg = stderrSpy.mock.calls.find((c: unknown[]) =>
       String(c[0]).includes('"version" must be a string'),
     );
     expect(warningMsg).toBeDefined();
@@ -635,9 +635,25 @@ describe("AuditLogger — Error Paths", () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rafter-audit-gauntlet-"));
+
+    // AuditLogger.log() reads the global ~/.rafter/config.json and no-ops
+    // unless agent.audit.logAllActions is set. Mock the config so log() writes
+    // deterministically regardless of this machine's global config state.
+    vi.spyOn(ConfigManager.prototype, "load").mockReturnValue({
+      version: "1",
+      agent: {
+        riskLevel: "moderate",
+        commandPolicy: { mode: "approve-dangerous", blockedPatterns: [], requireApproval: [] },
+        audit: { retentionDays: 30, logLevel: "info", logAllActions: true },
+        outputFiltering: { redactSecrets: true, blockPatterns: false },
+        notifications: {},
+        scan: {},
+      },
+    } as any);
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 

--- a/node/tests/mcp-server-integration.test.ts
+++ b/node/tests/mcp-server-integration.test.ts
@@ -132,7 +132,7 @@ describe("MCP Server — tool registration and schema", () => {
 
   it("should register exactly 7 tools", async () => {
     const { tools } = await client.listTools();
-    expect(tools).toHaveLength(7);
+    expect(tools).toHaveLength(11);
   });
 
   it("should expose suppress_finding with correct schema", async () => {
@@ -189,6 +189,10 @@ describe("MCP Server — tool registration and schema", () => {
       "list_docs",
       "read_audit_log",
       "scan_secrets",
+      "sites_create",
+      "sites_get",
+      "sites_list",
+      "sites_scan",
       "suppress_finding",
     ]);
   });
@@ -467,7 +471,7 @@ describe("MCP Server — lifecycle", () => {
 
       // Quick sanity — tools are still listed
       const { tools } = await c.listTools();
-      expect(tools).toHaveLength(7);
+      expect(tools).toHaveLength(11);
 
       await c.close();
       await s.close();

--- a/node/tests/mcp-server-stdio.test.ts
+++ b/node/tests/mcp-server-stdio.test.ts
@@ -46,9 +46,9 @@ describe("MCP Server — real stdio transport: tool listing", () => {
     await client.close();
   });
 
-  it("should register exactly 7 tools over stdio", async () => {
+  it("should register exactly 11 tools over stdio", async () => {
     const { tools } = await client.listTools();
-    expect(tools).toHaveLength(7);
+    expect(tools).toHaveLength(11);
   });
 
   it("tool names match expected set", async () => {
@@ -61,6 +61,10 @@ describe("MCP Server — real stdio transport: tool listing", () => {
       "list_docs",
       "read_audit_log",
       "scan_secrets",
+      "sites_create",
+      "sites_get",
+      "sites_list",
+      "sites_scan",
       "suppress_finding",
     ]);
   });
@@ -378,7 +382,7 @@ describe("MCP Server — real stdio transport: lifecycle", () => {
     const { client } = await createConnectedClient();
     // Verify we can list tools (connection works)
     const { tools } = await client.listTools();
-    expect(tools).toHaveLength(7);
+    expect(tools).toHaveLength(11);
     await client.close();
   });
 
@@ -396,7 +400,7 @@ describe("MCP Server — real stdio transport: lifecycle", () => {
     for (let i = 0; i < 3; i++) {
       const { client } = await createConnectedClient();
       const { tools } = await client.listTools();
-      expect(tools).toHaveLength(7);
+      expect(tools).toHaveLength(11);
       await client.close();
       // Let the subprocess's exit propagate before the next spawn.
       if (i < 2) await new Promise((resolve) => setTimeout(resolve, 200));

--- a/node/tests/mcp-sites.test.ts
+++ b/node/tests/mcp-sites.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+/**
+ * Tests for the sites_* MCP tools (sites_create, sites_scan, sites_list,
+ * sites_get) exposed by createServer(). Drives the real request handlers
+ * through an in-memory MCP client/server pair, with axios mocked.
+ */
+
+vi.mock("axios");
+
+vi.mock("../src/core/config-manager.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/core/config-manager.js")>()),
+  ConfigManager: vi.fn().mockImplementation(function () {
+    return {
+      load: vi.fn().mockReturnValue({ version: "1.0" }),
+      get: vi.fn().mockReturnValue(undefined),
+      loadWithPolicy: vi.fn().mockReturnValue({ version: "1.0" }),
+    };
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: vi.fn(),
+}));
+
+import axios from "axios";
+import { createServer } from "../src/commands/mcp/server.js";
+
+const mockedAxios = vi.mocked(axios, true);
+
+let client: Client;
+let server: Server;
+
+async function setupClientServer() {
+  server = createServer();
+  client = new Client({ name: "test-client", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+}
+
+async function teardown() {
+  try { await client.close(); } catch { /* ignore */ }
+  try { await server.close(); } catch { /* ignore */ }
+}
+
+function parseResult(result: any) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("MCP sites_* tools", () => {
+  beforeAll(async () => {
+    process.env.RAFTER_API_KEY = "test-key";
+    await setupClientServer();
+  });
+  afterAll(async () => {
+    delete process.env.RAFTER_API_KEY;
+    await teardown();
+  });
+
+  it("sites_create success", async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { site: { id: "p1" }, run: { id: "r1" }, created: true },
+    });
+    const result = await client.callTool({ name: "sites_create", arguments: { url: "https://example.com" } });
+    expect(result.isError).toBeFalsy();
+    expect(parseResult(result)).toEqual({ site: { id: "p1" }, run: { id: "r1" }, created: true });
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites",
+      { url: "https://example.com" },
+      { headers: { "x-api-key": "test-key" } }
+    );
+  });
+
+  it("sites_create 401", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 401, data: { error: "invalid key" } } });
+    const result = await client.callTool({ name: "sites_create", arguments: { url: "https://example.com" } });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toBe("Unauthorized — invalid key");
+  });
+
+  it("sites_create 403 wrong scope", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 403, data: { error: "insufficient scope" } } });
+    const result = await client.callTool({ name: "sites_create", arguments: { url: "https://example.com" } });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain("insufficient scope");
+  });
+
+  it("sites_scan by projectId", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { run: { id: "r1" } } });
+    const result = await client.callTool({ name: "sites_scan", arguments: { projectId: "proj-1" } });
+    expect(result.isError).toBeFalsy();
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites/scan",
+      { projectId: "proj-1" },
+      expect.anything()
+    );
+  });
+
+  it("sites_scan requires projectId or url", async () => {
+    const result = await client.callTool({ name: "sites_scan", arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toBe("Provide exactly one of projectId or url");
+  });
+
+  it("sites_scan rejects when both projectId and url are provided", async () => {
+    const callsBefore = mockedAxios.post.mock.calls.length;
+    const result = await client.callTool({
+      name: "sites_scan",
+      arguments: { projectId: "proj-1", url: "https://example.com" },
+    });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toBe("Provide exactly one of projectId or url, not both");
+    expect(mockedAxios.post.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("sites_scan 404 (not owned)", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 404, data: { error: "not found" } } });
+    const result = await client.callTool({ name: "sites_scan", arguments: { projectId: "proj-1" } });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toBe("Not found — not found");
+  });
+
+  it("sites_list success with params", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { sites: [], limit: 5, offset: 0, has_more: false } });
+    const result = await client.callTool({ name: "sites_list", arguments: { limit: 5, include_archived: true } });
+    expect(result.isError).toBeFalsy();
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites",
+      { params: { limit: "5", include_archived: "true" }, headers: { "x-api-key": "test-key" } }
+    );
+  });
+
+  it("sites_list 429", async () => {
+    mockedAxios.get.mockRejectedValueOnce({ response: { status: 429, data: { error: "Rate limit exceeded" } } });
+    const result = await client.callTool({ name: "sites_list", arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toBe("Rate limited — Rate limit exceeded");
+  });
+
+  it("sites_get success", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: { site: { id: "p1" }, latest_run: null, security: { critical: 0, warn: 0, info: 0, total: 0 } },
+    });
+    const result = await client.callTool({ name: "sites_get", arguments: { id: "p1" } });
+    expect(result.isError).toBeFalsy();
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites/p1",
+      { headers: { "x-api-key": "test-key" } }
+    );
+  });
+
+  it("sites_get 404", async () => {
+    mockedAxios.get.mockRejectedValueOnce({ response: { status: 404, data: { error: "not found" } } });
+    const result = await client.callTool({ name: "sites_get", arguments: { id: "nonexistent" } });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toBe("Not found — not found");
+  });
+
+  it("sites_get requires id", async () => {
+    const result = await client.callTool({ name: "sites_get", arguments: {} });
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("MCP sites_* tools — missing API key", () => {
+  it("returns a helpful error instead of crashing the server", async () => {
+    delete process.env.RAFTER_API_KEY;
+    const s = createServer();
+    const c = new Client({ name: "no-key-client", version: "1.0.0" });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([s.connect(st), c.connect(ct)]);
+
+    const result = await c.callTool({ name: "sites_get", arguments: { id: "p1" } });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain("No API key configured");
+
+    await c.close();
+    await s.close();
+  });
+});

--- a/node/tests/sites-cli.test.ts
+++ b/node/tests/sites-cli.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for `rafter sites` — CLI commands for Rafter Sites (live-application
+ * security monitoring). All tests mock axios so no network calls are made.
+ */
+
+vi.mock("axios");
+
+import axios from "axios";
+import { runSitesCreate } from "../src/commands/sites/create.js";
+import { runSitesScan } from "../src/commands/sites/scan.js";
+import { runSitesList } from "../src/commands/sites/list.js";
+import { runSitesGet } from "../src/commands/sites/get.js";
+import { EXIT_SUCCESS, EXIT_GENERAL_ERROR, EXIT_INSUFFICIENT_SCOPE, EXIT_SCAN_NOT_FOUND, EXIT_QUOTA_EXHAUSTED } from "../src/utils/api.js";
+
+const mockedAxios = vi.mocked(axios, true);
+const opts = { apiKey: "test-key", format: "json", quiet: true };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("sites create", () => {
+  it("returns EXIT_SUCCESS and posts the url on success", async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { site: { id: "p1" }, run: { id: "r1" }, created: true },
+    });
+
+    const code = await runSitesCreate("https://example.com", opts);
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites",
+      { url: "https://example.com" },
+      { headers: { "x-api-key": "test-key" } }
+    );
+  });
+
+  it("returns EXIT_GENERAL_ERROR for 401 with the server's error message", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 401, data: { error: "bad key" } } });
+    const code = await runSitesCreate("https://example.com", opts);
+    expect(code).toBe(EXIT_GENERAL_ERROR);
+    expect(console.error).toHaveBeenCalledWith("Error: Unauthorized — bad key");
+  });
+
+  it("uses the status-specific default message when the server sends no error field", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 401, data: {} } });
+    const code = await runSitesCreate("https://example.com", opts);
+    expect(code).toBe(EXIT_GENERAL_ERROR);
+    expect(console.error).toHaveBeenCalledWith("Error: Unauthorized — invalid or missing API key");
+  });
+
+  it("rejects --format md without calling the API", async () => {
+    const code = await runSitesCreate("https://example.com", { ...opts, format: "md" });
+    expect(code).toBe(EXIT_GENERAL_ERROR);
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Error: Sites does not support --format md yet, use --format json"
+    );
+  });
+
+  it("returns EXIT_INSUFFICIENT_SCOPE for 403 wrong scope", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 403, data: { error: "insufficient scope: requires read-and-scan" } } });
+    const code = await runSitesCreate("https://example.com", opts);
+    expect(code).toBe(EXIT_INSUFFICIENT_SCOPE);
+  });
+
+  it("returns EXIT_QUOTA_EXHAUSTED for 429", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 429, data: { error: "Rate limit exceeded" } } });
+    const code = await runSitesCreate("https://example.com", opts);
+    expect(code).toBe(EXIT_QUOTA_EXHAUSTED);
+  });
+});
+
+describe("sites scan", () => {
+  it("sends { projectId } when given a bare id", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { run: { id: "r1" } } });
+    const code = await runSitesScan("proj-123", opts);
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites/scan",
+      { projectId: "proj-123" },
+      expect.anything()
+    );
+  });
+
+  it("sends { url } when given a URL", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { run: { id: "r1" } } });
+    const code = await runSitesScan("https://example.com", opts);
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites/scan",
+      { url: "https://example.com" },
+      expect.anything()
+    );
+  });
+
+  it("rejects --format md without calling the API", async () => {
+    const code = await runSitesScan("proj-123", { ...opts, format: "md" });
+    expect(code).toBe(EXIT_GENERAL_ERROR);
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Error: Sites does not support --format md yet, use --format json"
+    );
+  });
+
+  it("includes sections when provided", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { run: { id: "r1" } } });
+    await runSitesScan("proj-123", { ...opts, sections: "security, dns" });
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining("/static/sites/scan"),
+      { projectId: "proj-123", sections: ["security", "dns"] },
+      expect.anything()
+    );
+  });
+
+  it("rejects an invalid section without calling the API", async () => {
+    const code = await runSitesScan("proj-123", { ...opts, sections: "bogus" });
+    expect(code).toBe(1);
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it("returns EXIT_SCAN_NOT_FOUND for 404 (not owned)", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 404, data: { error: "not found" } } });
+    const code = await runSitesScan("proj-123", opts);
+    expect(code).toBe(EXIT_SCAN_NOT_FOUND);
+    expect(console.error).toHaveBeenCalledWith("Error: Not found — not found");
+  });
+
+  it("uses the status-specific default message for 404 when the server sends no error field", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 404, data: {} } });
+    const code = await runSitesScan("proj-123", opts);
+    expect(code).toBe(EXIT_SCAN_NOT_FOUND);
+    expect(console.error).toHaveBeenCalledWith("Error: Not found — site not found, or not owned by this account");
+  });
+
+  it("returns EXIT_INSUFFICIENT_SCOPE for 403 run-limit reached", async () => {
+    mockedAxios.post.mockRejectedValueOnce({ response: { status: 403, data: { error: "run limit reached" } } });
+    const code = await runSitesScan("proj-123", opts);
+    expect(code).toBe(EXIT_INSUFFICIENT_SCOPE);
+  });
+});
+
+describe("sites list", () => {
+  it("passes limit/offset/include_archived as query params", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { sites: [], limit: 10, offset: 5, has_more: false } });
+    const code = await runSitesList({ ...opts, limit: 10, offset: 5, includeArchived: true });
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites",
+      { params: { limit: "10", offset: "5", include_archived: "true" }, headers: { "x-api-key": "test-key" } }
+    );
+  });
+
+  it("returns EXIT_GENERAL_ERROR for 401 with the status-specific default message", async () => {
+    mockedAxios.get.mockRejectedValueOnce({ response: { status: 401 } });
+    const code = await runSitesList(opts);
+    expect(code).toBe(EXIT_GENERAL_ERROR);
+    expect(console.error).toHaveBeenCalledWith("Error: Unauthorized — invalid or missing API key");
+  });
+
+  it("rejects --format md without calling the API", async () => {
+    const code = await runSitesList({ ...opts, format: "md" });
+    expect(code).toBe(EXIT_GENERAL_ERROR);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Error: Sites does not support --format md yet, use --format json"
+    );
+  });
+});
+
+describe("sites get", () => {
+  it("returns EXIT_SUCCESS on success", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { site: { id: "p1" }, latest_run: null, security: { critical: 0, warn: 0, info: 0, total: 0 } } });
+    const code = await runSitesGet("p1", opts);
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      "https://rafter.so/api/static/sites/p1",
+      { headers: { "x-api-key": "test-key" } }
+    );
+  });
+
+  it("returns EXIT_SCAN_NOT_FOUND for 404 (not owned/not found)", async () => {
+    mockedAxios.get.mockRejectedValueOnce({ response: { status: 404, data: { error: "not found" } } });
+    const code = await runSitesGet("nonexistent", opts);
+    expect(code).toBe(EXIT_SCAN_NOT_FOUND);
+    expect(console.error).toHaveBeenCalledWith("Error: Not found — not found");
+  });
+
+  it("returns EXIT_QUOTA_EXHAUSTED for 429 with the server's message", async () => {
+    mockedAxios.get.mockRejectedValueOnce({ response: { status: 429, data: { error: "Rate limit exceeded", retryAfter: 30 } } });
+    const code = await runSitesGet("p1", opts);
+    expect(code).toBe(EXIT_QUOTA_EXHAUSTED);
+    expect(console.error).toHaveBeenCalledWith("Error: Rate limited — Rate limit exceeded");
+  });
+
+  it("rejects --format md without calling the API", async () => {
+    const code = await runSitesGet("p1", { ...opts, format: "md" });
+    expect(code).toBe(EXIT_GENERAL_ERROR);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Error: Sites does not support --format md yet, use --format json"
+    );
+  });
+});

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.9.1"
+version = "0.10.0"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/__main__.py
+++ b/python/rafter_cli/__main__.py
@@ -16,6 +16,7 @@ from .commands.notify import notify_app
 from .commands.policy import policy_app
 from .commands.report import report_main
 from .commands.scan import scan_app, secrets_app
+from .commands.sites import sites_app
 from .commands.skill import skill_app
 from .utils.formatter import set_agent_mode
 
@@ -110,6 +111,7 @@ app.add_typer(issues_app)
 app.add_typer(mcp_app)
 app.add_typer(notify_app)
 app.add_typer(policy_app)
+app.add_typer(sites_app)
 app.add_typer(skill_app)
 app.command("report")(report_main)
 

--- a/python/rafter_cli/commands/mcp_server.py
+++ b/python/rafter_cli/commands/mcp_server.py
@@ -7,6 +7,7 @@ import sys
 from dataclasses import asdict
 from datetime import datetime, timezone
 
+import requests
 import typer
 
 from ..core.audit_logger import AuditLogger
@@ -21,6 +22,8 @@ from ..core.docs_loader import fetch_doc, list_docs, resolve_doc_selector
 from ..scanners.betterleaks import BetterleaksScanner
 from ..scanners.regex_scanner import RegexScanner, ScanResult
 from ..scanners.union import union_scan_results
+from ..utils.api import API_TIMEOUT
+from .sites import SITES_API_BASE, describe_sites_error, resolve_mcp_api_key
 
 mcp_app = typer.Typer(
     name="mcp",
@@ -199,6 +202,86 @@ def handle_suppress_finding(
     return {"ok": True, **result}
 
 
+def _require_mcp_api_key() -> str:
+    """Resolve the Sites API key for an MCP tool call, raising instead of exiting
+    the process — a missing key should fail just this one tool call, not take
+    down the whole MCP server (see resolve_mcp_api_key's docstring)."""
+    key = resolve_mcp_api_key()
+    if not key:
+        raise RuntimeError(
+            "No API key configured. Set RAFTER_API_KEY or run "
+            "'rafter agent config set backend.apiKey <key>'."
+        )
+    return key
+
+
+def handle_sites_create(url: str) -> dict:
+    """Register a URL as a Rafter Site and kick off its first scan."""
+    key = _require_mcp_api_key()
+    resp = requests.post(SITES_API_BASE, headers={"x-api-key": key}, json={"url": url}, timeout=API_TIMEOUT)
+    if resp.status_code != 200:
+        message, _ = describe_sites_error(resp)
+        raise RuntimeError(message)
+    return resp.json()
+
+
+def handle_sites_scan(
+    project_id: "str | None" = None,
+    url: "str | None" = None,
+    sections: "list[str] | None" = None,
+) -> dict:
+    """Trigger a re-scan of an existing Rafter Site, identified by projectId XOR url."""
+    if project_id and url:
+        raise RuntimeError("Provide exactly one of projectId or url, not both")
+    if not project_id and not url:
+        raise RuntimeError("Provide projectId or url")
+
+    key = _require_mcp_api_key()
+    body: dict = {"projectId": project_id} if project_id else {"url": url}
+    if sections:
+        body["sections"] = list(sections)
+
+    resp = requests.post(f"{SITES_API_BASE}/scan", headers={"x-api-key": key}, json=body, timeout=API_TIMEOUT)
+    if resp.status_code != 200:
+        message, _ = describe_sites_error(resp)
+        raise RuntimeError(message)
+    return resp.json()
+
+
+def handle_sites_list(
+    limit: "int | None" = None,
+    offset: "int | None" = None,
+    include_archived: bool = False,
+) -> dict:
+    """List Rafter Sites registered for monitoring, paginated."""
+    key = _require_mcp_api_key()
+    params: dict = {}
+    if limit is not None:
+        params["limit"] = str(limit)
+    if offset is not None:
+        params["offset"] = str(offset)
+    if include_archived:
+        params["include_archived"] = "true"
+
+    resp = requests.get(SITES_API_BASE, headers={"x-api-key": key}, params=params, timeout=API_TIMEOUT)
+    if resp.status_code != 200:
+        message, _ = describe_sites_error(resp)
+        raise RuntimeError(message)
+    return resp.json()
+
+
+def handle_sites_get(id: str) -> dict:
+    """Get a Rafter Site's status, latest scan run, and findings summary."""
+    from urllib.parse import quote
+
+    key = _require_mcp_api_key()
+    resp = requests.get(f"{SITES_API_BASE}/{quote(id, safe='')}", headers={"x-api-key": key}, timeout=API_TIMEOUT)
+    if resp.status_code != 200:
+        message, _ = describe_sites_error(resp)
+        raise RuntimeError(message)
+    return resp.json()
+
+
 # ── MCP server factory ────────────────────────────────────────────────
 
 
@@ -295,6 +378,61 @@ def create_mcp_server():
             reason: Why this is a false positive — persisted with the rule. Strongly recommended.
         """
         return json.dumps(handle_suppress_finding(path, rules, reason))
+
+    @mcp.tool()
+    def sites_create(url: str) -> str:
+        """Register a URL as a Rafter Site for live-application security monitoring
+        (exposed backends, DNS misconfig, SEO, accessibility) and kick off its
+        first scan. Use when asked to start monitoring a domain/site.
+
+        Args:
+            url: URL of the site to monitor.
+        """
+        return json.dumps(handle_sites_create(url))
+
+    @mcp.tool()
+    def sites_scan(
+        projectId: str | None = None,
+        url: str | None = None,
+        sections: list[str] | None = None,
+    ) -> str:
+        """Trigger a re-scan of an existing Rafter Site. Identify the site by
+        projectId OR url (exactly one required). Use when asked to re-scan or
+        refresh a site's findings.
+
+        Args:
+            projectId: The site's project id (use this or url, not both).
+            url: The site's URL (use this or projectId, not both).
+            sections: Subset of scan sections to run (flight, security, dns). Omit to run all.
+        """
+        return json.dumps(handle_sites_scan(projectId, url, sections))
+
+    @mcp.tool()
+    def sites_list(
+        limit: int | None = None,
+        offset: int | None = None,
+        include_archived: bool = False,
+    ) -> str:
+        """List Rafter Sites registered for monitoring, paginated. Use when asked
+        'what sites are being monitored?' or to browse before calling sites_get.
+
+        Args:
+            limit: Results per page, 1-100 (default: 25).
+            offset: Pagination offset (default: 0).
+            include_archived: Include archived sites (default: false).
+        """
+        return json.dumps(handle_sites_list(limit, offset, include_archived))
+
+    @mcp.tool()
+    def sites_get(id: str) -> str:
+        """Get a Rafter Site's status, latest scan run, and findings summary by
+        its project id. Use after sites_list or sites_create to check a
+        specific site's results.
+
+        Args:
+            id: The site's project id.
+        """
+        return json.dumps(handle_sites_get(id))
 
     @mcp.resource("rafter://config")
     def config_resource() -> str:

--- a/python/rafter_cli/commands/sites.py
+++ b/python/rafter_cli/commands/sites.py
@@ -1,0 +1,246 @@
+"""Sites commands: create, scan, list, get — live-application security monitoring.
+
+Rafter Sites scans a registered domain for exposed backends, DNS misconfig,
+SEO, and accessibility issues. Every route lives under
+``https://rafter.so/api/static/sites`` and requires an ``x-api-key`` header.
+
+Mirrors ``node/src/commands/sites/*.ts`` behaviorally (same commands, flags,
+error messages, and exit codes) — see that directory plus
+``node/src/commands/sites/errors.ts`` for the reference implementation this
+was built against.
+"""
+from __future__ import annotations
+
+import sys
+from urllib.parse import quote, urlparse
+
+import requests
+import typer
+
+from ..utils.api import (
+    API_BASE,
+    API_TIMEOUT,
+    EXIT_GENERAL_ERROR,
+    EXIT_INSUFFICIENT_SCOPE,
+    EXIT_QUOTA_EXHAUSTED,
+    EXIT_SCAN_NOT_FOUND,
+    resolve_key,
+    write_payload,
+)
+
+SITES_API_BASE = f"{API_BASE}static/sites"
+
+VALID_SECTIONS = {"flight", "security", "dns"}
+
+
+def _looks_like_url(value: str) -> bool:
+    """True when ``value`` parses as an absolute URL (has a scheme); false → treat as a project id."""
+    try:
+        parsed = urlparse(value)
+        return bool(parsed.scheme and parsed.netloc)
+    except ValueError:
+        return False
+
+
+def _error_body_message(resp: "requests.Response") -> str:
+    """Extract a human-readable message from a Sites API error response body."""
+    try:
+        body = resp.json()
+    except Exception:
+        return resp.text or ""
+    if isinstance(body, dict):
+        if isinstance(body.get("error"), str) and body["error"]:
+            return body["error"]
+        if isinstance(body.get("message"), str) and body["message"]:
+            return body["message"]
+    return resp.text or ""
+
+
+def describe_sites_error(resp: "requests.Response") -> tuple[str, int]:
+    """Map a Sites API error response to a (message, exit_code) pair.
+
+    Unlike the remote-scan API (``handle_403`` in ``utils/api.py``, which infers
+    "quota" from a ``scan_mode`` field), the Sites API returns 403 for BOTH wrong
+    API-key scope and plan/site limits — the only signal is the free-text
+    ``error`` string, so 403 is never assumed to mean quota here. 404 means "not
+    found or not owned by this account" — the Sites API deliberately does not
+    distinguish the two.
+    """
+    status = resp.status_code
+    msg = _error_body_message(resp)
+
+    if status == 400:
+        return f"Bad request — {msg}", EXIT_GENERAL_ERROR
+    if status == 401:
+        return f"Unauthorized — {msg or 'invalid or missing API key'}", EXIT_GENERAL_ERROR
+    if status == 403:
+        return f"Forbidden — {msg or 'access denied'}", EXIT_INSUFFICIENT_SCOPE
+    if status == 404:
+        return f"Not found — {msg or 'site not found, or not owned by this account'}", EXIT_SCAN_NOT_FOUND
+    if status == 429:
+        return f"Rate limited — {msg or 'too many requests, try again later'}", EXIT_QUOTA_EXHAUSTED
+    return msg or "Request failed", EXIT_GENERAL_ERROR
+
+
+def reject_unsupported_format(fmt: str) -> bool:
+    """The Sites API never returns a ``markdown`` field, so ``--format md`` has
+    nothing to render. Rather than silently falling back to JSON (which looks
+    like success but produces the wrong format), reject up front with a clear
+    error. Returns True (and prints the error) when ``fmt`` is unsupported.
+    """
+    if fmt != "md":
+        return False
+    print("Error: Sites does not support --format md yet, use --format json", file=sys.stderr)
+    return True
+
+
+def resolve_mcp_api_key() -> "str | None":
+    """Resolve the Rafter API key for a context with no CLI flag (an MCP tool
+    call). Same precedence as ``resolve_key()`` (env > stored config) minus the
+    ``--api-key`` flag, but returns None instead of calling ``sys.exit`` —
+    killing the whole MCP server over one tool's missing key would take every
+    other tool down with it.
+    """
+    import os
+
+    env_key = os.environ.get("RAFTER_API_KEY")
+    if env_key:
+        return env_key
+    try:
+        from ..core.config_manager import ConfigManager
+
+        stored = ConfigManager().get("backend.api_key")
+        if isinstance(stored, str) and stored.strip():
+            return stored.strip()
+    except Exception:
+        pass  # config unreadable — fall through
+    return None
+
+
+sites_app = typer.Typer(
+    name="sites",
+    help="Manage Rafter Sites — live-application security monitoring",
+    no_args_is_help=True,
+)
+
+
+@sites_app.command("create")
+def sites_create(
+    url: str = typer.Argument(..., help="URL of the site to monitor"),
+    api_key: "str | None" = typer.Option(None, "--api-key", "-k", envvar="RAFTER_API_KEY", help="API key"),
+    fmt: str = typer.Option("json", "--format", "-f", help="json | md"),
+    quiet: bool = typer.Option(False, "--quiet", help="suppress status messages"),
+):
+    """Register a site for live monitoring and kick off its first scan."""
+    if reject_unsupported_format(fmt):
+        raise typer.Exit(code=EXIT_GENERAL_ERROR)
+    key = resolve_key(api_key)
+    resp = requests.post(
+        SITES_API_BASE,
+        headers={"x-api-key": key},
+        json={"url": url},
+        timeout=API_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        message, exit_code = describe_sites_error(resp)
+        print(f"Error: {message}", file=sys.stderr)
+        raise typer.Exit(code=exit_code)
+    write_payload(resp.json(), fmt, quiet)
+
+
+@sites_app.command("scan")
+def sites_scan(
+    project_id_or_url: str = typer.Argument(..., help="site's project id, or its URL"),
+    api_key: "str | None" = typer.Option(None, "--api-key", "-k", envvar="RAFTER_API_KEY", help="API key"),
+    fmt: str = typer.Option("json", "--format", "-f", help="json | md"),
+    sections: "str | None" = typer.Option(None, "--sections", help="comma-separated subset of flight,security,dns (default: all)"),
+    quiet: bool = typer.Option(False, "--quiet", help="suppress status messages"),
+):
+    """Trigger a re-scan of an existing site."""
+    if reject_unsupported_format(fmt):
+        raise typer.Exit(code=EXIT_GENERAL_ERROR)
+
+    body: dict = {"url": project_id_or_url} if _looks_like_url(project_id_or_url) else {"projectId": project_id_or_url}
+
+    if sections:
+        section_list = [s.strip() for s in sections.split(",") if s.strip()]
+        invalid = [s for s in section_list if s not in VALID_SECTIONS]
+        if invalid:
+            print(
+                f"Error: invalid --sections value(s): {', '.join(invalid)} (expected: flight, security, dns)",
+                file=sys.stderr,
+            )
+            raise typer.Exit(code=EXIT_GENERAL_ERROR)
+        body["sections"] = section_list
+
+    key = resolve_key(api_key)
+    resp = requests.post(
+        f"{SITES_API_BASE}/scan",
+        headers={"x-api-key": key},
+        json=body,
+        timeout=API_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        message, exit_code = describe_sites_error(resp)
+        print(f"Error: {message}", file=sys.stderr)
+        raise typer.Exit(code=exit_code)
+    write_payload(resp.json(), fmt, quiet)
+
+
+@sites_app.command("list")
+def sites_list(
+    api_key: "str | None" = typer.Option(None, "--api-key", "-k", envvar="RAFTER_API_KEY", help="API key"),
+    fmt: str = typer.Option("json", "--format", "-f", help="json | md"),
+    limit: "int | None" = typer.Option(None, "--limit", help="results per page, 1-100 (default: 25)"),
+    offset: "int | None" = typer.Option(None, "--offset", help="pagination offset (default: 0)"),
+    include_archived: bool = typer.Option(False, "--include-archived", help="include archived sites"),
+    quiet: bool = typer.Option(False, "--quiet", help="suppress status messages"),
+):
+    """List registered sites."""
+    if reject_unsupported_format(fmt):
+        raise typer.Exit(code=EXIT_GENERAL_ERROR)
+
+    params: dict = {}
+    if limit is not None:
+        params["limit"] = str(limit)
+    if offset is not None:
+        params["offset"] = str(offset)
+    if include_archived:
+        params["include_archived"] = "true"
+
+    key = resolve_key(api_key)
+    resp = requests.get(
+        SITES_API_BASE,
+        headers={"x-api-key": key},
+        params=params,
+        timeout=API_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        message, exit_code = describe_sites_error(resp)
+        print(f"Error: {message}", file=sys.stderr)
+        raise typer.Exit(code=exit_code)
+    write_payload(resp.json(), fmt, quiet)
+
+
+@sites_app.command("get")
+def sites_get(
+    id: str = typer.Argument(..., help="site's project id"),
+    api_key: "str | None" = typer.Option(None, "--api-key", "-k", envvar="RAFTER_API_KEY", help="API key"),
+    fmt: str = typer.Option("json", "--format", "-f", help="json | md"),
+    quiet: bool = typer.Option(False, "--quiet", help="suppress status messages"),
+):
+    """Get a site's status, latest run, and findings summary."""
+    if reject_unsupported_format(fmt):
+        raise typer.Exit(code=EXIT_GENERAL_ERROR)
+    key = resolve_key(api_key)
+    site_id = quote(id, safe="")
+    resp = requests.get(
+        f"{SITES_API_BASE}/{site_id}",
+        headers={"x-api-key": key},
+        timeout=API_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        message, exit_code = describe_sites_error(resp)
+        print(f"Error: {message}", file=sys.stderr)
+        raise typer.Exit(code=exit_code)
+    write_payload(resp.json(), fmt, quiet)

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.9.1
+version: 0.10.0
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/tests/test_brief.py
+++ b/python/tests/test_brief.py
@@ -1,6 +1,8 @@
 """Tests for the brief command — knowledge delivery."""
 from __future__ import annotations
 
+import re
+
 import pytest
 from typer.testing import CliRunner
 
@@ -18,8 +20,22 @@ from rafter_cli.commands.brief import (
     PLATFORM_GUIDES,
     TOPIC_DESCRIPTIONS,
 )
+from rafter_cli.utils.formatter import set_agent_mode
 
 runner = CliRunner()
+EMOJI_RE = re.compile(
+    "[\u2600-\u27BF\U0001F1E6-\U0001F1FF\U0001F300-\U0001FAFF]"
+    "|[0-9#*]\ufe0f?\u20e3"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agent_mode():
+    set_agent_mode(False)
+    try:
+        yield
+    finally:
+        set_agent_mode(False)
 
 
 class TestTopicListing:
@@ -53,6 +69,14 @@ class TestTopicListing:
 
 
 class TestTopicRendering:
+    def test_agent_mode_has_no_terminal_formatting(self):
+        result = runner.invoke(app, ["--agent", "brief", "scanning"], color=True)
+
+        assert result.exit_code == 0
+        assert "# Rafter" in result.output
+        assert "\x1b" not in result.output
+        assert EMOJI_RE.search(result.output) is None
+
     def test_scanning_topic_loads_skill(self):
         result = runner.invoke(app, ["brief", "scanning"])
         assert result.exit_code == 0

--- a/python/tests/test_mcp_server.py
+++ b/python/tests/test_mcp_server.py
@@ -236,6 +236,7 @@ class TestServerFactory:
             expected = {
                 "scan_secrets", "evaluate_command", "read_audit_log", "get_config",
                 "list_docs", "get_doc", "suppress_finding",
+                "sites_create", "sites_scan", "sites_list", "sites_get",
             }
             assert expected == tool_names
 

--- a/python/tests/test_mcp_server_stdio.py
+++ b/python/tests/test_mcp_server_stdio.py
@@ -127,9 +127,9 @@ class TestToolListing:
         await cleanup(self.session, self.cm)
 
     @pytest.mark.asyncio
-    async def test_registers_exactly_7_tools(self):
+    async def test_registers_exactly_11_tools(self):
         result = await self.session.list_tools()
-        assert len(result.tools) == 7
+        assert len(result.tools) == 11
 
     @pytest.mark.asyncio
     async def test_tool_names_match_expected_set(self):
@@ -142,6 +142,10 @@ class TestToolListing:
             "list_docs",
             "read_audit_log",
             "scan_secrets",
+            "sites_create",
+            "sites_get",
+            "sites_list",
+            "sites_scan",
             "suppress_finding",
         ]
 
@@ -414,7 +418,7 @@ class TestLifecycle:
     async def test_connect_disconnect_cleanly(self):
         session, cm = await create_connected_session()
         result = await session.list_tools()
-        assert len(result.tools) == 7
+        assert len(result.tools) == 11
         await cleanup(session, cm)
 
     @pytest.mark.asyncio
@@ -422,5 +426,5 @@ class TestLifecycle:
         for _ in range(3):
             session, cm = await create_connected_session()
             result = await session.list_tools()
-            assert len(result.tools) == 7
+            assert len(result.tools) == 11
             await cleanup(session, cm)

--- a/python/tests/test_sites.py
+++ b/python/tests/test_sites.py
@@ -1,0 +1,317 @@
+"""Tests for `rafter sites` CLI commands and the sites_* MCP tools.
+
+Mirrors node/tests/sites-cli.test.ts and node/tests/mcp-sites.test.ts —
+mocked requests only, no live API calls.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from rafter_cli.commands.sites import sites_app
+from rafter_cli.commands.mcp_server import (
+    handle_sites_create,
+    handle_sites_get,
+    handle_sites_list,
+    handle_sites_scan,
+)
+from rafter_cli.utils.api import (
+    EXIT_GENERAL_ERROR,
+    EXIT_INSUFFICIENT_SCOPE,
+    EXIT_QUOTA_EXHAUSTED,
+    EXIT_SCAN_NOT_FOUND,
+    EXIT_SUCCESS,
+)
+
+runner = CliRunner()
+
+
+def _mock_response(status_code: int, json_body: dict | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body or {}
+    resp.text = json.dumps(json_body) if json_body else ""
+    return resp
+
+
+# ── rafter sites create ──────────────────────────────────────────────
+
+
+class TestSitesCreateCli:
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_success(self, mock_post):
+        mock_post.return_value = _mock_response(
+            200, {"site": {"id": "p1"}, "run": {"id": "r1"}, "created": True}
+        )
+        result = runner.invoke(
+            sites_app, ["create", "https://example.com", "-k", "test-key"]
+        )
+        assert result.exit_code == EXIT_SUCCESS, result.output
+        assert '"created": true' in result.output
+        args, kwargs = mock_post.call_args
+        assert args[0].endswith("/static/sites")
+        assert kwargs["json"] == {"url": "https://example.com"}
+        assert kwargs["headers"] == {"x-api-key": "test-key"}
+
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_401(self, mock_post):
+        mock_post.return_value = _mock_response(401, {"error": "bad key"})
+        result = runner.invoke(
+            sites_app, ["create", "https://example.com", "-k", "test-key"]
+        )
+        assert result.exit_code == EXIT_GENERAL_ERROR
+
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_403_wrong_scope(self, mock_post):
+        mock_post.return_value = _mock_response(
+            403, {"error": "insufficient scope: requires read-and-scan"}
+        )
+        result = runner.invoke(
+            sites_app, ["create", "https://example.com", "-k", "test-key"]
+        )
+        assert result.exit_code == EXIT_INSUFFICIENT_SCOPE
+
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_429(self, mock_post):
+        mock_post.return_value = _mock_response(429, {"error": "Rate limit exceeded"})
+        result = runner.invoke(
+            sites_app, ["create", "https://example.com", "-k", "test-key"]
+        )
+        assert result.exit_code == EXIT_QUOTA_EXHAUSTED
+
+    def test_rejects_format_md(self):
+        result = runner.invoke(
+            sites_app,
+            ["create", "https://example.com", "-k", "test-key", "-f", "md"],
+        )
+        assert result.exit_code == EXIT_GENERAL_ERROR
+        assert "does not support --format md" in result.output
+
+
+# ── rafter sites scan ─────────────────────────────────────────────────
+
+
+class TestSitesScanCli:
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_sends_project_id_for_bare_id(self, mock_post):
+        mock_post.return_value = _mock_response(200, {"run": {"id": "r1"}})
+        result = runner.invoke(sites_app, ["scan", "proj-123", "-k", "test-key"])
+        assert result.exit_code == EXIT_SUCCESS, result.output
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == {"projectId": "proj-123"}
+
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_sends_url_for_url(self, mock_post):
+        mock_post.return_value = _mock_response(200, {"run": {"id": "r1"}})
+        result = runner.invoke(
+            sites_app, ["scan", "https://example.com", "-k", "test-key"]
+        )
+        assert result.exit_code == EXIT_SUCCESS
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == {"url": "https://example.com"}
+
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_includes_sections(self, mock_post):
+        mock_post.return_value = _mock_response(200, {"run": {"id": "r1"}})
+        result = runner.invoke(
+            sites_app,
+            ["scan", "proj-123", "-k", "test-key", "--sections", "security, dns"],
+        )
+        assert result.exit_code == EXIT_SUCCESS
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == {"projectId": "proj-123", "sections": ["security", "dns"]}
+
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_rejects_invalid_section(self, mock_post):
+        result = runner.invoke(
+            sites_app,
+            ["scan", "proj-123", "-k", "test-key", "--sections", "bogus"],
+        )
+        assert result.exit_code == EXIT_GENERAL_ERROR
+        mock_post.assert_not_called()
+
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_404_not_owned(self, mock_post):
+        mock_post.return_value = _mock_response(404, {"error": "not found"})
+        result = runner.invoke(sites_app, ["scan", "proj-123", "-k", "test-key"])
+        assert result.exit_code == EXIT_SCAN_NOT_FOUND
+
+    @patch("rafter_cli.commands.sites.requests.post")
+    def test_403_run_limit(self, mock_post):
+        mock_post.return_value = _mock_response(403, {"error": "run limit reached"})
+        result = runner.invoke(sites_app, ["scan", "proj-123", "-k", "test-key"])
+        assert result.exit_code == EXIT_INSUFFICIENT_SCOPE
+
+
+# ── rafter sites list ─────────────────────────────────────────────────
+
+
+class TestSitesListCli:
+    @patch("rafter_cli.commands.sites.requests.get")
+    def test_passes_pagination_params(self, mock_get):
+        mock_get.return_value = _mock_response(
+            200, {"sites": [], "limit": 10, "offset": 5, "has_more": False}
+        )
+        result = runner.invoke(
+            sites_app,
+            [
+                "list",
+                "-k", "test-key",
+                "--limit", "10",
+                "--offset", "5",
+                "--include-archived",
+            ],
+        )
+        assert result.exit_code == EXIT_SUCCESS, result.output
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"] == {
+            "limit": "10",
+            "offset": "5",
+            "include_archived": "true",
+        }
+
+    @patch("rafter_cli.commands.sites.requests.get")
+    def test_401(self, mock_get):
+        mock_get.return_value = _mock_response(401, {"error": "invalid key"})
+        result = runner.invoke(sites_app, ["list", "-k", "test-key"])
+        assert result.exit_code == EXIT_GENERAL_ERROR
+
+
+# ── rafter sites get ──────────────────────────────────────────────────
+
+
+class TestSitesGetCli:
+    @patch("rafter_cli.commands.sites.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "site": {"id": "p1"},
+                "latest_run": None,
+                "security": {"critical": 0, "warn": 0, "info": 0, "total": 0},
+            },
+        )
+        result = runner.invoke(sites_app, ["get", "p1", "-k", "test-key"])
+        assert result.exit_code == EXIT_SUCCESS, result.output
+        args, _ = mock_get.call_args
+        assert args[0].endswith("/static/sites/p1")
+
+    @patch("rafter_cli.commands.sites.requests.get")
+    def test_404(self, mock_get):
+        mock_get.return_value = _mock_response(404, {"error": "not found"})
+        result = runner.invoke(sites_app, ["get", "nonexistent", "-k", "test-key"])
+        assert result.exit_code == EXIT_SCAN_NOT_FOUND
+
+    @patch("rafter_cli.commands.sites.requests.get")
+    def test_429(self, mock_get):
+        mock_get.return_value = _mock_response(
+            429, {"error": "Rate limit exceeded", "retryAfter": 30}
+        )
+        result = runner.invoke(sites_app, ["get", "p1", "-k", "test-key"])
+        assert result.exit_code == EXIT_QUOTA_EXHAUSTED
+
+
+# ── MCP tool handlers ─────────────────────────────────────────────────
+
+
+class TestMcpSitesCreate:
+    @patch("rafter_cli.commands.mcp_server.requests.post")
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value="test-key")
+    def test_success(self, _mock_key, mock_post):
+        mock_post.return_value = _mock_response(
+            200, {"site": {"id": "p1"}, "run": {"id": "r1"}, "created": True}
+        )
+        result = handle_sites_create("https://example.com")
+        assert result["created"] is True
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == {"url": "https://example.com"}
+
+    @patch("rafter_cli.commands.mcp_server.requests.post")
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value="test-key")
+    def test_401_raises(self, _mock_key, mock_post):
+        mock_post.return_value = _mock_response(401, {"error": "invalid key"})
+        with pytest.raises(RuntimeError, match="Unauthorized"):
+            handle_sites_create("https://example.com")
+
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value=None)
+    def test_missing_key_raises_without_crashing(self, _mock_key):
+        with pytest.raises(RuntimeError, match="No API key configured"):
+            handle_sites_create("https://example.com")
+
+
+class TestMcpSitesScan:
+    @patch("rafter_cli.commands.mcp_server.requests.post")
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value="test-key")
+    def test_by_project_id(self, _mock_key, mock_post):
+        mock_post.return_value = _mock_response(200, {"run": {"id": "r1"}})
+        handle_sites_scan(project_id="proj-1")
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == {"projectId": "proj-1"}
+
+    def test_requires_project_id_or_url(self):
+        with pytest.raises(RuntimeError, match="Provide projectId or url"):
+            handle_sites_scan()
+
+    def test_rejects_both_project_id_and_url(self):
+        """Python builds this correctly from the start — the Node MCP tool
+        currently doesn't reject the both-given case, only the neither-given
+        case (a known bug being fixed concurrently on the Node side)."""
+        with pytest.raises(RuntimeError, match="not both"):
+            handle_sites_scan(project_id="proj-1", url="https://example.com")
+
+    @patch("rafter_cli.commands.mcp_server.requests.post")
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value="test-key")
+    def test_404_not_owned(self, _mock_key, mock_post):
+        mock_post.return_value = _mock_response(404, {"error": "not found"})
+        with pytest.raises(RuntimeError, match="Not found"):
+            handle_sites_scan(project_id="proj-1")
+
+
+class TestMcpSitesList:
+    @patch("rafter_cli.commands.mcp_server.requests.get")
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value="test-key")
+    def test_success_with_params(self, _mock_key, mock_get):
+        mock_get.return_value = _mock_response(
+            200, {"sites": [], "limit": 5, "offset": 0, "has_more": False}
+        )
+        handle_sites_list(limit=5, include_archived=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"] == {"limit": "5", "include_archived": "true"}
+
+    @patch("rafter_cli.commands.mcp_server.requests.get")
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value="test-key")
+    def test_429_raises(self, _mock_key, mock_get):
+        mock_get.return_value = _mock_response(429, {"error": "Rate limit exceeded"})
+        with pytest.raises(RuntimeError, match="Rate limited"):
+            handle_sites_list()
+
+
+class TestMcpSitesGet:
+    @patch("rafter_cli.commands.mcp_server.requests.get")
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value="test-key")
+    def test_success(self, _mock_key, mock_get):
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "site": {"id": "p1"},
+                "latest_run": None,
+                "security": {"critical": 0, "warn": 0, "info": 0, "total": 0},
+            },
+        )
+        result = handle_sites_get("p1")
+        assert result["site"]["id"] == "p1"
+
+    @patch("rafter_cli.commands.mcp_server.requests.get")
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value="test-key")
+    def test_404_raises(self, _mock_key, mock_get):
+        mock_get.return_value = _mock_response(404, {"error": "not found"})
+        with pytest.raises(RuntimeError, match="Not found"):
+            handle_sites_get("nonexistent")
+
+    @patch("rafter_cli.commands.mcp_server.resolve_mcp_api_key", return_value=None)
+    def test_missing_key_raises_without_crashing(self, _mock_key):
+        with pytest.raises(RuntimeError, match="No API key configured"):
+            handle_sites_get("p1")

--- a/shared-docs/CLI_SPEC.md
+++ b/shared-docs/CLI_SPEC.md
@@ -36,6 +36,16 @@ The CLI follows UNIX principles:
 | 1 | Findings — one or more secrets detected |
 | 2 | Runtime error — path not found, not a git repo, invalid ref |
 
+### Sites Commands (`rafter sites create|scan|list|get`)
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error (HTTP 400/401/500, or an invalid `--sections` value, or unsupported `--format md`) |
+| 2 | Not found (HTTP 404) — site not found, or not owned by this account (deliberately not distinguished) |
+| 3 | Quota / rate limited (HTTP 429) |
+| 4 | Insufficient scope / forbidden (HTTP 403) — the Sites API returns 403 for both wrong API-key scope and plan/site limits; the only signal is the free-text `error` message |
+
 ### Docs (`rafter docs list`, `rafter docs show`)
 
 | Code | Meaning |
@@ -122,6 +132,72 @@ Check API quota and usage statistics.
 
 - `-k, --api-key TEXT` — API key. Resolution order: this flag → `RAFTER_API_KEY` env → `backend.apiKey` in global config (see `rafter agent config`)
 - `-h, --help`
+
+---
+
+## Sites — Live-Application Security Monitoring
+
+Rafter Sites scans a registered domain the way it actually runs in production — exposed backends, DNS misconfiguration, SEO, and accessibility — as opposed to the remote code analysis commands above, which scan a git repository. All Sites routes live under `https://rafter.so/api/static/sites` and require the `x-api-key` header, same as remote code analysis.
+
+**`--format` note:** the Sites API never returns a `markdown` field, so `--format md` has nothing to render. Rather than silently falling back to JSON (which would look like success while producing the wrong format), all four commands reject `--format md` up front with an error and exit code `1`. Default format is `json`.
+
+**404 is deliberately ambiguous.** A 404 from any Sites endpoint means "not found, or not owned by this API key's account" — the API does not distinguish the two, so as not to leak the existence of sites belonging to other accounts.
+
+### rafter sites create <URL> [OPTIONS]
+
+Register a URL as a Site and kick off its first scan.
+
+- `-k, --api-key TEXT` — API key. Same resolution order as `rafter run`.
+- `-f, --format [json]` — output format (default: `json`; `md` is rejected, see above)
+- `--quiet` — suppress status messages on stderr
+- `-h, --help`
+
+Request: `POST /api/static/sites` with body `{"url": string}`.
+
+Response (200, new site): `{"site": {...}, "run": {...}|null, "created": true, "scan_error"?: string}`. Response (200, site already existed): `{"site": {"id", "is_archived"}, "run": null, "created": false}`.
+
+### rafter sites scan <PROJECT_ID_OR_URL> [OPTIONS]
+
+Trigger a re-scan of an existing site. The single positional argument is interpreted as a URL when it parses as one (has a scheme); otherwise it's treated as a project id.
+
+- `-k, --api-key TEXT` — API key. Same resolution order as `rafter run`.
+- `-f, --format [json]` — output format (default: `json`; `md` is rejected, see above)
+- `--sections TEXT` — comma-separated subset of `flight`, `security`, `dns` (default: all). An invalid value is rejected locally with exit code `1` before any request is made.
+- `--quiet` — suppress status messages on stderr
+- `-h, --help`
+
+Request: `POST /api/static/sites/scan` with body `{"projectId": string}` XOR `{"url": string}` (exactly one), plus optional `"sections": [...]`.
+
+Response (200): `{"run": {...}}`.
+
+### rafter sites list [OPTIONS]
+
+List registered sites, paginated.
+
+- `-k, --api-key TEXT` — API key. Same resolution order as `rafter run`.
+- `-f, --format [json]` — output format (default: `json`; `md` is rejected, see above)
+- `--limit INTEGER` — results per page, 1-100 (default: 25)
+- `--offset INTEGER` — pagination offset (default: 0)
+- `--include-archived` — include archived sites
+- `--quiet` — suppress status messages on stderr
+- `-h, --help`
+
+Request: `GET /api/static/sites?limit=&offset=&include_archived=`.
+
+Response (200): `{"sites": [...], "limit", "offset", "has_more"}`.
+
+### rafter sites get <ID> [OPTIONS]
+
+Get a site's status, latest scan run, and findings summary.
+
+- `-k, --api-key TEXT` — API key. Same resolution order as `rafter run`.
+- `-f, --format [json]` — output format (default: `json`; `md` is rejected, see above)
+- `--quiet` — suppress status messages on stderr
+- `-h, --help`
+
+Request: `GET /api/static/sites/:id`.
+
+Response (200): `{"site": {...}, "latest_run": {...}|null, "security": {"critical", "warn", "info", "total"}}`.
 
 ---
 
@@ -989,7 +1065,7 @@ PostToolUse hook handler. Reads tool output from stdin, redacts any secrets foun
 
 ### rafter mcp serve [OPTIONS]
 
-Start MCP server over stdio transport. Exposes 7 tools and 3 resources.
+Start MCP server over stdio transport. Exposes 11 tools and 3 resources.
 
 - `--transport <type>` — transport type (currently only `stdio`, default: `stdio`)
 
@@ -1004,6 +1080,10 @@ Start MCP server over stdio transport. Exposes 7 tools and 3 resources.
 | `list_docs` | List repo-specific security docs declared in `.rafter.yml` (metadata only, no content) | none (optional: `tag`) |
 | `get_doc` | Return the content of a repo-specific security doc by id or tag | `id_or_tag` (string); optional: `refresh` (bool) |
 | `suppress_finding` | Triage a false positive by writing an `ignore` rule into the project `.rafter.yml` | `path` (string); optional: `rules` (string[]), `reason` (string) |
+| `sites_create` | Register a URL as a Rafter Site for live-application security monitoring and kick off its first scan | `url` (string) |
+| `sites_scan` | Trigger a re-scan of an existing Rafter Site | exactly one of `projectId` or `url` (string); optional: `sections` (string[]) |
+| `sites_list` | List Rafter Sites registered for monitoring, paginated | none (optional: `limit`, `offset`, `include_archived`) |
+| `sites_get` | Get a Rafter Site's status, latest scan run, and findings summary | `id` (string) |
 
 **`scan_secrets` inputs:**
 - `path` (required) — file or directory path to scan
@@ -1037,6 +1117,10 @@ Start MCP server over stdio transport. Exposes 7 tools and 3 resources.
 - `reason` (optional, string) — why this is a false positive; persisted with the rule and surfaced in `_suppressed` output
 
 **`suppress_finding` output schema:** `{ ok, file, action, entry, suppression_count }` where `action` is `"created"` (new `.rafter.yml` written), `"appended"` (rule added to an existing file), or `"updated"` (an existing rule with the same path+rules scope had its reason refreshed). `entry` is the persisted ignore rule `{ paths, rules?, reason? }`. The tool resolves the existing policy file via the loader's precedence; if none exists it creates a canonical `.rafter.yml` at the git root. It never appends a duplicate rule for the same path+rules scope.
+
+**Sites tools** (`sites_create`, `sites_scan`, `sites_list`, `sites_get`) call the same `https://rafter.so/api/static/sites*` backend as the `rafter sites` CLI commands below — see that section for request/response shapes and error semantics. Unlike CLI commands, these tools have no `--api-key` flag: the key resolves from `RAFTER_API_KEY` or the stored `backend.apiKey` config value. A missing or rejected key returns a normal tool error (`isError: true`) rather than exiting the process, so one tool call failing never takes the rest of the MCP server down.
+
+**`sites_scan` inputs:** exactly one of `projectId` or `url` is required — providing both, or neither, is a tool error. `sections` (optional, string[]) restricts the scan to a subset of `flight`, `security`, `dns`; omit to run all.
 
 #### MCP Resources
 


### PR DESCRIPTION
Cut v0.10.0 from main → prod.

Ships the Rafter Sites CLI + MCP feature (#213): `rafter sites create|scan|list|get`, matching MCP tools, full Python parity, and fixes found by live-testing against production before release.