### PR TITLE
ci: add stale issue and PR cleanup workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Stale Issue/PR Cleanup
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-pr-close: -1
+          exempt-issue-labels: 'pinned,security'
+          exempt-pr-labels: 'pinned,security'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Stale Issue/PR Cleanup
 
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
   workflow_dispatch:
 
 permissions:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   stale:
-    name: Mark and close stale issues/PRs
+    name: Mark stale issues and pull requests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,13 +11,35 @@ permissions:
 
 jobs:
   stale:
+    name: Mark and close stale issues/PRs
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/stale@v9
+      - name: Run stale action
+        uses: actions/stale@v9
         with:
+          stale-issue-label: stale
+          stale-pr-label: stale
+
           days-before-issue-stale: 60
           days-before-issue-close: 14
           days-before-pr-stale: 30
           days-before-pr-close: -1
-          exempt-issue-labels: 'pinned,security'
-          exempt-pr-labels: 'pinned,security'
+
+          exempt-issue-labels: pinned,security
+          exempt-pr-labels: pinned,security
+
+          remove-stale-when-updated: true
+
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity for 60 days. It will be closed in 14 days if no
+            further activity occurs. To keep it open, please comment or remove
+            the stale label.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity for 30 days. To keep it active, please
+            comment or remove the stale label.
+          close-issue-message: >
+            This issue was closed because it remained stale for 14 days with no
+            further activity.


### PR DESCRIPTION
## Summary

Closes #35.

This PR adds `.github/workflows/stale.yml` using `actions/stale@v9` to help manage inactive issues and pull requests.

## What changed

- Added a scheduled stale cleanup workflow.
- Issues are marked as `stale` after 60 days of inactivity.
- Stale issues are closed after 14 additional days of inactivity.
- Pull requests are marked as `stale` after 30 days of inactivity.
- Pull requests are not automatically closed because the issue only requested stale labeling for PRs.
- Issues and PRs labeled `pinned` or `security` are exempt.
- The `stale` label is removed when new activity occurs.
- Added `workflow_dispatch` so maintainers can run the workflow manually.

## Test plan

- [x] Confirmed the diff only touches `.github/workflows/stale.yml`.
- [x] Ran `git diff --check`.
- [x] Ran `npx -y prettier --check .github/workflows/stale.yml`.
- [x] Verified the workflow uses `actions/stale@v9`.
- [x] Verified issue stale/close timing matches the issue requirements.
- [x] Verified PR stale timing matches the issue requirements.
- [x] Verified PR auto-close is disabled with `days-before-pr-close: -1`.
- [x] Verified `pinned` and `security` labels are exempt.