### PR TITLE
ci: run the test suite on external PRs into main

### DIFF
--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -4,14 +4,49 @@ on:
   pull_request:
     branches:
       - prod
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  # ── Who gets the suite ────────────────────────────────────────────
+  # PRs into prod are the release gate and always run.
+  # PRs into main run only for outside contributions: our own work (Rome-1's
+  # PRs, or any branch living in the Raftersecurity repo) is reviewed and
+  # tested locally before it is pushed, so running the full matrix again
+  # would just burn runner minutes.
+  #
+  # Note this is `pull_request`, not `pull_request_target` — fork PRs run with
+  # a read-only token and no access to secrets. Do not "fix" that.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        # Values go through env rather than direct ${{ }} interpolation into
+        # the script, so nothing from the PR can be shell-injected.
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+          HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [ "$EVENT" != "pull_request" ] || [ "$BASE" != "main" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$HEAD_OWNER" = "Raftersecurity" ] || [ "$AUTHOR" = "Rome-1" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Internal PR into main (author=$AUTHOR, head repo owner=$HEAD_OWNER) — suite skipped." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── Unit & integration tests (both languages) ─────────────────────
   test-node:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -55,6 +90,8 @@ jobs:
           RAFTER_API_KEY: ${{ secrets.RAFTER_API_KEY }}
 
   test-python:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -78,6 +115,8 @@ jobs:
 
   # ── E2E CLI tests ─────────────────────────────────────────────────
   e2e-node:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -102,6 +141,8 @@ jobs:
 
   # ── Secret detection accuracy ──────────────────────────────────────
   secret-detection-accuracy:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -124,6 +165,8 @@ jobs:
 
   # ── SARIF output validation ────────────────────────────────────────
   sarif-validation:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -160,6 +203,8 @@ jobs:
 
   # ── Remote API integration (only when key available) ───────────────
   backend-api:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     env:
       RAFTER_API_KEY: ${{ secrets.RAFTER_API_KEY }}
@@ -185,6 +230,8 @@ jobs:
 
   # ── Package build verification ─────────────────────────────────────
   package-integrity:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -231,6 +278,8 @@ jobs:
 
   # ── Cross-platform smoke test ──────────────────────────────────────
   cross-platform:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The comprehensive suite only triggered on `pull_request` into `prod`, so contributor PRs targeting `main` merged with **no automated verification at all** — #215, #216 and #218 each sat MERGEABLE with an empty status-check rollup, and the last workflow run in the repo was 2026-07-29. Tests only ran later, at release time, when `main` was promoted to `prod`.

## What changed

- `main` added to the `pull_request` trigger.
- A `gate` job decides who gets the suite; the 8 existing jobs depend on it.

Policy, per request:

| PR | Suite runs? |
|---|---|
| into `prod` (release gate) | always — unchanged |
| into `main` from a fork / outside contributor | yes |
| into `main` authored by `Rome-1` | no |
| into `main` from a branch in the `Raftersecurity` repo | no |

Our own work is reviewed and tested locally before it's pushed, so re-running the full matrix would only burn runner minutes.

## Security notes

- Uses `pull_request`, **not** `pull_request_target` — fork PRs run with a read-only token and no access to secrets. There's a comment in the file saying so, because "fixing" that is the classic way to hand a fork repo-write credentials.
- The gate reads PR fields through `env:` rather than interpolating `${{ }}` straight into the shell script, so nothing attacker-controlled reaches the command line.
- Fork PRs can't read `secrets.RAFTER_API_KEY`. The tests that need it already skip when it's absent (`backend-api.test.ts` skips by design; the local suite passes with 9 skips), so an external PR gets a clean green rather than a spurious failure.

## Verification

YAML parses; all 8 jobs carry `needs: gate` + the `if` condition. This PR is itself from a `Raftersecurity` branch, so by its own policy the suite will skip on it — I'll confirm the workflow still runs end-to-end with a `workflow_dispatch` once it's on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)