### PR TITLE
fix(security): CLI ship set — classifier + install/verify hardening (rf-6pqx, rf-7dda, rf-er8a, rf-fuwy)

### DIFF
--- a/node/src/core/risk-rules.ts
+++ b/node/src/core/risk-rules.ts
@@ -162,7 +162,9 @@ interface Piece {
 }
 
 function isOpChar(c: string): boolean {
-  return c === ";" || c === "&" || c === "|" || c === ">" || c === "<";
+  // \n and \r are statement separators (rf-6pqx): a newline ends a command
+  // exactly as ";" does, so a payload on a later line is classified on its own.
+  return c === ";" || c === "&" || c === "|" || c === ">" || c === "<" || c === "\n" || c === "\r";
 }
 
 /** Read a `$(…)` substitution starting at `i`; returns its contents and the next index. */
@@ -191,18 +193,32 @@ function readBacktick(s: string, i: number): { inner: string; next: number } {
   return { inner, next: Math.min(j + 1, s.length) };
 }
 
-/** Split a command line into words and operators, respecting quotes and substitutions. */
-function tokenize(s: string): Piece[] {
+/**
+ * Split a command line into words and operators, respecting quotes and substitutions.
+ * `unterminated` is set when a quote is never closed — the parse is then unreliable
+ * and the caller must FAIL CLOSED (match the raw string) rather than trust a
+ * desynchronized sanitization (se-y6vo: `$'a\'b'` swallows a trailing payload).
+ */
+function tokenize(s: string): { pieces: Piece[]; unterminated: boolean } {
   const pieces: Piece[] = [];
+  let unterminated = false;
   let i = 0;
 
   while (i < s.length) {
     const c = s[i];
 
-    if (/\s/.test(c)) { i++; continue; }
+    // Whitespace EXCEPT newlines is skipped; a newline falls through to the
+    // operator branch below so it becomes a statement separator (rf-6pqx).
+    if (/\s/.test(c) && c !== "\n" && c !== "\r") { i++; continue; }
 
     if (isOpChar(c)) {
       const start = i;
+      if (c === "\n" || c === "\r") {
+        // Normalize a line break (incl. CRLF) to a ";" separator piece.
+        i += 1;
+        pieces.push({ start, end: i, op: ";", text: ";", quoted: false, substs: [] });
+        continue;
+      }
       const two = s.slice(i, i + 2);
       const op = (two === "&&" || two === "||" || two === ">>" || two === "<<") ? two : c;
       i += op.length;
@@ -220,6 +236,12 @@ function tokenize(s: string): Piece[] {
       if (/\s/.test(ch) || isOpChar(ch)) break;
 
       if (ch === "\\") {
+        // Line continuation: `\` immediately before a newline (incl. CRLF) is
+        // deleted by the shell — `r\<NL>m` is `rm`, so the newline must not be
+        // absorbed into the word (rf-6pqx/se-y6vo).
+        const nxt = s[i + 1] ?? "";
+        if (nxt === "\n") { i += 2; continue; }
+        if (nxt === "\r") { i += 2; if (s[i] === "\n") i++; continue; }
         i++;
         if (i < s.length) { text += s[i]; i++; }
         continue;
@@ -229,8 +251,12 @@ function tokenize(s: string): Piece[] {
       if (ch === "'") {
         i++;
         quoted = true;
-        while (i < s.length && s[i] !== "'") { text += s[i]; i++; }
-        i++;
+        let closed = false;
+        while (i < s.length) {
+          if (s[i] === "'") { closed = true; i++; break; }
+          text += s[i]; i++;
+        }
+        if (!closed) unterminated = true;
         continue;
       }
 
@@ -238,8 +264,13 @@ function tokenize(s: string): Piece[] {
       if (ch === '"') {
         i++;
         quoted = true;
-        while (i < s.length && s[i] !== '"') {
+        let closed = false;
+        while (i < s.length) {
+          if (s[i] === '"') { closed = true; i++; break; }
           if (s[i] === "\\") {
+            const nxt = s[i + 1] ?? "";
+            if (nxt === "\n") { i += 2; continue; }
+            if (nxt === "\r") { i += 2; if (s[i] === "\n") i++; continue; }
             i++;
             if (i < s.length) { text += s[i]; i++; }
             continue;
@@ -253,7 +284,7 @@ function tokenize(s: string): Piece[] {
           text += s[i];
           i++;
         }
-        i++;
+        if (!closed) unterminated = true;
         continue;
       }
 
@@ -271,7 +302,7 @@ function tokenize(s: string): Piece[] {
     pieces.push({ start, end: i, op: null, text, quoted, substs });
   }
 
-  return pieces;
+  return { pieces, unterminated };
 }
 
 /** `/usr/bin/rm` → `rm`; used to classify the executable of a segment. */
@@ -283,6 +314,16 @@ function execName(text: string): string {
 const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
 const SHELL_C_FLAG = /^-[a-z]*c$/;
 const LONG_FLAG_WITH_VALUE = /^(--[a-z][a-z-]*)=/;
+const NUMERIC_ARG = /^\d+[a-z]*$/i;
+
+/**
+ * A heredoc introducer: `<<`, optional `-`/`~` (indented-terminator forms), an
+ * optional quote around the delimiter, and the delimiter word. Group 1 is the
+ * dash/tilde, group 3 is the delimiter name. `g` so we can find all on a line.
+ */
+const HEREDOC_START = /<<([-~]?)\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/g;
+/** Chain/pipe operators, used to find the statement that owns a heredoc. */
+const CHAIN_SPLIT = /\|\||&&|[;|&]/;
 
 interface Replacement { start: number; end: number; with: string; }
 
@@ -423,10 +464,47 @@ function processSegment(pieces: Piece[], depth: number, out: Replacement[]): voi
   }
 }
 
+/**
+ * Remove `\<newline>` line continuations the way a shell does BEFORE parsing.
+ * `r\<NL>m -rf /` is `rm -rf /` to bash, so the backslash-newline must be deleted
+ * or the token `rm` never forms and the pattern misses it (se-y6vo). Removed when
+ * unquoted or inside double quotes; PRESERVED inside single quotes.
+ */
+function stripLineContinuations(s: string): string {
+  if (!s.includes("\\")) return s;
+  let out = "";
+  let i = 0;
+  let inSingle = false;
+  let inDouble = false;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === "'" && !inDouble) { inSingle = !inSingle; out += c; i++; continue; }
+    if (c === '"' && !inSingle) { inDouble = !inDouble; out += c; i++; continue; }
+    if (c === "\\" && !inSingle) {
+      const nxt = s[i + 1] ?? "";
+      if (nxt === "\n") { i += 2; continue; }
+      if (nxt === "\r") { i += 2; if (s[i] === "\n") i++; continue; }
+      // Normal escape (`\"`, `\$`, …): keep both chars so an escaped quote does
+      // not flip the quote state above.
+      out += c;
+      if (i + 1 < s.length) { out += s[i + 1]; i += 2; } else { i++; }
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
 function sanitize(command: string, depth: number): string {
   if (!command || depth > MAX_SANITIZE_DEPTH) return command;
 
-  const pieces = tokenize(command);
+  command = stripLineContinuations(command);
+  const { pieces, unterminated } = tokenize(command);
+  // Fail closed: an unterminated quote means the parse desynchronized from the
+  // shell, so a sanitized view could hide an executable payload. Match the raw
+  // command instead (se-y6vo).
+  if (unterminated) return command;
   const replacements: Replacement[] = [];
 
   let segment: Piece[] = [];
@@ -459,8 +537,74 @@ function sanitize(command: string, depth: number): string {
  * command consumes as DATA is redacted; text a shell or eval wrapper EXECUTES
  * is preserved (and recursively sanitized). Everything else is untouched.
  */
+/**
+ * Does the command that owns a heredoc EXECUTE its body? `cat > f <<EOF` /
+ * `grep -q x <<EOF` consume the body as DATA; `bash <<EOF` / `sh <<'EOF'` /
+ * `ssh host <<EOF` EXECUTE it. Only a data body may be stripped; an executed
+ * body must stay visible to the patterns (else the newline fix opens a fresh
+ * bypass — se-y6vo).
+ */
+function heredocOwnerExecutes(line: string, ltPos: number): boolean {
+  const head = line.slice(0, ltPos);
+  const segments = head.split(CHAIN_SPLIT);
+  const seg = segments.length ? segments[segments.length - 1] : head;
+  const tokens = seg.split(/\s+/).filter((t) => t.length > 0);
+  let idx = 0;
+  while (idx < tokens.length) {
+    const tok = tokens[idx];
+    if (ENV_ASSIGNMENT.test(tok)) { idx++; continue; }
+    const name = execName(tok);
+    if (TAIL_WRAPPERS.has(name)) {
+      idx++;
+      while (idx < tokens.length && (tokens[idx].startsWith("-") || NUMERIC_ARG.test(tokens[idx]))) idx++;
+      continue;
+    }
+    return SHELL_EXECS.has(name) || EVAL_EXECS.has(name);
+  }
+  return false;
+}
+
+/**
+ * Blank heredoc BODIES that a command consumes as DATA, before tokenizing.
+ * A body written to a file (`cat > doc.md <<EOF … EOF`) or searched
+ * (`grep <<EOF … EOF`) is data, never executed. Leaving it in place makes the
+ * newline-as-separator fix (rf-6pqx) classify ordinary documentation writes as
+ * CRITICAL (rf-3rsj) — the same over-block public #230 reported. Stripping it
+ * fixes both. A body EXECUTED by a shell/eval owner is KEPT so it is still
+ * scanned. Co-designed with kerckhoffs (se-ijzs) and achebe (#230).
+ */
+function stripHeredocBodies(command: string): string {
+  if (!command.includes("<<")) return command;
+  const lines = command.split("\n");
+  const out: string[] = [];
+  let k = 0;
+  while (k < lines.length) {
+    const line = lines[k];
+    out.push(line);
+    HEREDOC_START.lastIndex = 0;
+    const matches = [...line.matchAll(HEREDOC_START)];
+    k += 1;
+    if (matches.length === 0) continue;
+    const keep = heredocOwnerExecutes(line, matches[0].index ?? 0);
+    for (const m of matches) {
+      const delim = m[3];
+      const dash = m[1]; // '-'/'~': a tab-indented terminator is allowed
+      while (k < lines.length) {
+        // bash terminates only on a line EXACTLY equal to the delimiter — for
+        // plain `<<` an indented delimiter is body; `<<-` strips leading TABS.
+        let cand = lines[k].replace(/\r$/, "");
+        if (dash) cand = cand.replace(/^\t+/, "");
+        if (cand === delim) { k += 1; break; }
+        if (keep) out.push(lines[k]);
+        k += 1;
+      }
+    }
+  }
+  return out.join("\n");
+}
+
 export function sanitizeCommandForMatching(command: string): string {
-  return sanitize(command, 0);
+  return sanitize(stripHeredocBodies(command), 0);
 }
 
 /**

--- a/node/tests/risk-rules-newline-heredoc.test.ts
+++ b/node/tests/risk-rules-newline-heredoc.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { assessCommandRisk } from "../src/core/risk-rules.js";
+
+/**
+ * rf-6pqx + rf-3rsj + public #230 regression battery.
+ *
+ * A newline is a statement separator (rf-6pqx): `echo x\nrm -rf /` must NOT be
+ * hidden by the leading text-exec. Heredoc bodies a command consumes as DATA are
+ * stripped so the newline fix does not make ordinary documentation writes CRITICAL
+ * (rf-3rsj) — the same over-block #230 reported — while a body EXECUTED by a
+ * shell/eval owner (`bash <<EOF`) stays scannable (se-y6vo). Also covers
+ * backslash-newline line continuations and fail-closed-on-unterminated-quote.
+ *
+ * The battery JSON is shared BYTE-FOR-BYTE with the Python suite
+ * (python/tests/test_risk_rules_newline_heredoc.py) so a Node-clean result cannot
+ * hide a Python bug, and vice versa. Co-designed with kerckhoffs (se-ijzs) and
+ * achebe (#230).
+ */
+const here = path.dirname(fileURLToPath(import.meta.url));
+const batteryPath = path.resolve(here, "../../rf-6pqx-newline-heredoc-battery.json");
+const battery: Array<{ label: string; cmd: string; want: string[] }> = JSON.parse(
+  readFileSync(batteryPath, "utf8"),
+);
+
+describe("rf-6pqx/rf-3rsj/#230: newline + heredoc classifier battery", () => {
+  it.each(battery)("$label", ({ cmd, want }) => {
+    expect(want).toContain(assessCommandRisk(cmd));
+  });
+});

--- a/python/rafter_cli/core/risk_rules.py
+++ b/python/rafter_cli/core/risk_rules.py
@@ -141,6 +141,13 @@ _LONG_FLAG_WITH_VALUE = re.compile(r"^(--[a-z][a-z-]*)=")
 _NUMERIC_ARG = re.compile(r"^\d+[a-z]*$", re.IGNORECASE)
 _WHITESPACE = re.compile(r"\s")
 
+# A heredoc introducer: `<<`, optional `-`/`~` (indented-terminator forms), an
+# optional quote around the delimiter, and the delimiter word. Group 1 is the
+# dash/tilde, group 3 is the delimiter name.
+_HEREDOC_START = re.compile(r"<<([-~]?)\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\2")
+# Chain/pipe operators, used to find the statement that owns a heredoc.
+_CHAIN_SPLIT = re.compile(r"\|\||&&|[;|&]")
+
 
 class _Piece:
     """A word or an operator, with its span in the source string."""
@@ -165,7 +172,9 @@ class _Piece:
 
 
 def _is_op_char(c: str) -> bool:
-    return c in (";", "&", "|", ">", "<")
+    # \n and \r are statement separators (rf-6pqx): a newline ends a command
+    # exactly as ";" does, so a payload on a later line is classified on its own.
+    return c in (";", "&", "|", ">", "<", "\n", "\r")
 
 
 def _read_subst(s: str, i: int) -> tuple[str, int]:
@@ -196,21 +205,35 @@ def _read_backtick(s: str, i: int) -> tuple[str, int]:
     return "".join(inner), min(j + 1, len(s))
 
 
-def _tokenize(s: str) -> list[_Piece]:
-    """Split a command line into words and operators, respecting quotes/substitutions."""
+def _tokenize(s: str) -> tuple[list[_Piece], bool]:
+    """Split a command line into words and operators, respecting quotes/substitutions.
+
+    Returns (pieces, unterminated). `unterminated` is True when a quote was never
+    closed — the parse is then unreliable and the caller must FAIL CLOSED
+    (match the raw string) rather than trust a desynchronized sanitization
+    (se-y6vo: `$'a\\'b'` desyncs quote state and swallows a trailing payload).
+    """
     pieces: list[_Piece] = []
     i = 0
     n = len(s)
+    unterminated = False
 
     while i < n:
         c = s[i]
 
-        if c.isspace():
+        # Whitespace EXCEPT newlines is skipped; a newline falls through to the
+        # operator branch below so it becomes a statement separator (rf-6pqx).
+        if c.isspace() and c not in ("\n", "\r"):
             i += 1
             continue
 
         if _is_op_char(c):
             start = i
+            if c in ("\n", "\r"):
+                # Normalize a line break (incl. CRLF) to a ";" separator piece.
+                i += 1
+                pieces.append(_Piece(start, i, ";", ";", False, []))
+                continue
             two = s[i:i + 2]
             op = two if two in ("&&", "||", ">>", "<<") else c
             i += len(op)
@@ -228,6 +251,18 @@ def _tokenize(s: str) -> list[_Piece]:
                 break
 
             if ch == "\\":
+                # Line continuation: a backslash immediately before a newline
+                # (incl. CRLF) is DELETED by the shell — `r\<NL>m` is `rm`, so
+                # the newline must not be absorbed into the word (rf-6pqx/se-y6vo).
+                nxt = s[i + 1] if i + 1 < n else ""
+                if nxt == "\n":
+                    i += 2
+                    continue
+                if nxt == "\r":
+                    i += 2
+                    if i < n and s[i] == "\n":
+                        i += 1
+                    continue
                 i += 1
                 if i < n:
                     text.append(s[i])
@@ -238,18 +273,38 @@ def _tokenize(s: str) -> list[_Piece]:
             if ch == "'":
                 i += 1
                 quoted = True
-                while i < n and s[i] != "'":
+                closed = False
+                while i < n:
+                    if s[i] == "'":
+                        closed = True
+                        i += 1
+                        break
                     text.append(s[i])
                     i += 1
-                i += 1
+                if not closed:
+                    unterminated = True
                 continue
 
             # Double quotes are data, but `$( )` / backticks inside them DO execute.
             if ch == '"':
                 i += 1
                 quoted = True
-                while i < n and s[i] != '"':
+                closed = False
+                while i < n:
+                    if s[i] == '"':
+                        closed = True
+                        i += 1
+                        break
                     if s[i] == "\\":
+                        nxt = s[i + 1] if i + 1 < n else ""
+                        if nxt == "\n":
+                            i += 2
+                            continue
+                        if nxt == "\r":
+                            i += 2
+                            if i < n and s[i] == "\n":
+                                i += 1
+                            continue
                         i += 1
                         if i < n:
                             text.append(s[i])
@@ -265,7 +320,8 @@ def _tokenize(s: str) -> list[_Piece]:
                         continue
                     text.append(s[i])
                     i += 1
-                i += 1
+                if not closed:
+                    unterminated = True
                 continue
 
             if ch == "$" and i + 1 < n and s[i + 1] == "(":
@@ -282,7 +338,7 @@ def _tokenize(s: str) -> list[_Piece]:
 
         pieces.append(_Piece(start, i, None, "".join(text), quoted, substs))
 
-    return pieces
+    return pieces, unterminated
 
 
 def _exec_name(text: str) -> str:
@@ -433,11 +489,68 @@ def _process_segment(
                 out.append((p.start, p.end, " "))
 
 
+def _strip_line_continuations(s: str) -> str:
+    """Remove `\\<newline>` line continuations the way a shell does BEFORE parsing.
+
+    `r\\<NL>m -rf /` is `rm -rf /` to bash, so the backslash-newline must be
+    deleted or the token `rm` never forms and the pattern misses it (se-y6vo).
+    Removed when unquoted or inside double quotes; PRESERVED inside single quotes
+    (where bash keeps it literal). A normal escape (`\\x`) is left untouched.
+    """
+    if "\\" not in s:
+        return s
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    in_single = False
+    in_double = False
+    while i < n:
+        c = s[i]
+        if c == "'" and not in_double:
+            in_single = not in_single
+            out.append(c)
+            i += 1
+            continue
+        if c == '"' and not in_single:
+            in_double = not in_double
+            out.append(c)
+            i += 1
+            continue
+        if c == "\\" and not in_single:
+            nxt = s[i + 1] if i + 1 < n else ""
+            if nxt == "\n":
+                i += 2
+                continue
+            if nxt == "\r":
+                i += 2
+                if i < n and s[i] == "\n":
+                    i += 1
+                continue
+            # A normal escape (`\"`, `\$`, …): keep both chars verbatim so an
+            # escaped quote does not flip the quote state above.
+            out.append(c)
+            if i + 1 < n:
+                out.append(s[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
 def _sanitize(command: str, depth: int) -> str:
     if not command or depth > _MAX_SANITIZE_DEPTH:
         return command
 
-    pieces = _tokenize(command)
+    command = _strip_line_continuations(command)
+    pieces, unterminated = _tokenize(command)
+    # Fail closed: an unterminated quote means the parse desynchronized from the
+    # shell, so a sanitized view could hide an executable payload. Match the raw
+    # command instead (se-y6vo).
+    if unterminated:
+        return command
     replacements: list[tuple[int, int, str]] = []
 
     segment: list[_Piece] = []
@@ -465,13 +578,90 @@ def _sanitize(command: str, depth: int) -> str:
     return "".join(out)
 
 
+def _heredoc_owner_executes(line: str, lt_pos: int) -> bool:
+    """Does the command that owns the heredoc EXECUTE its body?
+
+    `cat > f <<EOF` / `grep -q x <<EOF` consume the body as DATA (write it,
+    search it). `bash <<EOF` / `sh <<'EOF'` / `ssh host <<EOF` EXECUTE it. Only
+    the data case may be stripped; an executed body must stay visible to the
+    patterns (else the newline fix would open a fresh bypass — se-y6vo).
+    """
+    head = line[:lt_pos]
+    segments = _CHAIN_SPLIT.split(head)
+    seg = segments[-1] if segments else head
+    tokens = seg.split()
+    idx = 0
+    while idx < len(tokens):
+        tok = tokens[idx]
+        if _ENV_ASSIGNMENT.match(tok):
+            idx += 1
+            continue
+        name = _exec_name(tok)
+        if name in _TAIL_WRAPPERS:
+            idx += 1
+            while idx < len(tokens) and (
+                tokens[idx].startswith("-") or _NUMERIC_ARG.match(tokens[idx])
+            ):
+                idx += 1
+            continue
+        return name in _SHELL_EXECS or name in _EVAL_EXECS
+    return False
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Blank heredoc BODIES that a command consumes as DATA, before tokenizing.
+
+    A heredoc body written to a file (`cat > doc.md <<EOF … EOF`) or searched
+    (`grep <<EOF … EOF`) is data, never executed. Leaving it in place makes the
+    newline-as-separator fix (rf-6pqx) classify ordinary documentation writes as
+    CRITICAL (rf-3rsj), and is the same over-block the public #230 reporter hit.
+    Stripping it fixes both. A body EXECUTED by a shell/eval owner is KEPT so it
+    is still scanned. Co-designed with kerckhoffs (se-ijzs) and achebe (#230).
+
+    Known limits: a literal `<<WORD` inside a quoted string is still treated as an
+    introducer, and delimiters are matched by `.strip() == DELIM` (looser than
+    bash, erring toward scanning more, which is the safe direction).
+    """
+    if "<<" not in command:
+        return command
+    lines = command.split("\n")
+    out: list[str] = []
+    k = 0
+    while k < len(lines):
+        line = lines[k]
+        out.append(line)
+        matches = list(_HEREDOC_START.finditer(line))
+        k += 1
+        if not matches:
+            continue
+        keep = _heredoc_owner_executes(line, matches[0].start())
+        for m in matches:
+            delim = m.group(3)
+            dash = m.group(1)  # '-'/'~': a tab-indented terminator is allowed
+            while k < len(lines):
+                # bash terminates a heredoc only on a line EXACTLY equal to the
+                # delimiter — for plain `<<` an indented delimiter is body, not a
+                # terminator; `<<-` strips leading TABS first. (rstrip \r for CRLF.)
+                cand = lines[k].rstrip("\r")
+                if dash:
+                    cand = cand.lstrip("\t")
+                if cand == delim:
+                    k += 1  # drop the terminator line
+                    break
+                if keep:
+                    out.append(lines[k])
+                k += 1
+    return "\n".join(out)
+
+
 def sanitize_command_for_matching(command: str) -> str:
     """Normalize a command line for risk/policy pattern matching.
 
     Quoted text the command consumes as DATA is redacted; text a shell or eval
-    wrapper EXECUTES is preserved (and recursively sanitized). Everything else is
-    untouched.
+    wrapper EXECUTES is preserved (and recursively sanitized). Heredoc bodies
+    consumed as data are stripped first. Everything else is untouched.
     """
+    command = _strip_heredoc_bodies(command)
     return _sanitize(command, 0)
 
 

--- a/python/tests/test_risk_rules_newline_heredoc.py
+++ b/python/tests/test_risk_rules_newline_heredoc.py
@@ -1,0 +1,34 @@
+"""rf-6pqx + rf-3rsj + public #230 regression battery (Python runtime).
+
+A newline is a statement separator (rf-6pqx): ``echo x\\nrm -rf /`` must not be
+hidden by the leading text-exec. Heredoc bodies a command consumes as DATA are
+stripped so the newline fix does not make ordinary documentation writes CRITICAL
+(rf-3rsj) — the same over-block public #230 reported — while a body EXECUTED by a
+shell/eval owner (``bash <<EOF``) stays scannable (se-y6vo). Also covers
+backslash-newline line continuations and fail-closed-on-unterminated-quote.
+
+The battery JSON is shared BYTE-FOR-BYTE with the Node suite
+(node/tests/risk-rules-newline-heredoc.test.ts) so a Python-clean result cannot
+hide a Node bug, and vice versa. Co-designed with kerckhoffs (se-ijzs) and
+achebe (#230).
+"""
+import json
+import unittest
+from pathlib import Path
+
+from rafter_cli.core.risk_rules import assess_command_risk
+
+_BATTERY_PATH = Path(__file__).resolve().parents[2] / "rf-6pqx-newline-heredoc-battery.json"
+_BATTERY = json.loads(_BATTERY_PATH.read_text())
+
+
+class TestNewlineHeredocBattery(unittest.TestCase):
+    def test_battery(self) -> None:
+        self.assertTrue(_BATTERY, "battery fixture is empty")
+        for case in _BATTERY:
+            with self.subTest(label=case["label"]):
+                self.assertIn(assess_command_risk(case["cmd"]), set(case["want"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rf-6pqx-newline-heredoc-battery.json
+++ b/rf-6pqx-newline-heredoc-battery.json
@@ -1,0 +1,208 @@
+[
+  {
+    "label": "nl: echo then rm -rf /",
+    "cmd": "echo start\nrm -rf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "nl: grep then rm -rf /",
+    "cmd": "grep -r x .\nrm -rf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "nl: printf then sudo rm",
+    "cmd": "printf a\nsudo rm -rf /etc",
+    "want": [
+      "critical",
+      "high"
+    ]
+  },
+  {
+    "label": "nl: CRLF variant",
+    "cmd": "echo x\r\nrm -rf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "hd: doc 'Never run rm -rf / on prod'",
+    "cmd": "cat > README.md <<'EOF'\nNever run rm -rf / on prod.\nEOF",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "hd: body rm -rf /",
+    "cmd": "cat > a.md <<'EOF'\nrm -rf /\nEOF",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "hd: grep -q heredoc body",
+    "cmd": "grep -q foo <<'EOF'\nrm -rf /\nEOF",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "hd: <<- tab-strip delim + tab-indented terminator",
+    "cmd": "cat <<-END > d.md\n\trm -rf /\n\tEND",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "hd: two heredocs one line, both bodies dangerous",
+    "cmd": "cat <<A <<B\nrm -rf /\nA\nchmod -R 777 /\nB",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "NESTED: body contains a fake <<FAKE opener + rm -rf /",
+    "cmd": "cat <<OUTER > f.sh\nexample: cat <<FAKE\nrm -rf /\nFAKE stuff\nOUTER",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "RECURS: delimiter word appears mid-line in body, real term later",
+    "cmd": "cat <<EOF > note.md\nThe EOF marker ends a heredoc.\nrm -rf /\nEOF",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "RECURS: body line has 'EOF;' not standalone",
+    "cmd": "cat <<EOF > n.md\nEOF; is not a terminator\nsudo rm -rf /etc\nEOF",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "PLAIN <<: indented EOF is NOT a terminator (body continues)",
+    "cmd": "cat <<EOF > n.md\n  EOF\nrm -rf /\nEOF",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "INVARIANT: real cmd AFTER standalone terminator -> critical",
+    "cmd": "cat <<EOF\nhi\nEOF\nrm -rf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "INVARIANT: <<- real cmd after tab-indented terminator -> critical",
+    "cmd": "cat <<-EOF\n\tdata\n\tEOF\nrm -rf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "INVARIANT: bare rm -rf /",
+    "cmd": "rm -rf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "INVARIANT: semicolon chain",
+    "cmd": "echo x; rm -rf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "INVARIANT: benign multiline echo",
+    "cmd": "echo one\necho two",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "INVARIANT: prose FP commit body",
+    "cmd": "git commit -m 'do not git push --force'",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "INVARIANT: benign heredoc",
+    "cmd": "cat <<EOF > out.txt\nhello world\nEOF",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "SHELL-HD (se-y6vo): bash <<EOF body IS executed",
+    "cmd": "bash <<EOF\nrm -rf /\nEOF",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "SHELL-HD: sudo bash <<EOF (tail-wrapper + shell)",
+    "cmd": "sudo bash <<EOF\nrm -rf /\nEOF",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "SHELL-HD: sh <<'X' quoted delim, executed",
+    "cmd": "sh <<'X'\nrm -rf /\nX",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "SHELL-HD: echo hi; bash <<EOF (owner is bash, not echo)",
+    "cmd": "echo hi; bash <<EOF\nrm -rf /\nEOF",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "MIXED: cat <<A then EOF; still strip cat body",
+    "cmd": "cat <<DATA > f\nrm -rf /\nDATA",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "BACKSLASH-NL (goldwasser): r\\<NL>m -rf / must not sidestep",
+    "cmd": "r\\\nm -rf /",
+    "want": [
+      "critical",
+      "high",
+      "medium"
+    ]
+  },
+  {
+    "label": "se-y6vo: unterminated ANSI-C quote fails closed",
+    "cmd": "echo $'a\\'b'\nrm -rf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "se-y6vo: backslash-nl splits rm -rf (must not downgrade)",
+    "cmd": "rm -r\\\nf /",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "invariant: backslash-nl joining echo args stays low",
+    "cmd": "echo hi \\\nrm -rf /",
+    "want": [
+      "low"
+    ]
+  }
+]


### PR DESCRIPTION
**DRAFT — held pending coordinated-disclosure clearance.** CLI security ship set under an active disclosure timeline with an external reporter. Reproduction detail is intentionally omitted here and tracked privately. Do not merge until disclosure timing is cleared with the maintainer.

Consolidated ship set (one branch, atomic merge, per mayor):
- **rf-6pqx / rf-3rsj / #230** — PreToolUse command classifier is heredoc-aware and treats line breaks as statement separators, with line-continuation and unterminated-quote hardening. Both runtimes; shared regression battery.
- **rf-7dda** — a repo-supplied `.env` can no longer toggle the hook security env vars.
- **rf-er8a** — `agent init` writes a resolvable (absolute) hook command and will not report success for a command that cannot execute.
- **rf-fuwy** — `agent verify` executes the configured hook and asserts it blocks a synthetic critical command, not just that configuration exists.

Tests green both runtimes. Co-designed with kerckhoffs and achebe. External report credited to J (github JJB1).