### PR TITLE
fix(release): bump BOTH gated skill manifests; give every full-suite job the differential baseline

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,6 +48,12 @@ jobs:
         run: |
           pip install -e ".[dev]" 2>/dev/null || pip install -e .
 
+      # The rf-6pqx differential FAILS rather than skips when main's classifier is
+      # unobtainable, and this job runs the FULL suite — so the publish path needs
+      # the baseline too, or the release breaks at the moment it fires.
+      - name: Fetch main for the differential gate
+        run: git fetch --depth=1 origin main:refs/remotes/origin/main
+
       - name: Run tests
         run: pnpm exec vitest run --reporter=default --reporter=json --outputFile.json=vitest-report.json
 
@@ -84,6 +90,12 @@ jobs:
         run: |
           pip install -e ".[dev]" 2>/dev/null || pip install -e .
           pip install pytest pytest-mock pytest-asyncio
+
+      # The rf-6pqx differential FAILS rather than skips when main's classifier is
+      # unobtainable, and this job runs the FULL suite — so the publish path needs
+      # the baseline too, or the release breaks at the moment it fires.
+      - name: Fetch main for the differential gate
+        run: git fetch --depth=1 origin main:refs/remotes/origin/main
 
       - name: Run all tests
         run: python -m pytest tests/ -v -o junit_family=xunit1 --junitxml=pytest-report.xml

--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -404,6 +404,13 @@ jobs:
       - name: Enable pnpm
         run: corepack enable && corepack prepare pnpm@10 --activate
 
+      # The rf-6pqx differential compares this branch's classifier against main's
+      # and FAILS rather than skips when the baseline is missing — correctly, but
+      # that means EVERY job running the suite has to supply it. actions/checkout
+      # fetches only the PR ref. A depth-1 fetch is enough: one blob, not history.
+      - name: Fetch main for the differential gate
+        run: git fetch --depth=1 origin main:refs/remotes/origin/main
+
       - name: Install and build
         run: |
           pnpm install --frozen-lockfile

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -84,6 +84,13 @@ jobs:
         with:
           python-version: "3.11"
 
+      # The rf-6pqx differential compares this branch's classifier against main's
+      # and FAILS rather than skips when the baseline is missing — correctly, but
+      # that means EVERY job running the suite has to supply it. actions/checkout
+      # fetches only the PR ref. A depth-1 fetch is enough: one blob, not history.
+      - name: Fetch main for the differential gate
+        run: git fetch --depth=1 origin main:refs/remotes/origin/main
+
       - name: Build Node package
         run: |
           cd node

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.10.0
+version: 0.10.1
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.10.0
+version: 0.10.1
 homepage: https://rafter.so
 metadata:
   openclaw:


### PR DESCRIPTION
Unblocks #237. **Larger than the one-line bump it looked like** — please read the second half before merging.

## 1. The version gate named one file because it exits at the first

`validate-versions` loops over **two** manifests and `exit 1`s on the first mismatch, so it only reported the node one. `python/rafter_cli/resources/rafter-security-skill.md` was equally stale at `0.10.0` and would have failed the very next run. Both are now `0.10.1`; I simulated the gate over both files.

Four other manifests carry a `version:` and are **not** in the loop — `rafter/SKILL.md` and `rafter-code-review` at 0.7.0, `rafter-secure-design` and `rafter-skill-review` at 0.1.0, each duplicated node/python. Left alone deliberately (they aren't release-versioned), but noted: prod history already contains `fix(release): bump ClawHub skill resource versions to 0.8.9`, so this desync recurs. Bead to follow.

## 2. Five other checks were failing, all of them mine

`test-build` and all four `cross-platform` legs failed on `tests/rf6pqx-differential.test.ts`:

```
Command failed: git show origin/main:node/src/core/risk-rules.ts
fatal: invalid object name 'origin/main'.
```

The differential **fails rather than skips** when the baseline is missing, which is correct — but that makes the baseline a precondition of every job running the suite, and I'd added the fetch to only the two jobs whose failure I happened to be looking at.

So I swept all four workflows rather than patching instances again:

| workflow | job | |
|---|---|---|
| test-comprehensive | test-node | already had it |
| test-comprehensive | test-python | already had it |
| test-comprehensive | cross-platform | **added** |
| validate-release | test-build | **added** |
| publish | test-node | **added** |
| publish | test-python | **added** |

**The last two are why this matters.** `publish.yaml` runs the full node and python suites, and `publish-node`/`publish-python` are gated on them — so without this, the release would have passed every check on #237 and then **failed at the moment Rome merged it**.

`e2e-node`, `secret-detection-accuracy` and `backend-api` run single targeted files, never collect the differential, and need nothing. Checked rather than assumed.

## Verification

Gate simulated over both manifests; differential and battery suites pass in both runtimes locally; full-suite sweep re-run and clean.
