### PR TITLE
release: v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-09-09
+
+### Security
+
+- **A repo's `.rafter.yml` can no longer lower the machine owner's global command policy** (rf-adth, sable-nz4y). Policy discovery walks up from cwd to the git root, so on a repository the agent didn't write, `.rafter.yml` is attacker-controlled — and it previously replaced the owner's command policy wholesale. Nine lines of repo content (`mode: allow-all`, `blocked_patterns: []`, `require_approval: []`) could turn an explicitly deny-listed `curl | bash` from blocked into allowed, and demote `rm -rf`, `sudo rm`, and `git push --force` from approval to allowed. The always-on critical hard-block was never affected — this is about everything below it. The global config is now a floor: `blockedPatterns`/`requireApproval` union rather than replace, and `mode` is accepted from a project only when at least as strict. Delegating policy to a project is still possible via the owner-only `agent.commandPolicy.allowProjectOverride` flag in the *global* config, which a project cannot express.
+
+## [0.10.1] - 2026-09-09
+
 ### Fixed
 
 - **`rafter agent exec --force` no longer skips approval, and approval needs a person at a terminal** (rf-ss67, reported in the secbolt audit se-ezvc). `--force "<quoted command>"` ran any HIGH-tier command unprompted: the PreToolUse hook classified the quoted argument as prose, and `exec` then skipped its own prompt. `--force` is now a hidden no-op kept only so old invocations parse; a command that needs approval is prompted only when stdin is an interactive TTY and is otherwise denied, so a piped `yes` is not an approval either. `--dry-run`, which three shipped docs already advertised, now exists: it prints the verdict and runs nothing (exit 0 allowed, 1 blocked, 2 needs approval). The documented `-- <command>` form is accepted, with the words re-quoted so the classifier evaluates exactly what the shell would run. Both runtimes.

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "repository": {
     "type": "git",

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.10.1
+version: 0.10.2
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.10.1"
+version = "0.10.2"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.10.1
+version: 0.10.2
 homepage: https://rafter.so
 metadata:
   openclaw:


### PR DESCRIPTION
Patch release bundling the one unreleased change on `main` since 0.10.1.

## Why this release exists

npm `@rafter-security/cli` 0.10.1 and PyPI `rafter-cli` 0.10.1 were published 2026-09-09T01:59:14Z from gitHead `2a83cf04` (#237). #233 — the global command-policy floor fix — merged over an hour later, at 03:10:49Z, and is now the tip of `main`. The published 0.10.1 artifact does **not** contain it, and because #233 landed after 0.10.1 was already cut, `main` and the published package are both labelled `0.10.1` — `--version` cannot tell them apart. This release exists to make that distinguishable.

Verified: `gh api repos/Raftersecurity/rafter-cli/compare/12a1429f...2a83cf04` (main HEAD vs. published gitHead) returns `diverged`, 35 ahead / 3 behind. Positive control `gh api .../compare/31f9c114...2a83cf04` (#238, which *is* in the release) returns `ahead`, 36/0.

## Contents

- **#233** — `fix(policy): make the global command policy a floor a project cannot lower` (rf-adth, sable-nz4y). A repo-supplied `.rafter.yml` could replace the machine owner's global command policy wholesale instead of only tightening it; the global config is now a floor (union on `blockedPatterns`/`requireApproval`, `mode` accepted only when at least as strict).

That is the only unreleased change with any effect on shipped behavior. The one other commit ahead of the published gitHead, **#240** (`ci: add the Node 18 smoke test that 5409a84 left missing`), is CI-only and not user-facing — not included in the CHANGELOG entry, consistent with how this repo has treated CI-only PRs in every prior release.

## Release mechanics

- Bumps `node/package.json` + `python/pyproject.toml` → **0.10.2** (parity checked), and both `rafter-security-skill.md` frontmatter versions (node + python).
- Adds `## [0.10.2] - 2026-09-09` to CHANGELOG.md with the #233 entry.
- Also adds the `## [0.10.1] - 2026-09-09` heading that 0.10.1 never got — the `[Unreleased]` section had accumulated the 0.10.1-era entries (rf-ss67, sable-l10k ×4, the Action timeout/retry changes) but nothing renamed the heading when 0.10.1 was cut (its version bump was folded into #235 rather than a standalone release commit, and that commit only added bullets under `[Unreleased]` without renaming it). This closes that gap so `[0.10.2]`'s own heading has something correct to sit above. Note this does **not** backfill the 0.10.1 entries that were never written in the first place — PR #235's ship set (rf-6pqx, rf-3rsj, sable-c6an, rf-7dda, rf-er8a, rf-fuwy) and #223/#224 have no CHANGELOG entries under `[0.10.1]` even though they shipped in it. Flagging that gap here rather than silently patching it in, since backfilling accurate descriptions of already-shipped changes is a separate piece of work from cutting this release.
- Version-only + changelog change; no source/behavior changes beyond #233, which already merged separately.

## What else is on `main` beyond #233

Full accounting, everything merged after the published gitHead `2a83cf04`:

| PR | Merged | Title | Ships in 0.10.2? |
|---|---|---|---|
| #240 | 2026-09-09T01:55:03Z | `ci: add the Node 18 smoke test that 5409a84 left missing` | Yes (CI-only, no behavior change) |
| #233 | 2026-09-09T03:10:49Z | `fix(policy): make the global command policy a floor a project cannot lower` | Yes — the reason for this release |

Nothing else sits on `main` unreleased.

## Validation

- Node build (`tsc`) clean.
- `pnpm exec vitest run` (full suite, maxWorkers=4) — see CI / session notes for pass/fail counts.
- `pytest tests/` (full suite) — see CI / session notes for pass/fail counts.
- Version parity: node == python == skill manifests == 0.10.2.

After merge, promote `main` → `prod` to trigger the npm + PyPI publish (OIDC). **Verify the artifact, not the workflow exit code:** `npm view @rafter-security/cli version` must read `0.10.2` and `pip index versions rafter-cli` (or the PyPI JSON API) must show `0.10.2` before considering this shipped.

**Not merged, not tagged, not published by this PR** — review and merge is Rome's call.
