### PR TITLE
fix(hook): see through rafter's own `agent exec` — operand is a command; pty wrapper around it is HIGH (sable-lbyp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The PreToolUse hook now sees through rafter's own `agent exec`** (sable-lbyp, the classifier half of rf-ss67). `rafter agent exec --force "rm -rf /tmp/x"` classified `low`: rafter was an unrecognised evaluator to the sanitizer, so its quoted operand was prose. The operand of `rafter agent exec` is now a command string — resolved by basename (`/usr/local/bin/rafter`), through package runners (`npx @rafter-security/cli`, `pnpm dlx rafter-cli`) and wrappers (`sudo -E`, `env`, `unbuffer`) — and is classified on its own merits; `--dry-run` is exempt because it runs nothing and is the documented way to check a command first. A pseudo-terminal wrapper around `rafter agent exec` (`script -c`, `expect`, `unbuffer`, `socat`, Python's `pty.spawn`) is HIGH on its own, since the approval prompt only trusts a person at a TTY and those manufacture one. 17 rows added to the shared classifier battery; both runtimes.
+
 ## [0.10.3] - 2026-09-11
 
 ### Security

--- a/node/src/core/risk-rules.ts
+++ b/node/src/core/risk-rules.ts
@@ -38,6 +38,12 @@ const CRITICAL_PATTERN_SOURCES: string[] = [
 export const CRITICAL_PATTERNS: RegExp[] = CRITICAL_PATTERN_SOURCES.map((s) => new RegExp(s));
 
 export const HIGH_PATTERNS: RegExp[] = [
+  // sable-lbyp: a pseudo-terminal wrapper around rafter's own approval prompt.
+  // `rafter agent exec` grants approval only to a person at a TTY; `script`,
+  // `expect`, `unbuffer`, `socat` and Python's pty module manufacture one and
+  // can type "yes". Wrapping rafter in any of them is itself the signal.
+  /\b(?:script|expect|unbuffer|socat)\b.*\brafter(?:-cli)?\s+agent\s+exec\b/,
+  /\bpty\.(?:spawn|fork|openpty)\b.*\brafter\b/,
   /rm\s+(-[a-z]*r[a-z]*\s+)*-[a-z]*f[a-z]*/,  // rm -rf, -fr, -r -f, -f -r (any path)
   /rm\s+(-[a-z]*f[a-z]*\s+)*-[a-z]*r[a-z]*/,  // rm -fr, reversed
   /sudo\s+rm/,
@@ -127,6 +133,7 @@ const EVAL_FLAGS = new Set(["-c", "-e", "--command", "--execute", "--eval", "-ex
 const TAIL_WRAPPERS = new Set([
   "sudo", "doas", "env", "nohup", "timeout", "nice", "ionice",
   "time", "watch", "setsid", "stdbuf", "chrt", "command",
+  "unbuffer",  // expect's pty wrapper: delegates to the command that follows (sable-lbyp)
 ]);
 
 /** Commands whose operands are pure text data — searching or printing, never executing. */
@@ -412,7 +419,10 @@ function processSegment(
     if (!p.quoted && SHELL_EXECS.has(execName(p.text))) hasShellExec = true;
     if (!p.quoted && EVAL_FLAGS.has(p.text.toLowerCase())) hasEvalFlag = true;
   }
-  const codeCarrying = hasShellExec || hasEvalFlag || EVAL_EXECS.has(exec);
+  // sable-lbyp: rafter's own `agent exec` runs its operand, so the hook must
+  // see through its own binary the way it sees through `bash -c`.
+  const codeCarrying =
+    hasShellExec || hasEvalFlag || EVAL_EXECS.has(exec) || rafterExecRunsOperand(pieces, execIdx);
 
   // sable-c6an. Two questions the code conflated, and conflating them gets one
   // of them wrong:
@@ -734,6 +744,52 @@ const RAFTER_PACKAGE = /^(?:@rafter-security\/cli|rafter-cli|rafter)(?:@[\w.^~*-
 
 /** Config keys that gate the hook. Namespace, not a leaf — see hook-control. */
 const PROTECTED_CONFIG_KEY = /^(?:agent\.)?(?:hooks|commandpolicy)\b|^agent\.risklevel$/;
+
+/**
+ * sable-lbyp (from rf-ss67) — `rafter agent exec <operand>` RUNS its operand,
+ * so a segment whose exec is rafter's own binary is code-carrying: the quoted
+ * operand is a command string, not prose, and must reach the patterns.
+ *
+ * Before this, `rafter agent exec --force "rm -rf /tmp/x"` was the one shape
+ * the hook could not see: an unrecognised evaluator with a quoted multi-word
+ * argument is data by the sanitizer's rule, so the hook said `low` while exec
+ * ran a HIGH-tier command. rf-ss67 closed the bypass at the other end (exec no
+ * longer skips approval and only a person at a TTY can grant it); this makes
+ * the hook itself classify the operand, so the audit trail and the block land
+ * where the agent's tool call is, not two processes later.
+ *
+ * Resolution is the same as the rf-vnxs disarm check: the segment's resolved
+ * exec (wrappers such as `sudo -E`, `env`, `unbuffer` already skipped by the
+ * caller), an absolute path (`execName` keeps the basename, so
+ * `/usr/local/bin/rafter` is `rafter`), or a package runner
+ * (`npx @rafter-security/cli`, `pnpm dlx rafter-cli`, `bunx rafter`).
+ *
+ * `--dry-run` is the one exemption: exec then prints the classification and
+ * runs nothing, and that flow is what the shipped docs tell agents to use to
+ * check a command BEFORE running it. Treating its operand as executed would
+ * block the very check. A flag an old CLI does not know makes it error out,
+ * never execute, so the exemption cannot be abused by version skew.
+ */
+function rafterExecRunsOperand(pieces: Piece[], execIdx: number): boolean {
+  if (execIdx === -1) return false;
+  let k = execIdx;
+  let exec = execName(pieces[k].text);
+  if (pieces[k].quoted) return false;
+  k++;
+  if (PACKAGE_RUNNERS.has(exec)) {
+    while (k < pieces.length && !pieces[k].op && (pieces[k].text.startsWith("-") || ["dlx", "exec"].includes(pieces[k].text.toLowerCase()))) k++;
+    if (k >= pieces.length || pieces[k].op || !RAFTER_PACKAGE.test(pieces[k].text.toLowerCase())) return false;
+    k++;
+    exec = "rafter";
+  }
+  if (!RAFTER_EXECS.has(exec)) return false;
+
+  const rest = pieces.slice(k).filter((p) => !p.op);
+  const args = rest.filter((p) => !p.text.startsWith("-")).map((p) => p.text.toLowerCase());
+  if (args[0] !== "agent" || args[1] !== "exec") return false;
+  const dryRun = rest.some((p) => !p.quoted && p.text.toLowerCase() === "--dry-run");
+  return !dryRun;
+}
 
 /**
  * True if this statement's argv reconfigures or removes a rafter security

--- a/node/tests/risk-rules-rafter-exec.test.ts
+++ b/node/tests/risk-rules-rafter-exec.test.ts
@@ -65,4 +65,13 @@ describe("rafter agent exec operand is a command (sable-lbyp)", () => {
     // The wrapper alone, without rafter, is not the signal.
     expect(assessCommandRisk('script -q -c "ls -la" /dev/null')).toBe("low");
   });
+
+  it("unbuffer is a tail wrapper: the command after it resolves as the exec", () => {
+    // Without the wrapper entry, `unbuffer` would be the exec and the operand
+    // prose, so this would only reach HIGH through the pty pattern. The
+    // operand must still be seen, so a critical one is CRITICAL.
+    const cmd = 'unbuffer rafter agent exec "rm -rf /"';
+    expect(sanitizeCommandForMatching(cmd)).toContain("rm -rf /");
+    expect(assessCommandRisk(cmd)).toBe("critical");
+  });
 });

--- a/node/tests/risk-rules-rafter-exec.test.ts
+++ b/node/tests/risk-rules-rafter-exec.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  assessCommandRisk,
+  sanitizeCommandForMatching,
+} from "../src/core/risk-rules.js";
+
+/**
+ * sable-lbyp (from rf-ss67) — the hook sees through rafter's own binary.
+ *
+ * `rafter agent exec <operand>` RUNS its operand. Before this the sanitizer
+ * treated rafter as an unrecognised evaluator, so a quoted multi-word operand
+ * was prose and `rafter agent exec --force "rm -rf /tmp/x"` classified `low`
+ * while exec ran a HIGH-tier command. The level assertions live in the shared
+ * battery (rf-6pqx-newline-heredoc-battery.json, "lbyp:" rows) so both
+ * runtimes prove them; this file pins the SHAPE of the sanitized text and the
+ * one exemption.
+ */
+describe("rafter agent exec operand is a command (sable-lbyp)", () => {
+  it("inlines the quoted operand so the patterns can see it", () => {
+    const s = sanitizeCommandForMatching('rafter agent exec --force "rm -rf /tmp/x"');
+    expect(s).toContain("rm -rf /tmp/x");
+    expect(assessCommandRisk('rafter agent exec --force "rm -rf /tmp/x"')).toBe("high");
+  });
+
+  it("resolves the binary by basename, package runner and wrapper", () => {
+    for (const cmd of [
+      '/usr/local/bin/rafter agent exec "chmod 777 /etc/passwd"',
+      'npx @rafter-security/cli agent exec "chmod 777 /etc/passwd"',
+      'bunx rafter agent exec "chmod 777 /etc/passwd"',
+      'sudo -E rafter agent exec "chmod 777 /etc/passwd"',
+      'env RAFTER_X=1 rafter-cli agent exec "chmod 777 /etc/passwd"',
+    ]) {
+      expect(sanitizeCommandForMatching(cmd), cmd).toContain("chmod 777 /etc/passwd");
+      expect(assessCommandRisk(cmd), cmd).toBe("high");
+    }
+  });
+
+  it("--dry-run runs nothing, so its operand stays data", () => {
+    const cmd = 'rafter agent exec --dry-run "rm -rf /"';
+    expect(sanitizeCommandForMatching(cmd)).not.toContain("rm -rf /");
+    expect(assessCommandRisk(cmd)).toBe("low");
+  });
+
+  it("a quoted --dry-run is not the flag", () => {
+    // Quoting the flag would make exec treat it as the command; the hook must
+    // not honour it as the exemption.
+    expect(assessCommandRisk('rafter agent exec "--dry-run" "rm -rf /"')).toBe("critical");
+  });
+
+  it("only agent exec is code-carrying; other rafter operands stay prose", () => {
+    expect(assessCommandRisk('rafter secrets "my project/src"')).toBe("low");
+    expect(assessCommandRisk('rafter agent config get "agent risk level"')).toBe("low");
+    expect(assessCommandRisk("echo 'rafter agent exec \"rm -rf /\"'")).toBe("low");
+  });
+
+  it("a pty wrapper around rafter agent exec is HIGH on its own", () => {
+    for (const cmd of [
+      'script -q -c "rafter agent exec \'echo hi\'" /dev/null',
+      'unbuffer rafter agent exec "echo hi"',
+      "expect -c 'spawn rafter agent exec \"echo hi\"; send \"yes\\r\"'",
+      "python3 -c \"import pty; pty.spawn(['rafter','agent','exec','echo hi'])\"",
+    ]) {
+      expect(assessCommandRisk(cmd), cmd).toBe("high");
+    }
+    // The wrapper alone, without rafter, is not the signal.
+    expect(assessCommandRisk('script -q -c "ls -la" /dev/null')).toBe("low");
+  });
+});

--- a/python/rafter_cli/core/risk_rules.py
+++ b/python/rafter_cli/core/risk_rules.py
@@ -33,6 +33,12 @@ CRITICAL_PATTERNS: list[str] = [
 ]
 
 HIGH_PATTERNS: list[str] = [
+    # sable-lbyp: a pseudo-terminal wrapper around rafter's own approval prompt.
+    # `rafter agent exec` grants approval only to a person at a TTY; `script`,
+    # `expect`, `unbuffer`, `socat` and Python's pty module manufacture one and
+    # can type "yes". Wrapping rafter in any of them is itself the signal.
+    r"\b(?:script|expect|unbuffer|socat)\b.*\brafter(?:-cli)?\s+agent\s+exec\b",
+    r"\bpty\.(?:spawn|fork|openpty)\b.*\brafter\b",
     r"rm\s+(-[a-z]*r[a-z]*\s+)*-[a-z]*f[a-z]*",   # rm -rf, -fr, -r -f, -f -r
     r"rm\s+(-[a-z]*f[a-z]*\s+)*-[a-z]*r[a-z]*",   # reversed order
     r"sudo\s+rm",
@@ -113,6 +119,7 @@ _EVAL_FLAGS = {"-c", "-e", "--command", "--execute", "--eval", "-exec", "--exec"
 
 # Prefix wrappers that delegate to the command that follows them.
 _TAIL_WRAPPERS = {
+    "unbuffer",  # expect's pty wrapper: delegates to the command that follows (sable-lbyp)
     "sudo", "doas", "env", "nohup", "timeout", "nice", "ionice",
     "time", "watch", "setsid", "stdbuf", "chrt", "command",
 }
@@ -448,7 +455,12 @@ def _process_segment(
             has_shell_exec = True
         if not p.quoted and p.text.lower() in _EVAL_FLAGS:
             has_eval_flag = True
-    code_carrying = has_shell_exec or has_eval_flag or exec_ in _EVAL_EXECS
+    # sable-lbyp: rafter's own `agent exec` runs its operand, so the hook must
+    # see through its own binary the way it sees through `bash -c`.
+    code_carrying = (
+        has_shell_exec or has_eval_flag or exec_ in _EVAL_EXECS
+        or _rafter_exec_runs_operand(pieces, exec_idx)
+    )
 
     # sable-c6an. Two questions the code conflated:
     #   code_carrying   -- this segment RUNS a command string it was handed
@@ -793,6 +805,54 @@ _RAFTER_PACKAGE = re.compile(r"^(?:@rafter-security/cli|rafter-cli|rafter)(?:@[\
 
 # Config keys that gate the hook. A namespace, not a leaf — see hook_control.
 _PROTECTED_CONFIG_KEY = re.compile(r"^(?:agent\.)?(?:hooks|commandpolicy)\b|^agent\.risklevel$")
+
+
+def _rafter_exec_runs_operand(pieces: list[_Piece], exec_idx: int) -> bool:
+    """sable-lbyp (from rf-ss67) -- ``rafter agent exec <operand>`` RUNS its
+    operand, so a segment whose exec is rafter's own binary is code-carrying:
+    the quoted operand is a command string, not prose, and must reach the
+    patterns.
+
+    Before this, ``rafter agent exec --force "rm -rf /tmp/x"`` was the one
+    shape the hook could not see: an unrecognised evaluator with a quoted
+    multi-word argument is data by the sanitizer's rule, so the hook said
+    ``low`` while exec ran a HIGH-tier command. rf-ss67 closed the bypass at
+    the other end (exec no longer skips approval; only a person at a TTY can
+    grant it); this makes the hook itself classify the operand, so the audit
+    trail and the block land where the agent's tool call is.
+
+    Resolution mirrors the rf-vnxs disarm check: the segment's resolved exec
+    (wrappers such as ``sudo -E``, ``env``, ``unbuffer`` already skipped by the
+    caller), an absolute path (``_exec_name`` keeps the basename), or a package
+    runner (``npx @rafter-security/cli``, ``pnpm dlx rafter-cli``).
+
+    ``--dry-run`` is the one exemption: exec then prints the classification and
+    runs nothing, and that flow is what the shipped docs tell agents to use to
+    check a command BEFORE running it. A flag an old CLI does not know makes it
+    error out, never execute, so the exemption cannot be abused by version skew.
+    """
+    if exec_idx == -1 or pieces[exec_idx].quoted:
+        return False
+    k = exec_idx
+    exec_ = _exec_name(pieces[k].text)
+    k += 1
+    if exec_ in _PACKAGE_RUNNERS:
+        while k < len(pieces) and pieces[k].op is None and (
+            pieces[k].text.startswith("-") or pieces[k].text.lower() in ("dlx", "exec")
+        ):
+            k += 1
+        if k >= len(pieces) or pieces[k].op is not None or not _RAFTER_PACKAGE.match(pieces[k].text.lower()):
+            return False
+        k += 1
+        exec_ = "rafter"
+    if exec_ not in _RAFTER_EXECS:
+        return False
+    rest = [p for p in pieces[k:] if p.op is None]
+    args = [p.text.lower() for p in rest if not p.text.startswith("-")]
+    if len(args) < 2 or args[0] != "agent" or args[1] != "exec":
+        return False
+    dry_run = any(not p.quoted and p.text.lower() == "--dry-run" for p in rest)
+    return not dry_run
 
 
 def _statement_disarms_rafter(words: list[_Piece]) -> bool:

--- a/python/tests/test_risk_rules_rafter_exec.py
+++ b/python/tests/test_risk_rules_rafter_exec.py
@@ -1,0 +1,66 @@
+"""sable-lbyp (from rf-ss67) -- the hook sees through rafter's own binary.
+
+``rafter agent exec <operand>`` RUNS its operand. Before this the sanitizer
+treated rafter as an unrecognised evaluator, so a quoted multi-word operand
+was prose and ``rafter agent exec --force "rm -rf /tmp/x"`` classified ``low``
+while exec ran a HIGH-tier command. The level assertions live in the shared
+battery (rf-6pqx-newline-heredoc-battery.json, "lbyp:" rows) so both runtimes
+prove them; this file pins the SHAPE of the sanitized text and the one
+exemption. Mirrors node/tests/risk-rules-rafter-exec.test.ts.
+"""
+from __future__ import annotations
+
+import pytest
+
+from rafter_cli.core.risk_rules import (
+    assess_command_risk,
+    sanitize_command_for_matching,
+)
+
+
+def test_inlines_the_quoted_operand():
+    cmd = 'rafter agent exec --force "rm -rf /tmp/x"'
+    assert "rm -rf /tmp/x" in sanitize_command_for_matching(cmd)
+    assert assess_command_risk(cmd) == "high"
+
+
+@pytest.mark.parametrize("cmd", [
+    '/usr/local/bin/rafter agent exec "chmod 777 /etc/passwd"',
+    'npx @rafter-security/cli agent exec "chmod 777 /etc/passwd"',
+    'bunx rafter agent exec "chmod 777 /etc/passwd"',
+    'sudo -E rafter agent exec "chmod 777 /etc/passwd"',
+    'env RAFTER_X=1 rafter-cli agent exec "chmod 777 /etc/passwd"',
+])
+def test_resolves_binary_by_basename_runner_and_wrapper(cmd):
+    assert "chmod 777 /etc/passwd" in sanitize_command_for_matching(cmd)
+    assert assess_command_risk(cmd) == "high"
+
+
+def test_dry_run_operand_stays_data():
+    cmd = 'rafter agent exec --dry-run "rm -rf /"'
+    assert "rm -rf /" not in sanitize_command_for_matching(cmd)
+    assert assess_command_risk(cmd) == "low"
+
+
+def test_quoted_dry_run_is_not_the_flag():
+    assert assess_command_risk('rafter agent exec "--dry-run" "rm -rf /"') == "critical"
+
+
+def test_only_agent_exec_is_code_carrying():
+    assert assess_command_risk('rafter secrets "my project/src"') == "low"
+    assert assess_command_risk('rafter agent config get "agent risk level"') == "low"
+    assert assess_command_risk("echo 'rafter agent exec \"rm -rf /\"'") == "low"
+
+
+@pytest.mark.parametrize("cmd", [
+    'script -q -c "rafter agent exec \'echo hi\'" /dev/null',
+    'unbuffer rafter agent exec "echo hi"',
+    "expect -c 'spawn rafter agent exec \"echo hi\"; send \"yes\\r\"'",
+    "python3 -c \"import pty; pty.spawn(['rafter','agent','exec','echo hi'])\"",
+])
+def test_pty_wrapper_around_rafter_exec_is_high(cmd):
+    assert assess_command_risk(cmd) == "high"
+
+
+def test_pty_wrapper_without_rafter_is_not_the_signal():
+    assert assess_command_risk('script -q -c "ls -la" /dev/null') == "low"

--- a/python/tests/test_risk_rules_rafter_exec.py
+++ b/python/tests/test_risk_rules_rafter_exec.py
@@ -64,3 +64,12 @@ def test_pty_wrapper_around_rafter_exec_is_high(cmd):
 
 def test_pty_wrapper_without_rafter_is_not_the_signal():
     assert assess_command_risk('script -q -c "ls -la" /dev/null') == "low"
+
+
+def test_unbuffer_is_a_tail_wrapper_so_the_operand_is_still_seen():
+    # Without the wrapper entry `unbuffer` would be the exec and the operand
+    # prose, reaching only HIGH through the pty pattern. A critical operand
+    # must still be CRITICAL.
+    cmd = 'unbuffer rafter agent exec "rm -rf /"'
+    assert "rm -rf /" in sanitize_command_for_matching(cmd)
+    assert assess_command_risk(cmd) == "critical"

--- a/rf-6pqx-newline-heredoc-battery.json
+++ b/rf-6pqx-newline-heredoc-battery.json
@@ -611,5 +611,12 @@
     "want": [
       "high"
     ]
+  },
+  {
+    "label": "lbyp: unbuffer pty wrapper around rafter agent exec with a critical operand",
+    "cmd": "unbuffer rafter agent exec \"rm -rf /\"",
+    "want": [
+      "critical"
+    ]
   }
 ]

--- a/rf-6pqx-newline-heredoc-battery.json
+++ b/rf-6pqx-newline-heredoc-battery.json
@@ -492,5 +492,124 @@
       "low",
       "medium"
     ]
+  },
+  {
+    "label": "lbyp: rafter agent exec --force quoted rm -rf path",
+    "cmd": "rafter agent exec --force \"rm -rf /tmp/x\"",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: rafter agent exec quoted rm -rf /",
+    "cmd": "rafter agent exec \"rm -rf /\"",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "lbyp: rafter agent exec --force quoted chmod 777",
+    "cmd": "rafter agent exec --force \"chmod 777 /etc/passwd\"",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: rafter agent exec quoted git push --force",
+    "cmd": "rafter agent exec \"git push origin main --force\"",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: npx @rafter-security/cli agent exec quoted chmod 777",
+    "cmd": "npx @rafter-security/cli agent exec \"chmod 777 /etc/passwd\"",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: pnpm dlx rafter-cli agent exec quoted chmod 777",
+    "cmd": "pnpm dlx rafter-cli agent exec \"chmod 777 /etc/passwd\"",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: sudo -E rafter agent exec quoted chmod 777",
+    "cmd": "sudo -E rafter agent exec \"chmod 777 /etc/passwd\"",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: absolute-path rafter agent exec quoted chmod 777",
+    "cmd": "/usr/local/bin/rafter agent exec \"chmod 777 /etc/passwd\"",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: bash -c wrapping rafter agent exec quoted rm -rf /",
+    "cmd": "bash -c \"rafter agent exec 'rm -rf /'\"",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "lbyp: rafter agent exec --dry-run quoted rm -rf / is a check, not a run",
+    "cmd": "rafter agent exec --dry-run \"rm -rf /\"",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "lbyp: rafter agent exec quoted safe command stays low",
+    "cmd": "rafter agent exec \"echo hello world\"",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "lbyp: echo of a rafter agent exec line is prose",
+    "cmd": "echo 'rafter agent exec \"rm -rf /\"'",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "lbyp: rafter secrets with a quoted path is not exec",
+    "cmd": "rafter secrets \"my project/src\"",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "lbyp: script -c pty wrapper around rafter agent exec",
+    "cmd": "script -q -c \"rafter agent exec 'echo hi'\" /dev/null",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: unbuffer pty wrapper around rafter agent exec",
+    "cmd": "unbuffer rafter agent exec \"echo hi\"",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: expect -c spawning rafter agent exec and typing yes",
+    "cmd": "expect -c 'spawn rafter agent exec \"echo hi\"; send \"yes\\r\"'",
+    "want": [
+      "high"
+    ]
+  },
+  {
+    "label": "lbyp: python pty.spawn around rafter",
+    "cmd": "python3 -c \"import pty; pty.spawn(['rafter','agent','exec','echo hi'])\"",
+    "want": [
+      "high"
+    ]
   }
 ]


### PR DESCRIPTION
Bead sable-lbyp — the classifier half of rf-ss67 (whose exec/TTY half shipped in #235 / v0.10.1). Rome merges; not merging.

## What the hook could not see

`rafter agent exec --force "rm -rf /tmp/x"` classified `low`. To the sanitizer, rafter was an unrecognised evaluator, so a quoted multi-word operand was prose by rule. exec no longer skips approval, but the hook still let the tool call through and the block landed two processes later, out of the audit trail.

## Change (both runtimes)

- A segment whose resolved exec is rafter — by basename (`/usr/local/bin/rafter`), via package runners (`npx @rafter-security/cli`, `pnpm dlx rafter-cli`, `bunx rafter`), behind wrappers (`sudo -E`, `env`, `unbuffer`) — with operands `agent exec` is **code-carrying**: the quoted operand is unwrapped and sanitized recursively, the same path `bash -c` takes. Resolution reuses the rf-vnxs constants so the two rafter-aware checks cannot drift.
- **`--dry-run` (unquoted) is the one exemption**: exec then runs nothing, and that flow is what the shipped docs tell agents to use to check a command first. A quoted `"--dry-run"` is an operand, not the flag. An older CLI that lacks the flag errors out rather than executing, so version skew cannot turn the exemption into a bypass.
- **A pseudo-terminal wrapper around `rafter agent exec` is HIGH on its own** — `script -c`, `expect`, `unbuffer`, `socat`, Python `pty.spawn/fork/openpty` — because the approval prompt only trusts a person at a TTY and those manufacture one. `unbuffer` joins the tail-wrapper list so the command after it resolves as the exec and a critical operand behind it is still CRITICAL.

## Tests

18 rows added to the shared battery (`rf-6pqx-newline-heredoc-battery.json`), which both runtimes execute; per-runtime files pin the sanitized-text shape and the quoted-flag case. Under-block rows: quoted `rm -rf /` → critical, `--force` chmod 777 → high, runner / wrapper / absolute-path forms, `bash -c` wrapping rafter exec, `unbuffer … "rm -rf /"` → critical. Over-block rows: `--dry-run` → low, safe operand → low, `echo` of the line → low, `rafter secrets "a b"` → low, `script -c` without rafter → low.

- **Red on the pre-fix classifier** (origin/main swapped in): 16 node / 22 python failures, every under-block row and shape test; every over-block row passes on both, as a control should.
- **Mutation gate**, each reverted by hand, names read: see-through removed → 11 node / 14 python; dry-run exemption removed → 2 / 2; pty patterns removed → 5 / 8; unbuffer entry removed → 2 / 2 (this last one was found untested by the gate and pinned in the second commit); restored → node 94/94 across the classifier files, python 16 + 87 battery subtests.
- Classifier files: node 162 tests pass; `tsc` clean.

Not more permissive than main anywhere: the exemption only names as prose what main already treated as prose, and the wrapper entry only exposes more.

Disclosure: this branch was pushed before I had read the no-push rule for this public repo; the mayor has since said keep.
