### PR TITLE
fix(risk-rules): a here-string is data or code by the same rule as a heredoc (rf-gn0h, sable-4nt2)

### DIFF
--- a/node/src/core/risk-rules.ts
+++ b/node/src/core/risk-rules.ts
@@ -142,6 +142,13 @@ const TEXT_FLAGS = new Set([
 const CHAIN_OPS = new Set([";", "&&", "||", "|", "&"]);
 
 /** Operators whose following token is a redirect target (a path — never data). */
+// `<<<` is deliberately ABSENT: it is a here-STRING, and its operand is stdin
+// CONTENT, not a path. Treating it as a redirect target left the text
+// untouched, which over-blocked a data owner (`cat <<< "…rm -rf /…" > notes.md`
+// classified critical — #230's shape, one operator over) and under-blocked a
+// shell one (`bash <<< "rm -rf /"` classified high, though the shell runs it).
+// Falling through to the ordinary operand path asks the question the heredoc
+// work already answers: does this command execute what it reads? (sable-4nt2)
 const REDIRECT_OPS = new Set([">", ">>", "<", "<<"]);
 
 /** Bound on recursion through nested shell wrappers / substitutions. */
@@ -220,7 +227,16 @@ function tokenize(s: string): { pieces: Piece[]; unterminated: boolean } {
         continue;
       }
       const two = s.slice(i, i + 2);
-      const op = (two === "&&" || two === "||" || two === ">>" || two === "<<") ? two : c;
+      // `<<<` before `<<`, or it tokenizes as `<<` + `<` and the here-string
+      // operand becomes a redirect target — left untouched, which is how it
+      // ended up both over- and under-blocked (sable-4nt2).
+      const three = s.slice(i, i + 3);
+      const op =
+        three === "<<<"
+          ? three
+          : (two === "&&" || two === "||" || two === ">>" || two === "<<")
+            ? two
+            : c;
       i += op.length;
       pieces.push({ start, end: i, op, text: op, quoted: false, substs: [] });
       continue;

--- a/node/tests/rf6pqx-differential.ts
+++ b/node/tests/rf6pqx-differential.ts
@@ -1,6 +1,6 @@
 // rf-6pqx DIFFERENTIAL gate (node) — mirror of rf-6pqx-differential.py. Same
 // generated corpus; asserts the candidate is never more permissive than main
-// except a pure data-heredoc body (#230). Run:
+// except a construct whose owner does not execute it (data heredoc #230; here-string rf-gn0h). Run:
 //   bun run rf-6pqx-differential.node.ts <main risk-rules.ts> <candidate risk-rules.ts>
 const RANK: Record<string, number> = { low: 0, medium: 1, high: 2, critical: 3 };
 const mainMod = await import(process.argv[2]);
@@ -14,7 +14,13 @@ const corpus: [string, string, boolean][] = [];
 for (const E of [...DATA_EXECS, ...SHELL_EXECS]) {
   const sh = isShell(E);
   corpus.push([`heredoc-data [${E}]`, `${E} <<EOF\n${P}\nEOF`, !sh]);
-  corpus.push([`herestring-1 [${E}]`, `${E} <<< "${P}"`, false]);
+  // A here-string whose owner does NOT execute it is data, exactly as a data-heredoc
+  // body is (#230). Keyed on the exec name computed here, never on the code under
+  // test, so a broken candidate cannot grant itself the row. (rf-gn0h)
+  corpus.push([`herestring-1 [${E}]`, `${E} <<< "${P}"`, !sh]);
+  // ...and the composition that exemption must never mask: owner is data, output executed.
+  corpus.push([`herestring-pipe-bash [${E}]`, `${E} <<< "${P}" | bash`, false]);
+  corpus.push([`herestring-pipe-sh [${E}]`, `${E} <<< "${P}" | sudo sh`, false]);
   corpus.push([`herestring-multi [${E}]`, `${E} <<< "marker" > /tmp/x\n${P}`, false]);
   corpus.push([`heredoc-pipe-bash [${E}]`, `${E} <<EOF | bash\n${P}\nEOF`, false]);
   corpus.push([`heredoc-pipe-sh [${E}]`, `${E} <<DATA | sudo sh\n${P}\nDATA`, false]);

--- a/python/rafter_cli/core/risk_rules.py
+++ b/python/rafter_cli/core/risk_rules.py
@@ -130,6 +130,13 @@ _TEXT_FLAGS = {
 _CHAIN_OPS = {";", "&&", "||", "|", "&"}
 
 # Operators whose following token is a redirect target (a path — never data).
+# `<<<` is deliberately ABSENT: it is a here-STRING, and its operand is stdin
+# CONTENT, not a path. Treating it as a redirect target left the text untouched,
+# which over-blocked a data owner (`cat <<< "…rm -rf /…" > notes.md` classified
+# critical -- #230's shape, one operator over) and under-blocked a shell one
+# (`bash <<< "rm -rf /"` classified high, though the shell runs it). Falling
+# through to the ordinary operand path asks the question the heredoc work
+# already answers: does this command execute what it reads? (sable-4nt2)
 _REDIRECT_OPS = {">", ">>", "<", "<<"}
 
 # Bound on recursion through nested shell wrappers / substitutions.
@@ -242,7 +249,17 @@ def _tokenize(s: str) -> tuple[list[_Piece], bool]:
                 pieces.append(_Piece(start, i, ";", ";", False, []))
                 continue
             two = s[i:i + 2]
-            op = two if two in ("&&", "||", ">>", "<<") else c
+            # `<<<` before `<<`, or it tokenizes as `<<` + `<` and the
+            # here-string operand becomes a redirect target -- left untouched,
+            # which is how it ended up both over- and under-blocked
+            # (sable-4nt2).
+            three = s[i:i + 3]
+            if three == "<<<":
+                op = three
+            elif two in ("&&", "||", ">>", "<<"):
+                op = two
+            else:
+                op = c
             i += len(op)
             pieces.append(_Piece(start, i, op, op, False, []))
             continue

--- a/python/tests/rf6pqx_differential.py
+++ b/python/tests/rf6pqx_differential.py
@@ -5,7 +5,9 @@ case never exercised the multi-line path where <<< is misread as << and the next
 line is swallowed. So this gate does NOT trust hand-picked expectations alone: it
 runs a GENERATED corpus of shell-argument constructs on BOTH main and the
 candidate and asserts the candidate is NEVER more permissive than main — except a
-pure data-heredoc body, the one construct #230 intentionally strips.
+construct whose owner does not execute it (a pure data-heredoc body, #230; a here-
+string with a non-executing owner, rf-gn0h). Both exemptions are keyed on the exec
+name computed in THIS file, never on an answer from the code under test.
 
 Usage: rf-6pqx-differential.py <main risk_rules.py> <candidate risk_rules.py>
 Exit 0 iff no non-allowlisted row moved toward permissive AND every explicit
@@ -24,8 +26,15 @@ for E in DATA_EXECS + SHELL_EXECS:
     is_shell = any(E == s or E.endswith(" bash") or E.split()[-1] in ("bash","sh","zsh") for s in SHELL_EXECS)
     # pure data-heredoc: intentional strip ONLY when the owner does not execute
     add(f"heredoc-data [{E}]", f"{E} <<EOF\n{P}\nEOF", perm_ok=not is_shell)
-    # here-string, single line
-    add(f"herestring-1 [{E}]", f'{E} <<< "{P}"', perm_ok=False)
+    # here-string, single line. A here-string whose owner does NOT execute it is data,
+    # exactly as a data-heredoc body is (#230) — same construct, same rule, other syntax.
+    # The exemption is keyed on the EXEC NAME, computed here and not by the classifier
+    # under test, so a broken candidate cannot grant itself this row. (rf-gn0h)
+    add(f"herestring-1 [{E}]", f'{E} <<< "{P}"', perm_ok=not is_shell)
+    # ...and the composition that exemption must never mask: the owner is data, but its
+    # OUTPUT is executed. Stays perm_ok=False for EVERY exec, shell or not.
+    add(f"herestring-pipe-bash [{E}]", f'{E} <<< "{P}" | bash', perm_ok=False)
+    add(f"herestring-pipe-sh [{E}]", f'{E} <<< "{P}" | sudo sh', perm_ok=False)
     # here-string, MULTI-LINE (the regression: <<< misread as << swallows next line)
     add(f"herestring-multi [{E}]", f'{E} <<< "marker" > /tmp/x\n{P}', perm_ok=False)
     # heredoc piped to a shell (the other regression: owner is data but output is executed)

--- a/rf-6pqx-newline-heredoc-battery.json
+++ b/rf-6pqx-newline-heredoc-battery.json
@@ -311,5 +311,40 @@
     "want": [
       "low"
     ]
+  },
+  {
+    "label": "sable-4nt2: a shell EXECUTES its here-string",
+    "cmd": "bash <<< \"rm -rf /\"",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "sable-4nt2: sh here-string is executed too",
+    "cmd": "sh <<< \"rm -rf /\"",
+    "want": [
+      "critical"
+    ]
+  },
+  {
+    "label": "sable-4nt2 GUARD: cat WRITES its here-string (data)",
+    "cmd": "cat <<< \"rm -rf / in docs\" > notes.md",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "sable-4nt2 GUARD: grep SEARCHES its here-string (data)",
+    "cmd": "grep <<< \"rm -rf /\"",
+    "want": [
+      "low"
+    ]
+  },
+  {
+    "label": "sable-4nt2: here-string piped into a shell is executed",
+    "cmd": "cat <<< \"rm -rf /\" | bash",
+    "want": [
+      "critical"
+    ]
   }
 ]


### PR DESCRIPTION
**Held for Rome — do not merge until he says go.** Ready otherwise: gate is green and the allowlist decision it was blocked on has been taken.

## What it fixes

`<<<` was mis-classified in **both** directions, because it was never tokenized as one operator — it split into `<<` plus `<`, and the here-string operand became a `<` redirect target, left untouched. Untouched text is neither redacted nor scanned, which is how one operator managed to be wrong both ways at once:

| command | before | after |
|---|---|---|
| `bash <<< "rm -rf /"` | high — **under**: the shell runs it | critical |
| `sh <<< "rm -rf /"` | high — **under** | critical |
| `cat <<< "…rm -rf /…" > notes.md` | critical — **over**: cat writes it | low |
| `grep <<< "rm -rf /"` | high — **over**: grep searches it | low |
| `cat <<< "rm -rf /" \| bash` | high | critical |

The fix tokenizes `<<<` as a single operator and leaves it out of `REDIRECT_OPS`, so its operand falls through to the ordinary operand path — which asks the question the heredoc work already answers: *does this command execute what it reads?* No new rule.

Authored by achebe (`3ace4ce`). The second commit is mine.

## The decision it was blocked on

achebe left the differential gate deliberately RED and handed the allowlist call to kerckhoffs and me rather than moving the line himself. Taking it: the widening is correct — `herestring-1` moves to `perm_ok = not is_shell`, which is not a new exemption but the one the gate already grants `heredoc-data` (an owner that does not execute what it reads), applied to the same semantics in different syntax. The five permissive rows are all data execs that print or write.

**But not in the two-character form proposed, and that part is measured rather than argued.** The corpus had no here-string pipe-to-shell row at all, so exempting `herestring-1` removes the gate's only view of a data owner whose *output* is executed:

| corpus | mutation A (`codeCarrying=false`) | mutation B (`executesOutput=false`) |
|---|---|---|
| bare two-char widening | 5 regressions | **CLEAN — a hole** |
| this PR (adds pipe rows) | 5 regressions | 10 regressions |

Under the bare widening, a classifier that stopped catching `head <<< "rm -rf /" \| bash` reports `DIFFERENTIAL CLEAN` and ships. The added `herestring-pipe-bash` / `-sh` rows sit at `perm_ok=False` for every exec, shell or not.

The exemption is safe because `is_shell` is computed from the exec name **inside the corpus file**, never from the classifier under test — a broken candidate cannot grant itself the row.

## Gate

- differential **CLEAN** both runtimes at 90 rows (70 → 90), **RED under both mutations** in both runtimes
- direction: `bash`/`sh`/`sudo bash <<< "rm -rf /"` high→critical; `cat`/`grep` high→low; `cat <<< … | bash` high→critical; `herestring-multi` stays critical
- python 1659 passed / 8 failed; node 2199 passed / 10 failed — those same failures reproduce on clean main, verified by running them there rather than trusting the count

achebe's `DO NOT MERGE AS-IS` is discharged: the gate is green because the line moved deliberately and is guarded, not because the red was silenced.

## Scope note

Impact is bounded — the under-classification is critical→high, a downgrade rather than a silent allow, so HIGH still requires approval. That is why this sat behind the 0.10.1–0.10.3 security releases rather than riding one.