### PR TITLE
fix(secrets): add OpenAI and Supabase rules to the regex engine, in both runtimes (rf-f5is)

### DIFF
--- a/node/src/scanners/secret-patterns.ts
+++ b/node/src/scanners/secret-patterns.ts
@@ -87,6 +87,36 @@ export const DEFAULT_SECRET_PATTERNS: Pattern[] = [
     description: "Stripe Restricted API Key detected"
   },
 
+  // OpenAI (rf-f5is / se-wagv, external report). The hook's Write gate is
+  // regex-only, and this file had NO OpenAI rule at all — so `sk-proj-` and
+  // legacy keys were ALLOWED through the gate at any length, while
+  // `rafter secrets` caught them via betterleaks. The two engines disagreed,
+  // and the one guarding writes was the blind one.
+  //
+  // No `(?i)`: these prefixes and their base62 bodies are case-sensitive, and
+  // the convention here is that prefixed vendor tokens (ghp_, AKIA, AIza, xox)
+  // match case-sensitively. Lower-casing them would only add false positives.
+  {
+    name: "OpenAI API Key",
+    regex: "sk-(proj|svcacct|admin)-[A-Za-z0-9_-]{40,}",
+    severity: "critical",
+    description: "OpenAI project/service/admin API key detected"
+  },
+  {
+    name: "OpenAI API Key (legacy)",
+    regex: "sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}",
+    severity: "critical",
+    description: "OpenAI legacy API key detected"
+  },
+
+  // Supabase (rf-f5is / se-wagv). Detected by NEITHER engine at any length.
+  {
+    name: "Supabase Secret Key",
+    regex: "sb_secret_[A-Za-z0-9_-]{20,}",
+    severity: "critical",
+    description: "Supabase secret key detected"
+  },
+
   // Twilio
   {
     name: "Twilio API Key",

--- a/node/tests/secret-patterns-openai-supabase.test.ts
+++ b/node/tests/secret-patterns-openai-supabase.test.ts
@@ -1,0 +1,57 @@
+/**
+ * OpenAI + Supabase secret rules, and the runtime parity they were missing.
+ *
+ * rf-f5is / se-wagv (external report). The hook's Write gate is regex-only, and
+ * secret-patterns.ts had NO OpenAI rule at all — so `sk-proj-` and legacy keys
+ * were ALLOWED through the gate at any length, while `rafter secrets` caught
+ * them via betterleaks. Two engines, disagreeing, and the one guarding writes
+ * was the blind one. `sb_secret_` was caught by neither at any length.
+ *
+ * Fixtures come from the SHARED rf-f5is-key-fixtures.json so both runtimes
+ * assert on byte-identical input; the python twin is
+ * python/tests/test_secret_patterns_openai_supabase.py.
+ *
+ * Keys are ASSEMBLED at runtime rather than stored literally: a file of
+ * real-shaped keys in the repo would be flagged by rafter's own scanner — these
+ * rules would see to it — and a fixture that trips the product's CI is a
+ * fixture someone deletes.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { RegexScanner } from "../src/scanners/regex-scanner.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixtures: Array<{
+  label: string; prefix: string; fill: string; len: number; suffix: string; expect: string | null;
+}> = JSON.parse(fs.readFileSync(path.resolve(here, "../../rf-f5is-key-fixtures.json"), "utf8"));
+
+const build = (r: (typeof fixtures)[number]) => r.prefix + r.fill.repeat(r.len) + r.suffix;
+const names = (ms: any[]) => new Set((ms ?? []).map((m) => m.pattern?.name ?? m.name ?? "?"));
+
+describe("OpenAI + Supabase secret rules (rf-f5is)", () => {
+  for (const row of fixtures) {
+    it(row.label, () => {
+      const found = names(new RegexScanner().scanText(build(row)));
+      if (row.expect === null) {
+        expect([...found], row.label).toEqual([]);
+      } else {
+        expect([...found], row.label).toContain(row.expect);
+      }
+    });
+  }
+
+  it("CONTROL — an unrelated rule still fires", () => {
+    // Without this, every row above could pass with the scanner broken outright.
+    const found = names(new RegexScanner().scanText('GH = "ghp_16CharsMinimumxxxxxxxxxxxxxxxxxxxxxx"'));
+    expect([...found]).toContain("GitHub Personal Access Token");
+  });
+
+  it("rules are case-sensitive", () => {
+    // Matching an uppercased prefix would only add noise; the convention for
+    // prefixed vendor tokens here (ghp_, AKIA, AIza, xox) is case-sensitive.
+    const found = names(new RegexScanner().scanText('X = "SB_SECRET_' + "A".repeat(32) + '"'));
+    expect([...found]).toEqual([]);
+  });
+});

--- a/python/rafter_cli/scanners/secret_patterns.py
+++ b/python/rafter_cli/scanners/secret_patterns.py
@@ -81,6 +81,34 @@ DEFAULT_SECRET_PATTERNS: list[Pattern] = [
         severity="critical",
         description="Stripe Restricted API Key detected",
     ),
+    # OpenAI (rf-f5is / se-wagv, external report). The hook's Write gate is
+    # regex-only and this file had NO OpenAI rule at all, so `sk-proj-` and
+    # legacy keys were ALLOWED through the gate at any length while
+    # `rafter secrets` caught them via betterleaks. The two engines disagreed
+    # and the one guarding writes was the blind one.
+    #
+    # No `(?i)`: these prefixes and their base62 bodies are case-sensitive, and
+    # the convention here is that prefixed vendor tokens (ghp_, AKIA, AIza, xox)
+    # match case-sensitively. Lower-casing them would only add false positives.
+    Pattern(
+        name="OpenAI API Key",
+        regex=r"sk-(proj|svcacct|admin)-[A-Za-z0-9_-]{40,}",
+        severity="critical",
+        description="OpenAI project/service/admin API key detected",
+    ),
+    Pattern(
+        name="OpenAI API Key (legacy)",
+        regex=r"sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}",
+        severity="critical",
+        description="OpenAI legacy API key detected",
+    ),
+    # Supabase (rf-f5is / se-wagv). Detected by NEITHER engine at any length.
+    Pattern(
+        name="Supabase Secret Key",
+        regex=r"sb_secret_[A-Za-z0-9_-]{20,}",
+        severity="critical",
+        description="Supabase secret key detected",
+    ),
     # Twilio
     Pattern(
         name="Twilio API Key",

--- a/python/tests/test_secret_patterns_openai_supabase.py
+++ b/python/tests/test_secret_patterns_openai_supabase.py
@@ -1,0 +1,63 @@
+"""OpenAI + Supabase secret rules, and the runtime parity they were missing.
+
+rf-f5is / se-wagv (external report). The hook's Write gate is regex-only, and
+secret_patterns had NO OpenAI rule at all — so `sk-proj-` and legacy keys were
+ALLOWED through the gate at any length, while `rafter secrets` caught them via
+betterleaks. Two engines, disagreeing, and the one guarding writes was blind.
+`sb_secret_` was caught by neither at any length.
+
+Fixtures come from the SHARED rf-f5is-key-fixtures.json so both runtimes assert
+on byte-identical input; the node twin is
+node/tests/secret-patterns-openai-supabase.test.ts.
+
+The keys are ASSEMBLED at runtime rather than stored literally. A file of
+real-shaped keys in the repo would be flagged by rafter's own scanner — these
+rules would see to that — and a fixture that trips the product's CI is a fixture
+someone deletes.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rafter_cli.scanners.regex_scanner import RegexScanner
+
+FIXTURES = json.loads(
+    (Path(__file__).resolve().parents[2] / "rf-f5is-key-fixtures.json").read_text()
+)
+
+
+def _build(row: dict) -> str:
+    return row["prefix"] + row["fill"] * row["len"] + row["suffix"]
+
+
+def _names(matches) -> set[str]:
+    out = set()
+    for m in matches or []:
+        p = getattr(m, "pattern", None)
+        out.add(p.name if p is not None else getattr(m, "name", "?"))
+    return out
+
+
+@pytest.mark.parametrize("row", FIXTURES, ids=[r["label"] for r in FIXTURES])
+def test_shared_key_fixtures(row):
+    found = _names(RegexScanner().scan_text(_build(row)))
+    if row["expect"] is None:
+        assert found == set(), f"{row['label']}: expected no match, got {found}"
+    else:
+        assert row["expect"] in found, f"{row['label']}: expected {row['expect']}, got {found}"
+
+
+def test_control_an_unrelated_rule_still_fires():
+    # Without this, every row above could pass with the scanner broken outright.
+    found = _names(RegexScanner().scan_text('GH = "ghp_16CharsMinimumxxxxxxxxxxxxxxxxxxxxxx"'))
+    assert "GitHub Personal Access Token" in found
+
+
+def test_rules_are_case_sensitive():
+    # These prefixes are case-sensitive, and the convention for prefixed vendor
+    # tokens here (ghp_, AKIA, AIza, xox) is to match case-sensitively. An
+    # uppercased prefix is not a key, and matching it would only add noise.
+    assert _names(RegexScanner().scan_text("X = \"SB_SECRET_" + "A" * 32 + "\"")) == set()

--- a/rf-f5is-key-fixtures.json
+++ b/rf-f5is-key-fixtures.json
@@ -1,0 +1,42 @@
+[
+  {
+    "label": "supabase sb_secret_ at a real length",
+    "prefix": "sb_secret_", "fill": "A", "len": 32, "suffix": "",
+    "expect": "Supabase Secret Key"
+  },
+  {
+    "label": "openai sk-proj- at a real length",
+    "prefix": "sk-proj-", "fill": "A", "len": 48, "suffix": "",
+    "expect": "OpenAI API Key"
+  },
+  {
+    "label": "openai sk-svcacct-",
+    "prefix": "sk-svcacct-", "fill": "B", "len": 44, "suffix": "",
+    "expect": "OpenAI API Key"
+  },
+  {
+    "label": "openai sk-admin-",
+    "prefix": "sk-admin-", "fill": "C", "len": 40, "suffix": "",
+    "expect": "OpenAI API Key"
+  },
+  {
+    "label": "openai legacy sk- with the T3BlbkFJ marker",
+    "prefix": "sk-", "fill": "A", "len": 20, "suffix": "T3BlbkFJBBBBBBBBBBBBBBBBBBBB",
+    "expect": "OpenAI API Key (legacy)"
+  },
+  {
+    "label": "GUARD a too-short sb_secret_ is not a key",
+    "prefix": "sb_secret_", "fill": "A", "len": 8, "suffix": "",
+    "expect": null
+  },
+  {
+    "label": "GUARD a too-short sk-proj- is not a key",
+    "prefix": "sk-proj-", "fill": "A", "len": 10, "suffix": "",
+    "expect": null
+  },
+  {
+    "label": "GUARD prose mentioning sk and secrets",
+    "prefix": "ordinary text about sk and secrets, ", "fill": "x", "len": 5, "suffix": "",
+    "expect": null
+  }
+]


### PR DESCRIPTION
## The gap

The hook's Write gate is regex-only, and `secret-patterns` had **no OpenAI rule at all**. So `sk-proj-`, `sk-svcacct-`, `sk-admin-` and legacy `sk-…T3BlbkFJ…` keys were allowed straight through the gate at any length — while `rafter secrets` caught them via betterleaks. Two engines disagreeing, and the one guarding writes was the blind one. `sb_secret_` (Supabase) was caught by neither, at any length.

## Reproduced against the published artifact first

Run against the downloaded **0.10.3 npm tarball**, with controls, before touching anything:

```
MISSED    sb_secret_ (Supabase)
MISSED    sk-proj- (OpenAI)
MISSED    legacy sk- (OpenAI)
DETECTED  CONTROL github token
DETECTED  CONTROL aws key id
```

`dist/scanners/secret-patterns.js` contains zero occurrences of `openai` / `sk-proj` / `T3BlbkFJ` / `sb_secret` / `supabase`. The scanner was working; these rules were simply absent. The controls are what make the miss evidence rather than an empty result.

## The rules

```
sb_secret_[A-Za-z0-9_-]{20,}
sk-(proj|svcacct|admin)-[A-Za-z0-9_-]{40,}
sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}
```

Added to `node/src/scanners/secret-patterns.ts` and `python/rafter_cli/scanners/secret_patterns.py`.

**No `(?i)` on any of them, deliberately, and pinned by a test.** These prefixes and their base62 bodies are case-sensitive, and the convention in this file is that prefixed vendor tokens — `ghp_`, `AKIA`, `AIza`, `xox` — match case-sensitively, while only the descriptive patterns (`aws…`, `sk_live_`) carry the flag. Lower-casing these would add false positives and catch nothing real.

## Parity by construction

The fixtures live in a shared `rf-f5is-key-fixtures.json` that **both** runtimes read, so the two assert on byte-identical input and cannot drift — the same design the newline/heredoc battery uses. 10 tests per runtime off 8 fixtures.

The keys are **assembled at runtime** from a prefix, a fill character and a length rather than stored literally. A file of real-shaped keys in this repo would be flagged by rafter's own scanner — these very rules would see to it — and a fixture that trips the product's CI is a fixture someone deletes.

## Gate

| check | result |
|---|---|
| red | all three shapes missed on the published 0.10.3 tarball; two controls detected |
| green | all five positive shapes detected in **both** runtimes, identical |
| guards | a too-short `sb_secret_`, a too-short `sk-proj-`, and prose mentioning "sk" all match nothing — the length bounds are load-bearing |
| mutation | delete the three rules → exactly the 5 positive rows go red, all 3 guards stay green (so the guards are not vacuously matching) |
| case | an uppercased prefix matches nothing |
| python | 401 passed on the secret/scanner/pattern/hook selection |
| node | full suite 2229 passed / 10 failed — **same 5 files and same count as before this change**, with passed up exactly +10 (the new tests). No new failures, so no false positives introduced. Those 10 reproduce on clean main. |
| typecheck | clean |

## Scope

Does not touch betterleaks, which already caught the OpenAI shapes. This closes the gap between the two engines rather than changing the one that worked.

Bead is owned by `secbolt/crew/kerckhoffs`; I took it on the mayor's instruction because of the 09-14 clock, not by claiming it — re-review or reassign as preferred.
